### PR TITLE
fix(cli): Remove malicious node.moneroworld remote node

### DIFF
--- a/swap/src/monero/wallet_rpc.rs
+++ b/swap/src/monero/wallet_rpc.rs
@@ -25,7 +25,6 @@ use tokio_util::io::StreamReader;
 const MONERO_DAEMONS: [MoneroDaemon; 17] = [
     MoneroDaemon::new("xmr-node.cakewallet.com", 18081, Network::Mainnet),
     MoneroDaemon::new("nodex.monerujo.io", 18081, Network::Mainnet),
-    MoneroDaemon::new("node.moneroworld.com", 18089, Network::Mainnet),
     MoneroDaemon::new("nodes.hashvault.pro", 18081, Network::Mainnet),
     MoneroDaemon::new("p2pmd.xmrvsbeast.com", 18081, Network::Mainnet),
     MoneroDaemon::new("node.monerodevs.org", 18089, Network::Mainnet),

--- a/swap/src/monero/wallet_rpc.rs
+++ b/swap/src/monero/wallet_rpc.rs
@@ -22,7 +22,7 @@ use tokio_util::io::StreamReader;
 
 // See: https://www.moneroworld.com/#nodes, https://monero.fail
 // We don't need any testnet nodes because we don't support testnet at all
-const MONERO_DAEMONS: [MoneroDaemon; 17] = [
+const MONERO_DAEMONS: [MoneroDaemon; 16] = [
     MoneroDaemon::new("xmr-node.cakewallet.com", 18081, Network::Mainnet),
     MoneroDaemon::new("nodex.monerujo.io", 18081, Network::Mainnet),
     MoneroDaemon::new("nodes.hashvault.pro", 18081, Network::Mainnet),


### PR DESCRIPTION
The moneroworld node has been confirmed to have been operated by Chainalysis, a company specialising in blockchain surveillance. They are collecting the ip addresses of anyone who connects to the node.

https://www.digilol.net/blog/chainanalysis-malicious-xmr.html