### PR TITLE
CI: fix spurious network erros

### DIFF
--- a/.github/workflows/build-gui-release-binaries-cb.yml
+++ b/.github/workflows/build-gui-release-binaries-cb.yml
@@ -78,6 +78,12 @@ jobs:
             gir1.2-javascriptcoregtk-4.1=2.44.0-2 \
             gir1.2-webkit2-4.1=2.44.0-2;
 
+      - name: work around spurious network errors in curl 8.0
+        run: |
+          if rustc --version --verbose | grep -q '^release: 1\.79\.'; then
+            echo CARGO_HTTP_MULTIPLEXING=false >> $GITHUB_ENV
+          fi
+
       - name: Install Frontend Dependencies
         working-directory: src-gui
         run: yarn install

--- a/.github/workflows/build-gui-release-binaries.yml
+++ b/.github/workflows/build-gui-release-binaries.yml
@@ -64,6 +64,12 @@ jobs:
             gir1.2-javascriptcoregtk-4.1=2.44.0-2 \
             gir1.2-webkit2-4.1=2.44.0-2;
 
+      - name: work around spurious network errors in curl 8.0
+        run: |
+          if rustc --version --verbose | grep -q '^release: 1\.79\.'; then
+            echo CARGO_HTTP_MULTIPLEXING=false >> $GITHUB_ENV
+          fi
+
       - name: install frontend dependencies
         working-directory: src-gui
         run: yarn install


### PR DESCRIPTION
Occasionally our ci jobs would fail due to network errors. This is a known issue which is worked around by disabling http multiplexing, for now. Hopefully.