### PR TITLE
cli: log the reason we can't find tx_cancel

### DIFF
--- a/src-gui/src/renderer/components/navigation/NavigationFooter.tsx
+++ b/src-gui/src/renderer/components/navigation/NavigationFooter.tsx
@@ -7,7 +7,7 @@ import UnfinishedSwapsAlert from "../alert/UnfinishedSwapsAlert";
 import LinkIconButton from "../icons/LinkIconButton";
 import BackgroundRefundAlert from "../alert/BackgroundRefundAlert";
 import MatrixIcon from "../icons/MatrixIcon";
-import { BookRounded } from "@material-ui/icons";
+import { BookRounded, MenuBook } from "@material-ui/icons";
 
 const useStyles = makeStyles((theme) => ({
   outer: {
@@ -50,7 +50,7 @@ export default function NavigationFooter() {
         <Tooltip title="Read our official documentation">
           <span>
             <LinkIconButton url="https://docs.unstoppableswap.net">
-              <BookRounded />
+              <MenuBook />
             </LinkIconButton>
           </span>
         </Tooltip>

--- a/swap/src/protocol/bob/swap.rs
+++ b/swap/src/protocol/bob/swap.rs
@@ -416,7 +416,11 @@ async fn next_state(
             event_emitter
                 .emit_swap_progress_event(swap_id, TauriSwapProgressEvent::CancelTimelockExpired);
 
-            if state4.check_for_tx_cancel(bitcoin_wallet).await.is_err() {
+            if let Err(err) = state4.check_for_tx_cancel(bitcoin_wallet).await {
+                tracing::debug!(
+                    %err,
+                    "Couldn't find tx_cancel yet, publishing ourselves"
+                );
                 state4.submit_tx_cancel(bitcoin_wallet).await?;
             }
 


### PR DESCRIPTION
When we can't find tx_cancel even though the cancel timelock expired, we publish it ourselves.

However, some users had a problem where the tx_cancel wasn't found even though it was already published.
This leads to the cli getting stuck in `CancelTimelockExpired` when it should go to `BtcCancelled`.
This commit introduces an additional log statement that will help us narrow down why that is.