### PR TITLE
feat(asb): Retry locking Monero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- ASB: We now retry indefinitely to lock Monero funds until the swap is cancelled. This fixes an issue where we would fail to lock Monero on the first try (e.g., due to the daemon not being fully synced) and would never try again, forcing the swap to be refunded.
 - ASB + CLI: You can now use the `logs` command to retrieve logs stored in the past, redacting addresses and id's using `logs --redact`.
 - ASB: The `--disable-timestamp` flag has been removed
 - ASB: The `history` command can now be used while the asb is running.

--- a/swap/src/protocol/alice/swap.rs
+++ b/swap/src/protocol/alice/swap.rs
@@ -154,7 +154,7 @@ where
                         tracing::warn!(
                             swap_id = %swap_id,
                             error = ?e,
-                            "Failed to lock Monero funds. We will retry."
+                            "Failed to lock Monero. Make sure your monero-wallet-rpc is connected to a synced daemon and enough funds are available. We will retry."
                         )
                     })
                     .map_err(backoff::Error::transient)

--- a/swap/src/protocol/alice/swap.rs
+++ b/swap/src/protocol/alice/swap.rs
@@ -113,63 +113,72 @@ where
             }
         }
         AliceState::BtcLocked { state3 } => {
-            // If the swap is cancelled, there is no need to lock the Monero funds anymore
-            match state3.expired_timelocks(bitcoin_wallet).await? {
-                ExpiredTimelocks::None { .. } => {
-                    // Record the current monero wallet block height so we don't have to scan from
-                    // block 0 for scenarios where we create a refund wallet.
-                    let monero_wallet_restore_blockheight = monero_wallet.block_height().await?;
+            // We will retry indefinitely to lock the Monero funds, until the swap is cancelled
+            // Sometimes locking the Monero can fail e.g due to the daemon not being fully synced
+            let backoff = backoff::ExponentialBackoffBuilder::new()
+                .with_max_elapsed_time(None)
+                .with_max_interval(Duration::from_secs(60))
+                .build();
 
-                    // We configure this to retry indefinitely
-                    // We check if the swap is cancelled before every retry
-                    let backoff = backoff::ExponentialBackoffBuilder::new()
-                        .with_max_elapsed_time(None)
-                        .with_max_interval(Duration::from_secs(30))
-                        .build();
+            let transfer_proof = backoff::future::retry(backoff, || async {
+                // We check the status of the Bitcoin lock transaction
+                // If the swap is cancelled, there is no need to lock the Monero funds anymore
+                // because there is no way for the swap to succeed.
+                if !matches!(
+                    state3.expired_timelocks(bitcoin_wallet).await?,
+                    ExpiredTimelocks::None { .. }
+                ) {
+                    return Ok(None);
+                }
 
-                    let transfer_proof = backoff::future::retry(backoff, || async {
-                        // We check the status of the Bitcoin lock transaction
-                        // If the swap is cancelled, there is no need to lock the Monero funds anymore
-                        // because there is no way for the swap to succeed.
-                        if !matches!(state3.expired_timelocks(bitcoin_wallet).await?, ExpiredTimelocks::None { .. }) {
-                            return Ok(None);
-                        }
-
-                        // Try to lock the Monero funds
-                        monero_wallet
-                            .transfer(state3.lock_xmr_transfer_request())
-                            .await
-                            .map(Some)
-                            .map_err(|e| {
-                                tracing::warn!(
-                                    swap_id = %swap_id,
-                                    error = ?e,
-                                    "Failed to lock Monero funds. Retrying..."
-                                );
-                                backoff::Error::transient(e)
-                            })
+                // Record the current monero wallet block height so we don't have to scan from
+                // block 0 for scenarios where we create a refund wallet.
+                let monero_wallet_restore_blockheight = monero_wallet
+                    .block_height()
+                    .await
+                    .inspect_err(|e| {
+                        tracing::warn!(
+                            swap_id = %swap_id,
+                            error = ?e,
+                            "Failed to get Monero wallet block height while trying to lock XMR. We will retry."
+                        )
                     })
-                    .await?;
+                    .map_err(backoff::Error::transient)?;
 
-                    match transfer_proof {
-                        // If the transfer was successful, we transition to the next state
-                        Some(proof) => AliceState::XmrLockTransactionSent {
-                            monero_wallet_restore_blockheight,
-                            transfer_proof: proof,
-                            state3,
-                        },
-                        // If the swap was cancelled, we abort the swap
-                        // We did not lock any funds, so we can safely abort
-                        None => {
-                            tracing::info!(
-                                swap_id = %swap_id,
-                                "Swap was cancelled while trying to lock XMR. Aborting swap."
-                            );
-                            AliceState::SafelyAborted
-                        }
+                // Lock the Monero
+                monero_wallet
+                    .transfer(state3.lock_xmr_transfer_request())
+                    .await
+                    .map(|proof| Some((monero_wallet_restore_blockheight, proof)))
+                    .inspect_err(|e| {
+                        tracing::warn!(
+                            swap_id = %swap_id,
+                            error = ?e,
+                            "Failed to lock Monero funds. We will retry."
+                        )
+                    })
+                    .map_err(backoff::Error::transient)
+            })
+            .await?;
+
+            match transfer_proof {
+                // If the transfer was successful, we transition to the next state
+                Some((monero_wallet_restore_blockheight, transfer_proof)) => {
+                    AliceState::XmrLockTransactionSent {
+                        monero_wallet_restore_blockheight,
+                        transfer_proof,
+                        state3,
                     }
                 }
-                _ => AliceState::SafelyAborted,
+                // If we were not able to lock the Monero funds before the timelock expired,
+                // we can safely abort the swap because we did not lock any funds
+                None => {
+                    tracing::info!(
+                        swap_id = %swap_id,
+                        "We did not manage to lock the Monero funds before the timelock expired. Aborting swap."
+                    );
+                    AliceState::SafelyAborted
+                }
             }
         }
         AliceState::XmrLockTransactionSent {


### PR DESCRIPTION
There are a number of reasons the locking of the Monero funds could fail:
- Insufficient funds in wallet
- Network errors (`no connection to daemon`)
- Daemon not being fully synced
- `monero-wallet-rpc` crashed

We will retry continously until the cancel timelock expires.

Closes https://github.com/UnstoppableSwap/core/issues/138