### PR TITLE
feat(swap): Log tracing in rolling log files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- ASB: We now log verbose messages to hourly rotating `tracing*.log` which are kept for 24 hours. General logs are written to `swap-all.log`.
+
 ## [1.0.0-rc.2] - 2024-11-16
 
 - GUI: ASBs discovered via rendezvous are now prioritized if they are running the latest version

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9504,7 +9504,7 @@ dependencies = [
 
 [[package]]
 name = "unstoppableswap-gui-rs"
-version = "1.0.0-rc.2"
+version = "0.7.0"
 dependencies = [
  "anyhow",
  "once_cell",

--- a/swap/src/asb/event_loop.rs
+++ b/swap/src/asb/event_loop.rs
@@ -413,7 +413,7 @@ where
                                 "Communication error: {:#}", error);
                         }
                         SwarmEvent::ConnectionEstablished { peer_id: peer, endpoint, .. } => {
-                            tracing::debug!(%peer, address = %endpoint.get_remote_address(), "New connection established");
+                            tracing::trace!(%peer, address = %endpoint.get_remote_address(), "New connection established");
 
                             // If we have buffered transfer proofs for this peer, we can now send them
                             if let Some(transfer_proofs) = self.buffered_transfer_proofs.remove(&peer) {
@@ -429,13 +429,13 @@ where
                             }
                         }
                         SwarmEvent::IncomingConnectionError { send_back_addr: address, error, .. } => {
-                            tracing::warn!(%address, "Failed to set up connection with peer: {:#}", error);
+                            tracing::trace!(%address, "Failed to set up connection with peer: {:#}", error);
                         }
                         SwarmEvent::ConnectionClosed { peer_id: peer, num_established: 0, endpoint, cause: Some(error), connection_id } => {
-                            tracing::debug!(%peer, address = %endpoint.get_remote_address(), %connection_id, "Lost connection to peer: {:#}", error);
+                            tracing::trace!(%peer, address = %endpoint.get_remote_address(), %connection_id, "Lost connection to peer: {:#}", error);
                         }
                         SwarmEvent::ConnectionClosed { peer_id: peer, num_established: 0, endpoint, cause: None, connection_id } => {
-                            tracing::info!(%peer, address = %endpoint.get_remote_address(), %connection_id,  "Successfully closed connection");
+                            tracing::trace!(%peer, address = %endpoint.get_remote_address(), %connection_id,  "Successfully closed connection");
                         }
                         SwarmEvent::NewListenAddr{address, ..} => {
                             tracing::info!(%address, "New listen address reported");
@@ -493,7 +493,7 @@ where
         tracing::debug!(%ask_price, %xmr_balance, %max_bitcoin_for_monero, "Computed quote");
 
         if min_buy > max_bitcoin_for_monero {
-            tracing::warn!(
+            tracing::trace!(
                         "Your Monero balance is too low to initiate a swap, as your minimum swap amount is {}. You could at most swap {}",
                         min_buy, max_bitcoin_for_monero
                     );
@@ -506,7 +506,7 @@ where
         }
 
         if max_buy > max_bitcoin_for_monero {
-            tracing::warn!(
+            tracing::trace!(
                     "Your Monero balance is too low to initiate a swap with the maximum swap amount {} that you have specified in your config. You can at most swap {}",
                     max_buy, max_bitcoin_for_monero
                 );

--- a/swap/src/common/tracing_util.rs
+++ b/swap/src/common/tracing_util.rs
@@ -42,6 +42,7 @@ pub fn init(
         .build(&dir)
         .expect("initializing rolling file appender failed");
 
+    // Log to file
     let file_layer = fmt::layer()
         .with_writer(file_appender)
         .with_ansi(false)
@@ -90,7 +91,7 @@ pub fn init(
         .try_init()?;
 
     // Now we can use the tracing macros to log messages
-    tracing::info!(%level_filter, logs_dir=%dir.as_ref().display(), "Initialized tracing");
+    tracing::info!(%level_filter, logs_dir=%dir.as_ref().display(), "Initialized tracing. General logs will be written to swap-all.log, and verbose logs to tracing*.log");
 
     Ok(())
 }

--- a/swap/src/kraken.rs
+++ b/swap/src/kraken.rs
@@ -186,8 +186,6 @@ mod connection {
                 return Ok(None);
             }
             Ok(wire::Event::Heartbeat) => {
-                tracing::trace!("Received heartbeat message");
-
                 return Ok(None);
             }
             // if the message is not an event, it is a ticker update or an unknown event


### PR DESCRIPTION
Logs below DEBUG (network failures, balance warnings, ...) will be written to a log file that'll be deleted daily (24 log files, hourly rotated, deleted daily). All other logs will continue to be written to stdout/stderr and the permanent log file.
