### PR TITLE
feat(gui): Display state page for inflight swap setup

### DIFF
--- a/src-gui/src/renderer/components/modal/swap/SwapStateStepper.tsx
+++ b/src-gui/src/renderer/components/modal/swap/SwapStateStepper.tsx
@@ -55,14 +55,14 @@ function getActiveStep(state: SwapState | null): PathStep | null {
     case "RequestingQuote":
     case "ReceivedQuote":
     case "WaitingForBtcDeposit":
-    case "Started":
+    case "SwapSetupInflight":
       return [PathType.HAPPY_PATH, 0, isReleased];
 
     // Step 1: Waiting for Bitcoin lock confirmation
     // Bitcoin has been locked, waiting for the counterparty to lock their XMR
     case "BtcLockTxInMempool":
       // We only display the first step as completed if the Bitcoin lock has been confirmed
-      if(latestState.content.btc_lock_confirmations > 0) {
+      if (latestState.content.btc_lock_confirmations > 0) {
         return [PathType.HAPPY_PATH, 1, isReleased];
       }
       return [PathType.HAPPY_PATH, 0, isReleased];
@@ -86,7 +86,7 @@ function getActiveStep(state: SwapState | null): PathStep | null {
     // XMR redemption transaction is in mempool, swap is essentially complete
     case "XmrRedeemInMempool":
       return [PathType.HAPPY_PATH, 4, false];
-      
+
     // Unhappy Path States
 
     // Step 1: Cancel timelock has expired. Waiting for cancel transaction to be published
@@ -117,8 +117,8 @@ function getActiveStep(state: SwapState | null): PathStep | null {
       return null;
     default:
       return fallbackStep("No step is assigned to the current state");
-      // TODO: Make this guard work. It should force the compiler to check if we have covered all possible cases.
-      // return exhaustiveGuard(latestState.type);  
+    // TODO: Make this guard work. It should force the compiler to check if we have covered all possible cases.
+    // return exhaustiveGuard(latestState.type);  
   }
 }
 

--- a/src-gui/src/renderer/components/modal/swap/pages/SwapStatePage.tsx
+++ b/src-gui/src/renderer/components/modal/swap/pages/SwapStatePage.tsx
@@ -11,7 +11,7 @@ import BitcoinRedeemedPage from "./in_progress/BitcoinRedeemedPage";
 import CancelTimelockExpiredPage from "./in_progress/CancelTimelockExpiredPage";
 import EncryptedSignatureSentPage from "./in_progress/EncryptedSignatureSentPage";
 import ReceivedQuotePage from "./in_progress/ReceivedQuotePage";
-import SwapSetupInflightPage from "./in_progress/StartedPage";
+import SwapSetupInflightPage from "./in_progress/SwapSetupInflightPage";
 import XmrLockedPage from "./in_progress/XmrLockedPage";
 import XmrLockTxInMempoolPage from "./in_progress/XmrLockInMempoolPage";
 import InitPage from "./init/InitPage";

--- a/src-gui/src/renderer/components/modal/swap/pages/SwapStatePage.tsx
+++ b/src-gui/src/renderer/components/modal/swap/pages/SwapStatePage.tsx
@@ -11,7 +11,7 @@ import BitcoinRedeemedPage from "./in_progress/BitcoinRedeemedPage";
 import CancelTimelockExpiredPage from "./in_progress/CancelTimelockExpiredPage";
 import EncryptedSignatureSentPage from "./in_progress/EncryptedSignatureSentPage";
 import ReceivedQuotePage from "./in_progress/ReceivedQuotePage";
-import StartedPage from "./in_progress/StartedPage";
+import SwapSetupInflightPage from "./in_progress/StartedPage";
 import XmrLockedPage from "./in_progress/XmrLockedPage";
 import XmrLockTxInMempoolPage from "./in_progress/XmrLockInMempoolPage";
 import InitPage from "./init/InitPage";
@@ -21,7 +21,7 @@ export default function SwapStatePage({ state }: { state: SwapState | null }) {
   if (state === null) {
     return <InitPage />;
   }
-  
+
   switch (state.curr.type) {
     case "RequestingQuote":
       return <CircularProgressWithSubtitle description="Requesting quote..." />;
@@ -31,8 +31,8 @@ export default function SwapStatePage({ state }: { state: SwapState | null }) {
       return <ReceivedQuotePage />;
     case "WaitingForBtcDeposit":
       return <WaitingForBitcoinDepositPage {...state.curr.content} />;
-    case "Started":
-      return <StartedPage {...state.curr.content} />;
+    case "SwapSetupInflight":
+      return <SwapSetupInflightPage {...state.curr.content} />;
     case "BtcLockTxInMempool":
       return <BitcoinLockTxInMempoolPage {...state.curr.content} />;
     case "XmrLockTxInMempool":

--- a/src-gui/src/renderer/components/modal/swap/pages/in_progress/StartedPage.tsx
+++ b/src-gui/src/renderer/components/modal/swap/pages/in_progress/StartedPage.tsx
@@ -2,16 +2,15 @@ import { TauriSwapProgressEventContent } from "models/tauriModelExt";
 import { SatsAmount } from "renderer/components/other/Units";
 import CircularProgressWithSubtitle from "../../CircularProgressWithSubtitle";
 
-export default function StartedPage({
+export default function SwapSetupInflightPage({
   btc_lock_amount,
   btc_tx_lock_fee,
-}: TauriSwapProgressEventContent<"Started">) {
+}: TauriSwapProgressEventContent<"SwapSetupInflight">) {
   return (
     <CircularProgressWithSubtitle
       description={
         <>
-          Locking <SatsAmount amount={btc_lock_amount} /> with a network fee of{" "}
-          <SatsAmount amount={btc_tx_lock_fee} />
+          Negotiating with the swap provider to lock <SatsAmount amount={btc_lock_amount} />
         </>
       }
     />

--- a/src-gui/src/renderer/components/modal/swap/pages/in_progress/SwapSetupInflightPage.tsx
+++ b/src-gui/src/renderer/components/modal/swap/pages/in_progress/SwapSetupInflightPage.tsx
@@ -10,7 +10,7 @@ export default function SwapSetupInflightPage({
     <CircularProgressWithSubtitle
       description={
         <>
-          Negotiating with the swap provider to lock <SatsAmount amount={btc_lock_amount} />
+          Starting swap with provider to lock <SatsAmount amount={btc_lock_amount} />
         </>
       }
     />

--- a/src-gui/src/renderer/components/modal/swap/pages/init/WaitingForBitcoinDepositPage.tsx
+++ b/src-gui/src/renderer/components/modal/swap/pages/init/WaitingForBitcoinDepositPage.tsx
@@ -24,12 +24,11 @@ export default function WaitingForBtcDepositPage({
   min_deposit_until_swap_will_start,
   max_deposit_until_maximum_amount_is_reached,
   min_bitcoin_lock_tx_fee,
+  max_giveable,
   quote,
 }: TauriSwapProgressEventContent<"WaitingForBtcDeposit">) {
   const classes = useStyles();
-  const bitcoinBalance = useAppSelector((s) => s.rpc.state.balance) || 0;
 
-  // TODO: Account for BTC lock tx fees
   return (
     <Box>
       <DepositAddressInfoBox
@@ -39,10 +38,10 @@ export default function WaitingForBtcDepositPage({
           <Box className={classes.additionalContent}>
             <Typography variant="subtitle2">
               <ul>
-                {bitcoinBalance > 0 ? (
+                {max_giveable > 0 ? (
                   <li>
-                    You have already deposited{" "}
-                    <SatsAmount amount={bitcoinBalance} />
+                    You have already deposited enough funds to swap
+                    <SatsAmount amount={max_giveable} />. However, that is below the minimum amount required to start the swap.
                   </li>
                 ) : null}
                 <li>
@@ -52,7 +51,7 @@ export default function WaitingForBtcDepositPage({
                     amount={max_deposit_until_maximum_amount_is_reached}
                   />{" "}
                   to the address above
-                  {bitcoinBalance > 0 && (
+                  {max_giveable > 0 && (
                     <> (on top of the already deposited funds)</>
                   )}
                 </li>

--- a/swap/src/cli/api/tauri_bindings.rs
+++ b/swap/src/cli/api/tauri_bindings.rs
@@ -149,7 +149,7 @@ pub enum TauriSwapProgressEvent {
         min_bitcoin_lock_tx_fee: bitcoin::Amount,
         quote: BidQuote,
     },
-    Started {
+    SwapSetupInflight {
         #[typeshare(serialized_as = "number")]
         #[serde(with = "::bitcoin::util::amount::serde::as_sat")]
         btc_lock_amount: bitcoin::Amount,


### PR DESCRIPTION
We now display a `Starting swap with provider to lock ... BTC` page when the Bitcoin have been deposited and the swap setup is inflight.