### PR TITLE
Send offer duration from ASB to CLI

### DIFF
--- a/swap/src/asb/network.rs
+++ b/swap/src/asb/network.rs
@@ -205,9 +205,11 @@ pub mod behaviour {
     where
         LR: LatestRate + Send + 'static,
     {
+        #[allow(clippy::too_many_arguments)]
         pub fn new(
             min_buy: bitcoin::Amount,
             max_buy: bitcoin::Amount,
+            max_swap_timeout: Duration,
             latest_rate: LR,
             resume_only: bool,
             env_config: env::Config,
@@ -235,6 +237,7 @@ pub mod behaviour {
                 swap_setup: alice::Behaviour::new(
                     min_buy,
                     max_buy,
+                    max_swap_timeout,
                     env_config,
                     latest_rate,
                     resume_only,

--- a/swap/src/bin/asb.rs
+++ b/swap/src/bin/asb.rs
@@ -20,6 +20,7 @@ use rust_decimal::Decimal;
 use std::convert::TryInto;
 use std::env;
 use std::sync::Arc;
+use std::time::Duration;
 use structopt::clap;
 use structopt::clap::ErrorKind;
 use swap::asb::command::{parse_args, Arguments, Command};
@@ -166,6 +167,7 @@ pub async fn main() -> Result<()> {
                 &seed,
                 config.maker.min_buy_btc,
                 config.maker.max_buy_btc,
+                Duration::from_secs(120),
                 kraken_rate.clone(),
                 resume_only,
                 env_config,
@@ -212,6 +214,7 @@ pub async fn main() -> Result<()> {
                 kraken_rate.clone(),
                 config.maker.min_buy_btc,
                 config.maker.max_buy_btc,
+                Duration::from_secs(120),
                 config.maker.external_bitcoin_redeem_address,
             )
             .unwrap();

--- a/swap/src/bin/swap.rs
+++ b/swap/src/bin/swap.rs
@@ -416,6 +416,7 @@ mod tests {
             price: Amount::from_btc(0.001).unwrap(),
             max_quantity: Amount::from_btc(btc).unwrap(),
             min_quantity: Amount::ZERO,
+            valid_duration: Some(Duration::from_secs(120)),
         }
     }
 
@@ -424,6 +425,7 @@ mod tests {
             price: Amount::from_btc(0.001).unwrap(),
             max_quantity: Amount::max_value(),
             min_quantity: Amount::from_btc(btc).unwrap(),
+            valid_duration: Some(Duration::from_secs(120)),
         }
     }
 

--- a/swap/src/cli.rs
+++ b/swap/src/cli.rs
@@ -82,6 +82,7 @@ mod tests {
             price: bitcoin::Amount::from_sat(1337),
             min_quantity: bitcoin::Amount::from_sat(42),
             max_quantity: bitcoin::Amount::from_sat(9001),
+            valid_duration: Some(Duration::from_secs(42)),
         };
 
         let mut asb = new_swarm(|identity| {

--- a/swap/src/cli/list_sellers.rs
+++ b/swap/src/cli/list_sellers.rs
@@ -345,6 +345,7 @@ mod tests {
                     price: Default::default(),
                     min_quantity: Default::default(),
                     max_quantity: Default::default(),
+                    valid_duration: Some(Duration::from_secs(120)),
                 }),
             },
         ];
@@ -360,6 +361,7 @@ mod tests {
                         price: Default::default(),
                         min_quantity: Default::default(),
                         max_quantity: Default::default(),
+                        valid_duration: Some(Duration::from_secs(120)),
                     })
                 },
                 Seller {

--- a/swap/src/network/quote.rs
+++ b/swap/src/network/quote.rs
@@ -38,6 +38,8 @@ pub struct BidQuote {
     #[serde(with = "::bitcoin::util::amount::serde::as_sat")]
     #[typeshare(serialized_as = "number")]
     pub max_quantity: bitcoin::Amount,
+
+    pub valid_duration: Option<Duration>,
 }
 
 #[derive(Clone, Copy, Debug, thiserror::Error)]

--- a/swap/src/network/swap_setup/alice.rs
+++ b/swap/src/network/swap_setup/alice.rs
@@ -116,6 +116,7 @@ pub struct Behaviour<LR> {
     events: VecDeque<OutEvent>,
     min_buy: bitcoin::Amount,
     max_buy: bitcoin::Amount,
+    max_swap_timeout: Duration,
     env_config: env::Config,
 
     latest_rate: LR,
@@ -126,6 +127,7 @@ impl<LR> Behaviour<LR> {
     pub fn new(
         min_buy: bitcoin::Amount,
         max_buy: bitcoin::Amount,
+        max_swap_timeout: Duration,
         env_config: env::Config,
         latest_rate: LR,
         resume_only: bool,
@@ -134,6 +136,7 @@ impl<LR> Behaviour<LR> {
             events: Default::default(),
             min_buy,
             max_buy,
+            max_swap_timeout,
             env_config,
             latest_rate,
             resume_only,
@@ -161,6 +164,7 @@ where
         let handler = Handler::new(
             self.min_buy,
             self.max_buy,
+            self.max_swap_timeout,
             self.env_config,
             self.latest_rate.clone(),
             self.resume_only,
@@ -181,6 +185,7 @@ where
         let handler = Handler::new(
             self.min_buy,
             self.max_buy,
+            self.max_swap_timeout,
             self.env_config,
             self.latest_rate.clone(),
             self.resume_only,
@@ -256,6 +261,7 @@ impl<LR> Handler<LR> {
     fn new(
         min_buy: bitcoin::Amount,
         max_buy: bitcoin::Amount,
+        negotiation_timeout: Duration,
         env_config: env::Config,
         latest_rate: LR,
         resume_only: bool,
@@ -268,7 +274,7 @@ impl<LR> Handler<LR> {
             env_config,
             latest_rate,
             resume_only,
-            negotiation_timeout: Duration::from_secs(120),
+            negotiation_timeout,
             keep_alive_until: Some(Instant::now() + Duration::from_secs(30)),
         }
     }

--- a/swap/src/network/swarm.rs
+++ b/swap/src/network/swarm.rs
@@ -18,6 +18,7 @@ pub fn asb<LR>(
     seed: &Seed,
     min_buy: bitcoin::Amount,
     max_buy: bitcoin::Amount,
+    max_swap_timeout: Duration,
     latest_rate: LR,
     resume_only: bool,
     env_config: env::Config,
@@ -46,6 +47,7 @@ where
     let behaviour = asb::Behaviour::new(
         min_buy,
         max_buy,
+        max_swap_timeout,
         latest_rate,
         resume_only,
         env_config,

--- a/swap/tests/harness/mod.rs
+++ b/swap/tests/harness/mod.rs
@@ -247,6 +247,7 @@ async fn start_alice(
         seed,
         min_buy,
         max_buy,
+        Duration::from_secs(120),
         latest_rate,
         resume_only,
         env_config,
@@ -268,6 +269,7 @@ async fn start_alice(
         FixedRate::default(),
         min_buy,
         max_buy,
+        Duration::from_secs(120),
         None,
     )
     .unwrap();


### PR DESCRIPTION
On the ASB side this is max_swap_timeout, and may eventually be configurable, or dynamic. On the CLI side this is just received as valid_duration, an Optional Duration.

Rebase of comit-network/xmr-btc-swap/pull/1662 onto this codebase.  Resolves #264 .