### PR TITLE
feat(gui): switch to showing the maker fee instead of markup

### DIFF
--- a/src-gui/src/renderer/components/modal/provider/MakerInfo.tsx
+++ b/src-gui/src/renderer/components/modal/provider/MakerInfo.tsx
@@ -6,7 +6,7 @@ import {
   MoneroBitcoinExchangeRate,
   SatsAmount,
 } from "renderer/components/other/Units";
-import { getMarkup, satsToBtc, secondsToDays } from "utils/conversionUtils";
+import { calculateFee, satsToBtc, secondsToDays } from "utils/conversionUtils";
 import { isMakerOutdated } from 'utils/multiAddrUtils';
 import WarningIcon from '@material-ui/icons/Warning';
 import { useAppSelector } from "store/hooks";
@@ -41,18 +41,18 @@ const useStyles = makeStyles((theme) => ({
 /**
  * A chip that displays the markup of the maker's exchange rate compared to the market rate.
  */
-function MakerMarkupChip({ maker }: { maker: ExtendedMakerStatus }) {
+function MakerFeeChip({ maker }: { maker: ExtendedMakerStatus }) {
   const marketExchangeRate = useAppSelector(s => s.rates?.xmrBtcRate);
   if (marketExchangeRate == null)
     return null;
 
   const makerExchangeRate = satsToBtc(maker.price);
-  /** The markup of the exchange rate compared to the market rate in percent */
-  const markup = getMarkup(makerExchangeRate, marketExchangeRate);
+  /** The fee of the exchange rate compared to the market rate in percent */
+  const fee = calculateFee(1 / makerExchangeRate, 1 / marketExchangeRate);
 
   return (
-    <Tooltip title="The markup this maker charges compared to centralized markets. A lower markup means that you get more Monero for your Bitcoin.">
-      <Chip label={`Markup ${markup.toFixed(2)}%`} />
+    <Tooltip title="The fee this maker charges compared to centralized markets as a percentage of the maker's exchange rate. A lower fee means that you get more Monero for your Bitcoin.">
+      <Chip label={`Fee ${fee.toFixed(2)}%`} />
     </Tooltip>
   );
 }
@@ -119,7 +119,7 @@ export default function MakerInfo({
             <Chip label="Outdated" icon={<WarningIcon />} color="primary" />
           </Tooltip>
         )}
-        <MakerMarkupChip maker={maker} />
+        <MakerFeeChip maker={maker} />
       </Box>
     </Box >
   );

--- a/src-gui/src/renderer/components/other/Units.tsx
+++ b/src-gui/src/renderer/components/other/Units.tsx
@@ -1,6 +1,6 @@
 import { Tooltip } from "@material-ui/core";
 import { useAppSelector } from "store/hooks";
-import { getMarkup, piconerosToXmr, satsToBtc } from "utils/conversionUtils";
+import { calculateFee, piconerosToXmr, satsToBtc } from "utils/conversionUtils";
 
 type Amount = number | null | undefined;
 
@@ -75,14 +75,14 @@ export function MoneroBitcoinExchangeRate({
   displayMarkup?: boolean;
 }) {
   const marketRate = useAppSelector((state) => state.rates?.xmrBtcRate);
-  const markup = (displayMarkup && marketRate != null) ? `${getMarkup(rate, marketRate).toFixed(2)}% markup` : null;
+  const fee = (displayMarkup && marketRate != null) ? `${calculateFee(rate, marketRate).toFixed(2)}% fee` : null;
 
   return (
     <AmountWithUnit
       amount={rate}
       unit="BTC/XMR"
       fixedPrecision={8}
-      parenthesisText={markup}
+      parenthesisText={fee}
     />
   );
 }

--- a/src-gui/src/renderer/components/pages/help/SettingsBox.tsx
+++ b/src-gui/src/renderer/components/pages/help/SettingsBox.tsx
@@ -82,10 +82,10 @@ export default function SettingsBox() {
           <TableContainer>
             <Table>
               <TableBody>
+                <ThemeSetting />
+                <FetchFiatPricesSetting />
                 <ElectrumRpcUrlSetting />
                 <MoneroNodeUrlSetting />
-                <FetchFiatPricesSetting />
-                <ThemeSetting />
               </TableBody>
             </Table>
           </TableContainer>
@@ -139,7 +139,7 @@ function FetchFiatPricesSetting() {
     <>
       <TableRow>
         <TableCell>
-          <SettingLabel label="Query fiat prices" tooltip="Whether to fetch fiat prices via the clearnet. This is required for the price display to work. If you require total anonymity and don't use a VPN, you should disable this." />
+          <SettingLabel label="Query fiat prices" tooltip="Whether to fetch fiat prices via the clearnet. This is required for the price and fee display. If you require total privacy and don't use a VPN, you should disable this." />
         </TableCell>
         <TableCell>
           <Switch
@@ -209,7 +209,7 @@ function ElectrumRpcUrlSetting() {
   return (
     <TableRow>
       <TableCell>
-        <SettingLabel label="Custom Electrum RPC URL" tooltip="This is the URL of the Electrum server that the GUI will connect to. It is used to sync Bitcoin transactions. If you leave this field empty, the GUI will choose from a list of known servers at random." />
+        <SettingLabel label="Custom Electrum RPC URL" tooltip="This is the url of the Electrum server that the app will connect to. It is used to sync Bitcoin transactions. If you leave this field empty, the app will choose from a list of known servers at random." />
       </TableCell>
       <TableCell>
         <IconButton
@@ -258,7 +258,7 @@ function MoneroNodeUrlSetting() {
   return (
     <TableRow>
       <TableCell>
-        <SettingLabel label="Custom Monero Node URL" tooltip="This is the URL of the Monero node that the GUI will connect to. Ensure the node is listening for RPC connections over HTTP. If you leave this field empty, the GUI will choose from a list of known nodes at random." />
+        <SettingLabel label="Custom Monero Node URL" tooltip="This is the url of the Monero remote node that the app will connect to. If you leave this field empty, the app will choose from a list of known nodes at random." />
       </TableCell>
       <TableCell>
         <IconButton
@@ -289,7 +289,7 @@ function ThemeSetting() {
   return (
     <TableRow>
       <TableCell>
-        <SettingLabel label="Theme" tooltip="This is the theme of the GUI." />
+        <SettingLabel label="Theme" tooltip="This is the color theme of the app." />
       </TableCell>
       <TableCell>
         <Select
@@ -364,16 +364,22 @@ function NodeStatus({ status }: { status: boolean | undefined }) {
 
   switch (status) {
     case true:
-      return <Tooltip title={"This node is available and responding to RPC requests"}>
-        <Circle color={theme.palette.success.dark} />
+      return <Tooltip title={"This node is reachable and responding to our requests"}>
+        <span>
+          <Circle color={theme.palette.success.dark} />
+        </span>
       </Tooltip>;
     case false:
-      return <Tooltip title={"This node is not available or not responding to RPC requests"}>
-        <Circle color={theme.palette.error.dark} />
+      return <Tooltip title={"This node is not reachable or not responding to our requests"}>
+        <span>
+          <Circle color={theme.palette.error.dark} />
+        </span>
       </Tooltip>;
     default:
       return <Tooltip title={"The status of this node is currently unknown"}>
-        <HourglassEmpty />
+        <span>
+          <Circle color={theme.palette.warning.dark} />
+        </span>
       </Tooltip>;
   }
 }

--- a/src-gui/src/utils/conversionUtils.ts
+++ b/src-gui/src/utils/conversionUtils.ts
@@ -71,7 +71,7 @@ export function bytesToMb(bytes: number): number {
   return bytes / (1024 * 1024);
 }
 
-/// Get the markup of a maker's exchange rate compared to the market rate in percent
-export function getMarkup(makerPrice: number, marketPrice: number): number {
-  return (makerPrice - marketPrice) / marketPrice * 100;
+/// Get the fee of a maker's exchange rate compared to the market rate in percent
+export function calculateFee(makerPrice: number, marketPrice: number): number {
+  return (marketPrice - makerPrice) / marketPrice * 100;
 }


### PR DESCRIPTION
The fee is what the maker charges in excess of market exchange rate, as a percentage of the makers price.

For example, if the market rate is 0.5BTC/XMR and the maker charges 0.75BTC/XMR, the fee is 33.3% since 1/3 of the maker's price goes beyond the market exchange rate.