### PR TITLE
Release version 1.0.0-alpha.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-alpha.2] - 2024-11-14
+
 ### **GUI**
+
 - Display a progress bar to user while we are downloading the `monero-wallet-rpc`
 - Release `.app` builds for Darwin
 
@@ -383,7 +386,8 @@ It is possible to migrate critical data from the old db to the sqlite but there 
 - Fixed an issue where Alice would not verify if Bob's Bitcoin lock transaction is semantically correct, i.e. pays the agreed upon amount to an output owned by both of them.
   Fixing this required a **breaking change** on the network layer and hence old versions are not compatible with this version.
 
-[unreleased]: https://github.com/UnstoppableSwap/core/compare/1.0.0-alpha.1...HEAD
+[unreleased]: https://github.com/UnstoppableSwap/core/compare/1.0.0-alpha.2...HEAD
+[1.0.0-alpha.2]: https://github.com/UnstoppableSwap/core/compare/1.0.0-alpha.1...1.0.0-alpha.2
 [1.0.0-alpha.1]: https://github.com/UnstoppableSwap/core/compare/0.13.2...1.0.0-alpha.1
 [0.13.2]: https://github.com/comit-network/xmr-btc-swap/compare/0.13.1...0.13.2
 [0.13.1]: https://github.com/comit-network/xmr-btc-swap/compare/0.13.0...0.13.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7890,7 +7890,7 @@ checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
 
 [[package]]
 name = "swap"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha.2"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -9437,7 +9437,7 @@ dependencies = [
 
 [[package]]
 name = "unstoppableswap-gui-rs"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha.2"
 dependencies = [
  "anyhow",
  "once_cell",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "UnstoppableSwap",
-  "version": "1.0.0-alpha.1",
+  "version": "1.0.0-alpha.2",
   "identifier": "net.unstoppableswap.gui",
   "build": {
     "devUrl": "http://localhost:1420",

--- a/swap/Cargo.toml
+++ b/swap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swap"
-version = "1.0.0-alpha.1"
+version = "1.0.0-alpha.2"
 authors = [ "The COMIT guys <hello@comit.network>" ]
 edition = "2021"
 description = "XMR/BTC trustless atomic swaps."


### PR DESCRIPTION
Hi @binarybaron!

This PR was created in response to a manual trigger of the release workflow here: https://github.com/UnstoppableSwap/core/actions/runs/11843269671.
I've updated the changelog and bumped the versions in the manifest files in this commit: 29cbad0a7c4126ee056948f9f2ebd798f541904d.

Merging this PR will create a GitHub release and upload any assets that are created as part of the release build.