### PR TITLE
fix(gui): Hide manual cancel and refund button

### DIFF
--- a/src-gui/src/renderer/components/alert/SwapStatusAlert.tsx
+++ b/src-gui/src/renderer/components/alert/SwapStatusAlert.tsx
@@ -119,7 +119,7 @@ const BitcoinPossiblyCancelledAlert = ({
       <MessageList
         messages={[
           "The swap was cancelled because it did not complete in time",
-          "You must resume the swap immediately to refund your Bitcoin. If that fails, you can manually refund it",
+          "You must resume the swap immediately to refund your Bitcoin",
           <>
             You might lose your funds if you do not refund within{" "}
             <HumanizedBitcoinBlockDuration
@@ -128,7 +128,6 @@ const BitcoinPossiblyCancelledAlert = ({
           </>,
         ]}
       />
-      <SwapCancelRefundButton swap={swap} size="small" variant="contained" />
     </Box>
   );
 };


### PR DESCRIPTION
The manual cancel and refund button has been removed. This functionality is not currently implemented in the GUI, and the state machine will handle resuming the swap instead. This feature can be reimplemented later if needed.