### PR TITLE
rework asb monero wallet thread safety

### DIFF
--- a/swap/src/monero/wallet.rs
+++ b/swap/src/monero/wallet.rs
@@ -331,6 +331,9 @@ pub struct WatchRequest {
     pub expected: Amount,
 }
 
+/// This is a shorthand for the dynamic type we use to pass listeners to
+/// i.e. the `wait_for_confirmations` function. It is basically
+/// an `async fn` which takes a `u64` and returns nothing, but in dynamic.
 type ConfirmationListener =
     Box<dyn Fn(u64) -> Pin<Box<dyn Future<Output = ()> + Send + 'static>> + Send + 'static>;
 


### PR DESCRIPTION
Our current approach to thread safety regarding `monero::Wallet`, which we pass around as `Arc<monero::Wallet>`, is that it contains a `Mutex::monero_rpc::wallet::Client` and acquires that before using the monero wallet rpc process. Since it does that in each function, calling i.e. `create_from_and_load` from `create_from_keys_and_sweep` results in the lock being acquired, released and then acquired again, even though we expect an atomic operation. This results in a race condition where another thread acquires the lock after it is first released, even though the function isn't finished yet. 

We need to migrate to an API where we can guarantee that multiple functions can be called without releasing the lock. The best way to do this would be to always pass `Arc<Mutex<monero::Wallet>>` and have the caller lock the mutex. Any call to the `monero::Wallet` would then be guaranteed to happen within a single lock acquisition. However, this would introduce a lot of (small) changes, since we use `Arc<monero::Wallet>` quite a lot. 

@binarybaron can you think of another way to fix this with less friction, that is similarly robust? 