### PR TITLE
fix(abs): open existing monero wallet if it already exists

### DIFF
--- a/src-gui/.env.development
+++ b/src-gui/.env.development
@@ -1,2 +1,2 @@
 # You can configure the address of a locally running testnet asb. It'll displayed in the GUI. This is useful for testing
-VITE_TESTNET_STUB_PROVIDER_ADDRESS=/onion3/clztcslas7hlfrprevcdo3l6bczwa3cumr2b5up5nsumsj7sqgd3p2qd:9939/p2p/12D3KooWS1DtT4JmZoAS6m4wZcxXnUB3eVFNvW8hSPrAyCtVSSYm
+VITE_TESTNET_STUB_PROVIDER_ADDRESS=/onion3/yw6dctty3qhjesaqmkbkxyj6u4hy3zjuntk5q4cbgrc7jok5tg4ky3qd:9939/p2p/12D3KooWS1DtT4JmZoAS6m4wZcxXnUB3eVFNvW8hSPrAyCtVSSYm

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,9 +3,16 @@ use std::result::Result;
 use std::sync::Arc;
 use swap::cli::{
     api::{
-        data, request::{
-            BalanceArgs, BuyXmrArgs, CancelAndRefundArgs, CheckElectrumNodeArgs, CheckElectrumNodeResponse, CheckMoneroNodeArgs, CheckMoneroNodeResponse, ExportBitcoinWalletArgs, GetDataDirArgs, GetHistoryArgs, GetLogsArgs, GetMoneroAddressesArgs, GetSwapInfoArgs, GetSwapInfosAllArgs, ListSellersArgs, MoneroRecoveryArgs, ResumeSwapArgs, SuspendCurrentSwapArgs, WithdrawBtcArgs
-        }, tauri_bindings::{TauriContextStatusEvent, TauriEmitter, TauriHandle, TauriSettings}, Context, ContextBuilder
+        data,
+        request::{
+            BalanceArgs, BuyXmrArgs, CancelAndRefundArgs, CheckElectrumNodeArgs,
+            CheckElectrumNodeResponse, CheckMoneroNodeArgs, CheckMoneroNodeResponse,
+            ExportBitcoinWalletArgs, GetDataDirArgs, GetHistoryArgs, GetLogsArgs,
+            GetMoneroAddressesArgs, GetSwapInfoArgs, GetSwapInfosAllArgs, ListSellersArgs,
+            MoneroRecoveryArgs, ResumeSwapArgs, SuspendCurrentSwapArgs, WithdrawBtcArgs,
+        },
+        tauri_bindings::{TauriContextStatusEvent, TauriEmitter, TauriHandle, TauriSettings},
+        Context, ContextBuilder,
     },
     command::{Bitcoin, Monero},
 };
@@ -257,7 +264,10 @@ async fn get_data_dir(
     args: GetDataDirArgs,
     _: tauri::State<'_, RwLock<State>>,
 ) -> Result<String, String> {
-    Ok(data::data_dir_from(None, args.is_testnet).to_string_result()?.to_string_lossy().to_string())
+    Ok(data::data_dir_from(None, args.is_testnet)
+        .to_string_result()?
+        .to_string_lossy()
+        .to_string())
 }
 
 /// Tauri command to initialize the Context

--- a/swap/src/bin/asb.rs
+++ b/swap/src/bin/asb.rs
@@ -421,7 +421,7 @@ async fn init_monero_wallet(
     env_config: swap::env::Config,
 ) -> Result<monero::Wallet> {
     tracing::debug!("Opening Monero wallet");
-    let wallet = monero::Wallet::open_or_create(
+    let wallet = monero::Wallet::connect_to(
         config.monero.wallet_rpc_url.clone(),
         DEFAULT_WALLET_NAME.to_string(),
         env_config,

--- a/swap/src/cli/api.rs
+++ b/swap/src/cli/api.rs
@@ -566,7 +566,7 @@ async fn init_monero_wallet(
         .await
         .context("Failed to start monero-wallet-rpc process")?;
 
-    let monero_wallet = monero::Wallet::open_or_create(
+    let monero_wallet = monero::Wallet::connect_to(
         monero_wallet_rpc_process.endpoint(),
         MONERO_BLOCKCHAIN_MONITORING_WALLET_NAME.to_string(),
         env_config,


### PR DESCRIPTION
This PR introduces logic that, if we fail to generate a new monero wallet because it already exists, tries to open the existing wallet instead of aborting instantly.

Also ran dprint and clippy.