### PR TITLE
Release version 1.0.0-alpha.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-alpha.1] - 2024-11-14
+
 - GUI: Swaps will now be refunded as soon as the cancel timelock expires if the GUI is running but the swap dialog is not open.
 - Breaking change: Increased Bitcoin refund window from 12 hours (72 blocks) to 24 hours (144 blocks) on mainnet. This change affects the default transaction configuration and requires both CLI and ASB to be updated to maintain compatibility. Earlier versions will not be able to initiate new swaps with peers running this version.
 - Breaking network protocol change: The libp2p version has been upgraded to 0.53 which includes breaking network protocol changes. ASBs and CLIs will not be able to swap if one of them is on the old version.
@@ -377,7 +379,8 @@ It is possible to migrate critical data from the old db to the sqlite but there 
 - Fixed an issue where Alice would not verify if Bob's Bitcoin lock transaction is semantically correct, i.e. pays the agreed upon amount to an output owned by both of them.
   Fixing this required a **breaking change** on the network layer and hence old versions are not compatible with this version.
 
-[unreleased]: https://github.com/comit-network/xmr-btc-swap/compare/0.13.2...HEAD
+[unreleased]: https://github.com/UnstoppableSwap/core/compare/1.0.0-alpha.1...HEAD
+[1.0.0-alpha.1]: https://github.com/UnstoppableSwap/core/compare/0.13.2...1.0.0-alpha.1
 [0.13.2]: https://github.com/comit-network/xmr-btc-swap/compare/0.13.1...0.13.2
 [0.13.1]: https://github.com/comit-network/xmr-btc-swap/compare/0.13.0...0.13.1
 [0.13.0]: https://github.com/comit-network/xmr-btc-swap/compare/0.12.3...0.13.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7890,7 +7890,7 @@ checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
 
 [[package]]
 name = "swap"
-version = "0.13.2"
+version = "1.0.0-alpha.1"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -9437,7 +9437,7 @@ dependencies = [
 
 [[package]]
 name = "unstoppableswap-gui-rs"
-version = "0.7.0"
+version = "1.0.0-alpha.1"
 dependencies = [
  "anyhow",
  "once_cell",

--- a/swap/Cargo.toml
+++ b/swap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swap"
-version = "0.13.2"
+version = "1.0.0-alpha.1"
 authors = [ "The COMIT guys <hello@comit.network>" ]
 edition = "2021"
 description = "XMR/BTC trustless atomic swaps."


### PR DESCRIPTION
Hi @binarybaron!

This PR was created in response to a manual trigger of the release workflow here: https://github.com/UnstoppableSwap/core/actions/runs/11840935095.
I've updated the changelog and bumped the versions in the manifest files in this commit: 4e9949c8c49f6ad1f0c601d112a82ac819426e7f.

Merging this PR will create a GitHub release and upload any assets that are created as part of the release build.