### PR TITLE
Release version 1.0.0-rc.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-rc.16] - 2025-04-17
+
 - ASB: Quotes are now cached (Time-to-live of 2 minutes) to avoid overloading the maker with requests in times of high demand
 
 ## [1.0.0-rc.14] - 2025-04-16
@@ -446,7 +448,8 @@ It is possible to migrate critical data from the old db to the sqlite but there 
 - Fixed an issue where Alice would not verify if Bob's Bitcoin lock transaction is semantically correct, i.e. pays the agreed upon amount to an output owned by both of them.
   Fixing this required a **breaking change** on the network layer and hence old versions are not compatible with this version.
 
-[unreleased]: https://github.com/UnstoppableSwap/core/compare/1.0.0-rc.14...HEAD
+[unreleased]: https://github.com/UnstoppableSwap/core/compare/1.0.0-rc.16...HEAD
+[1.0.0-rc.16]: https://github.com/UnstoppableSwap/core/compare/1.0.0-rc.14...1.0.0-rc.16
 [1.0.0-rc.14]: https://github.com/UnstoppableSwap/core/compare/1.0.0-rc.13...1.0.0-rc.14
 [1.0.0-rc.13]: https://github.com/UnstoppableSwap/core/compare/1.0.0-rc.12...1.0.0-rc.13
 [1.0.0-rc.12]: https://github.com/UnstoppableSwap/core/compare/1.0.0-rc.11...1.0.0-rc.12

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9000,7 +9000,7 @@ checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
 
 [[package]]
 name = "swap"
-version = "1.0.0-rc.14"
+version = "1.0.0-rc.16"
 dependencies = [
  "anyhow",
  "arti-client",
@@ -11445,7 +11445,7 @@ dependencies = [
 
 [[package]]
 name = "unstoppableswap-gui-rs"
-version = "1.0.0-rc.14"
+version = "1.0.0-rc.16"
 dependencies = [
  "anyhow",
  "serde",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unstoppableswap-gui-rs"
-version = "1.0.0-rc.14"
+version = "1.0.0-rc.16"
 authors = [ "binarybaron", "einliterflasche", "unstoppableswap" ]
 edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "UnstoppableSwap",
-  "version": "1.0.0-rc.14",
+  "version": "1.0.0-rc.16",
   "identifier": "net.unstoppableswap.gui",
   "build": {
     "devUrl": "http://localhost:1420",

--- a/swap/Cargo.toml
+++ b/swap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swap"
-version = "1.0.0-rc.14"
+version = "1.0.0-rc.16"
 authors = [ "The COMIT guys <hello@comit.network>" ]
 edition = "2021"
 description = "XMR/BTC trustless atomic swaps."


### PR DESCRIPTION
Hi @binarybaron!

This PR was created in response to a manual trigger of the release workflow here: https://github.com/UnstoppableSwap/core/actions/runs/14522249139.
I've updated the changelog and bumped the versions in the manifest files in this commit: 916d0e5cc3b4f7d37f585e1720391b58d4aa9246.

Merging this PR will create a GitHub release and upload any assets that are created as part of the release build.