### PR TITLE
fix(ci): Pin libwebkit2gtk to 2.44.0-2

### DIFF
--- a/.github/workflows/build-gui-release-binaries.yml
+++ b/.github/workflows/build-gui-release-binaries.yml
@@ -45,8 +45,24 @@ jobs:
       - name: install dependencies (ubuntu only)
         if: matrix.platform == 'ubuntu-22.04' # This must match the platform value defined above.
         run: |
-          sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+          sudo apt update;
+          sudo apt install -y \
+            build-essential \
+            curl \
+            wget \
+            file \
+            libssl-dev \
+            libgtk-3-dev \
+            libappindicator3-dev \
+            librsvg2-dev;
+
+          sudo apt install -y \
+            libwebkit2gtk-4.1-0=2.44.0-2 \
+            libwebkit2gtk-4.1-dev=2.44.0-2 \
+            libjavascriptcoregtk-4.1-0=2.44.0-2 \
+            libjavascriptcoregtk-4.1-dev=2.44.0-2 \
+            gir1.2-javascriptcoregtk-4.1=2.44.0-2 \
+            gir1.2-webkit2-4.1=2.44.0-2;
 
       - name: install frontend dependencies
         working-directory: src-gui


### PR DESCRIPTION
Attempt at fixing https://github.com/UnstoppableSwap/core/issues/182. We are copying the system dependencies from https://github.com/gitbutlerapp/gitbutler/blob/master/.github/workflows/publish.yaml