### PR TITLE
fix(cli): Correctly check for available nodes, remove dead nodes

### DIFF
--- a/swap/src/cli/api.rs
+++ b/swap/src/cli/api.rs
@@ -364,8 +364,6 @@ impl ContextBuilder {
         let initialize_monero_wallet = async {
             match self.monero {
                 Some(monero) => {
-                    let monero_daemon_address = monero.apply_defaults(self.is_testnet);
-
                     self.tauri_handle.emit_context_init_progress_event(
                         TauriContextStatusEvent::Initializing(vec![
                             TauriPartialInitProgress::OpeningMoneroWallet(
@@ -376,7 +374,7 @@ impl ContextBuilder {
 
                     let (wlt, prc) = init_monero_wallet(
                         data_dir.clone(),
-                        monero_daemon_address,
+                        monero.monero_daemon_address,
                         env_config,
                         self.tauri_handle.clone(),
                     )
@@ -548,7 +546,7 @@ async fn init_bitcoin_wallet(
 
 async fn init_monero_wallet(
     data_dir: PathBuf,
-    monero_daemon_address: String,
+    monero_daemon_address: impl Into<Option<String>> + Clone,
     env_config: EnvConfig,
     tauri_handle: Option<TauriHandle>,
 ) -> Result<(monero::Wallet, monero::WalletRpcProcess)> {
@@ -559,7 +557,7 @@ async fn init_monero_wallet(
     let monero_wallet_rpc = monero::WalletRpc::new(data_dir.join("monero"), tauri_handle).await?;
 
     tracing::debug!(
-        address = monero_daemon_address,
+        override_monero_daemon_address = monero_daemon_address.clone().into(),
         "Attempting to start monero-wallet-rpc process"
     );
 

--- a/swap/src/cli/command.rs
+++ b/swap/src/cli/command.rs
@@ -21,10 +21,6 @@ use uuid::Uuid;
 use super::api::request::GetLogsArgs;
 use super::api::ContextBuilder;
 
-// See: https://moneroworld.com/
-pub const DEFAULT_MONERO_DAEMON_ADDRESS: &str = "node.community.rino.io:18081";
-pub const DEFAULT_MONERO_DAEMON_ADDRESS_STAGENET: &str = "stagenet.community.rino.io:38081";
-
 // See: https://1209k.com/bitcoin-eye/ele.php?chain=btc
 const DEFAULT_ELECTRUM_RPC_URL: &str = "ssl://blockstream.info:700";
 // See: https://1209k.com/bitcoin-eye/ele.php?chain=tbtc
@@ -504,18 +500,6 @@ pub struct Monero {
         help = "Specify to connect to a monero daemon of your choice: <host>:<port>"
     )]
     pub monero_daemon_address: Option<String>,
-}
-
-impl Monero {
-    pub fn apply_defaults(self, testnet: bool) -> String {
-        if let Some(address) = self.monero_daemon_address {
-            address
-        } else if testnet {
-            DEFAULT_MONERO_DAEMON_ADDRESS_STAGENET.to_string()
-        } else {
-            DEFAULT_MONERO_DAEMON_ADDRESS.to_string()
-        }
-    }
 }
 
 #[derive(structopt::StructOpt, Debug)]

--- a/swap/src/monero/wallet_rpc.rs
+++ b/swap/src/monero/wallet_rpc.rs
@@ -28,19 +28,15 @@ use crate::cli::api::tauri_bindings::{
 
 // See: https://www.moneroworld.com/#nodes, https://monero.fail
 // We don't need any testnet nodes because we don't support testnet at all
-static MONERO_DAEMONS: Lazy<[MoneroDaemon; 16]> = Lazy::new(|| {
+static MONERO_DAEMONS: Lazy<[MoneroDaemon; 12]> = Lazy::new(|| {
     [
         MoneroDaemon::new("xmr-node.cakewallet.com", 18081, Network::Mainnet),
         MoneroDaemon::new("nodex.monerujo.io", 18081, Network::Mainnet),
         MoneroDaemon::new("nodes.hashvault.pro", 18081, Network::Mainnet),
         MoneroDaemon::new("p2pmd.xmrvsbeast.com", 18081, Network::Mainnet),
         MoneroDaemon::new("node.monerodevs.org", 18089, Network::Mainnet),
-        MoneroDaemon::new("xmr-node-usa-east.cakewallet.com", 18081, Network::Mainnet),
         MoneroDaemon::new("xmr-node-uk.cakewallet.com", 18081, Network::Mainnet),
-        MoneroDaemon::new("node.community.rino.io", 18081, Network::Mainnet),
-        MoneroDaemon::new("testingjohnross.com", 20031, Network::Mainnet),
         MoneroDaemon::new("xmr.litepay.ch", 18081, Network::Mainnet),
-        MoneroDaemon::new("node.trocador.app", 18089, Network::Mainnet),
         MoneroDaemon::new("stagenet.xmr-tw.org", 38081, Network::Stagenet),
         MoneroDaemon::new("node.monerodevs.org", 38089, Network::Stagenet),
         MoneroDaemon::new("singapore.node.xmr.pm", 38081, Network::Stagenet),


### PR DESCRIPTION
There was an issue before we were falsely applying a default node to use and not actually iterating through our list and checking for availiability. This commit fixes this issue and removes a few dead nodes.
