### PR TITLE
GUI: warn against replace-by-fee for deposit transactions

### DIFF
--- a/src-gui/src/renderer/components/modal/swap/DepositAddressInfoBox.tsx
+++ b/src-gui/src/renderer/components/modal/swap/DepositAddressInfoBox.tsx
@@ -2,6 +2,7 @@ import { Box } from "@material-ui/core";
 import { ReactNode } from "react";
 import ActionableMonospaceTextBox from "renderer/components/other/ActionableMonospaceTextBox";
 import InfoBox from "./InfoBox";
+import { Alert } from "@material-ui/lab";
 
 type Props = {
   title: string;

--- a/src-gui/src/renderer/components/modal/swap/pages/init/WaitingForBitcoinDepositPage.tsx
+++ b/src-gui/src/renderer/components/modal/swap/pages/init/WaitingForBitcoinDepositPage.tsx
@@ -88,6 +88,7 @@ export default function WaitingForBtcDepositPage({
             <Alert severity="info">
               Please do not use replace-by-fee on your deposit transaction.
               You'll need to start a new swap if you do.
+              The funds will be available for future swaps.
             </Alert>
           </Box>
         }

--- a/src-gui/src/renderer/components/modal/swap/pages/init/WaitingForBitcoinDepositPage.tsx
+++ b/src-gui/src/renderer/components/modal/swap/pages/init/WaitingForBitcoinDepositPage.tsx
@@ -5,6 +5,7 @@ import BitcoinIcon from "../../../../icons/BitcoinIcon";
 import { MoneroSatsExchangeRate, SatsAmount } from "../../../../other/Units";
 import DepositAddressInfoBox from "../../DepositAddressInfoBox";
 import DepositAmountHelper from "./DepositAmountHelper";
+import { Alert } from "@material-ui/lab";
 
 const useStyles = makeStyles((theme) => ({
   amountHelper: {
@@ -67,20 +68,27 @@ export default function WaitingForBtcDepositPage({
                 </li>
                 <li>
                   The swap will start automatically as soon as the minimum
-                  amount is deposited
+                  amount is deposited.
+                </li>
+                <li>
+                  <DepositAmountHelper
+                    min_deposit_until_swap_will_start={
+                      min_deposit_until_swap_will_start
+                    }
+                    max_deposit_until_maximum_amount_is_reached={
+                      max_deposit_until_maximum_amount_is_reached
+                    }
+                    min_bitcoin_lock_tx_fee={min_bitcoin_lock_tx_fee}
+                    quote={quote}
+                  />
                 </li>
               </ul>
             </Typography>
-            <DepositAmountHelper
-              min_deposit_until_swap_will_start={
-                min_deposit_until_swap_will_start
-              }
-              max_deposit_until_maximum_amount_is_reached={
-                max_deposit_until_maximum_amount_is_reached
-              }
-              min_bitcoin_lock_tx_fee={min_bitcoin_lock_tx_fee}
-              quote={quote}
-            />
+
+            <Alert severity="info">
+              Please do not use replace-by-fee on your deposit transaction.
+              You'll need to start a new swap if you do.
+            </Alert>
           </Box>
         }
         icon={<BitcoinIcon />}


### PR DESCRIPTION
This PR adds a warning against replace-by-fee for deposit transactions.
Doing so will cause the app to fail to recognize the deposit. 
This leads to having to cancel the swap and start a new one.
The deposited funds can be used for that, there is no risk of loss of funds.