### PR TITLE
feat(gui): Review logs before sending feedback

### DIFF
--- a/src-gui/src/models/cliModel.ts
+++ b/src-gui/src/models/cliModel.ts
@@ -53,7 +53,7 @@ export function parseCliLogString(log: string): CliLog | string {
   try {
     const parsed = JSON.parse(log);
     if (isCliLog(parsed)) {
-      return parsed;
+      return parsed as CliLog;
     } else {
       return log;
     }

--- a/src-gui/src/models/cliModel.ts
+++ b/src-gui/src/models/cliModel.ts
@@ -61,3 +61,4 @@ export function parseCliLogString(log: string): CliLog | string {
     return log;
   }
 }
+

--- a/src-gui/src/renderer/components/other/RenderedCliLog.tsx
+++ b/src-gui/src/renderer/components/other/RenderedCliLog.tsx
@@ -1,6 +1,6 @@
 import { Box, Chip, Typography } from "@material-ui/core";
 import { CliLog } from "models/cliModel";
-import { useMemo, useState } from "react";
+import { ReactNode, useMemo, useState } from "react";
 import { logsToRawString } from "utils/parseUtils";
 import ScrollablePaperTextBox from "./ScrollablePaperTextBox";
 
@@ -61,9 +61,11 @@ function RenderedCliLog({ log }: { log: CliLog }) {
 export default function CliLogsBox({
   label,
   logs,
+  topRightButton = null,
 }: {
   label: string;
   logs: (CliLog | string)[];
+  topRightButton?: ReactNode
 }) {
   const [searchQuery, setSearchQuery] = useState<string>("");
 
@@ -82,6 +84,7 @@ export default function CliLogsBox({
       copyValue={logsToRawString(logs)}
       searchQuery={searchQuery}
       setSearchQuery={setSearchQuery}
+      topRightButton={topRightButton}
       rows={memoizedLogs.map((log) =>
         typeof log === "string" ? (
           <Typography key={log} component="pre">

--- a/src-gui/src/renderer/components/other/ScrollablePaperTextBox.tsx
+++ b/src-gui/src/renderer/components/other/ScrollablePaperTextBox.tsx
@@ -2,7 +2,7 @@ import { Box, Divider, IconButton, Paper, Typography } from "@material-ui/core";
 import FileCopyOutlinedIcon from "@material-ui/icons/FileCopyOutlined";
 import KeyboardArrowDownIcon from "@material-ui/icons/KeyboardArrowDown";
 import KeyboardArrowUpIcon from "@material-ui/icons/KeyboardArrowUp";
-import { ReactNode, useRef } from "react";
+import { ReactNode, useEffect, useRef } from "react";
 import { VList, VListHandle } from "virtua";
 import { ExpandableSearchBox } from "./ExpandableSearchBox";
 
@@ -69,11 +69,11 @@ export default function ScrollablePaperTextBox({
         <IconButton onClick={onCopy} size="small">
           <FileCopyOutlinedIcon />
         </IconButton>
-        <IconButton onClick={scrollToBottom} size="small">
-          <KeyboardArrowDownIcon />
-        </IconButton>
         <IconButton onClick={scrollToTop} size="small">
           <KeyboardArrowUpIcon />
+        </IconButton>
+        <IconButton onClick={scrollToBottom} size="small">
+          <KeyboardArrowDownIcon />
         </IconButton>
         {searchQuery !== undefined && setSearchQuery !== undefined && (
           <ExpandableSearchBox query={searchQuery} setQuery={setSearchQuery} />

--- a/src-gui/src/renderer/components/other/ScrollablePaperTextBox.tsx
+++ b/src-gui/src/renderer/components/other/ScrollablePaperTextBox.tsx
@@ -14,6 +14,7 @@ export default function ScrollablePaperTextBox({
   copyValue,
   searchQuery = null,
   setSearchQuery = null,
+  topRightButton = null,
   minHeight = MIN_HEIGHT,
 }: {
   rows: ReactNode[];
@@ -22,6 +23,7 @@ export default function ScrollablePaperTextBox({
   searchQuery: string | null;
   setSearchQuery?: ((query: string) => void) | null;
   minHeight?: string;
+  topRightButton?: ReactNode | null
 }) {
   const virtuaEl = useRef<VListHandle | null>(null);
 
@@ -48,7 +50,10 @@ export default function ScrollablePaperTextBox({
         width: "100%",
       }}
     >
-      <Typography>{title}</Typography>
+      <Box style={{ display: "flex", flexDirection: "row", justifyContent: "space-between", alignItems: "center" }}>
+        <Typography>{title}</Typography>
+        {topRightButton}
+      </Box>
       <Divider />
       <Box
         style={{

--- a/src-gui/src/renderer/rpc.ts
+++ b/src-gui/src/renderer/rpc.ts
@@ -25,6 +25,8 @@ import {
   GetDataDirArgs,
   ResolveApprovalArgs,
   ResolveApprovalResponse,
+  RedactArgs,
+  RedactResponse,
 } from "models/tauriModel";
 import {
   rpcSetBalance,
@@ -40,6 +42,8 @@ import { getNetwork, isTestnet } from "store/config";
 import { Blockchain, Network } from "store/features/settingsSlice";
 import { setStatus } from "store/features/nodesSlice";
 import { discoveredMakersByRendezvous } from "store/features/makersSlice";
+import { CliLog } from "models/cliModel";
+import { logsToRawString, parseLogsFromString } from "utils/parseUtils";
 
 export const PRESET_RENDEZVOUS_POINTS = [
   "/dns4/discover.unstoppableswap.net/tcp/8888/p2p/12D3KooWA6cnqJpVnreBVnoro8midDL9Lpzmg8oJPoAGi7YYaamE",
@@ -162,6 +166,18 @@ export async function getLogsOfSwap(
     swap_id: swapId,
     redact,
   });
+}
+
+/// Call the rust backend to redact logs.
+export async function redactLogs(
+  logs: (string | CliLog)[]
+): Promise<(string | CliLog)[]> {
+  const response = await invoke<RedactArgs, RedactResponse>("redact", {
+    text: logsToRawString(logs)
+  })
+
+  console.log(response.text.split("\n").length)
+  return parseLogsFromString(response.text);
 }
 
 export async function listSellersAtRendezvousPoint(

--- a/src-gui/src/store/features/rpcSlice.ts
+++ b/src-gui/src/store/features/rpcSlice.ts
@@ -10,7 +10,7 @@ import {
 } from "models/tauriModel";
 import { MoneroRecoveryResponse } from "../../models/rpcModel";
 import { GetSwapInfoResponseExt } from "models/tauriModelExt";
-import { getLogsAndStringsFromRawFileString } from "utils/parseUtils";
+import { parseLogsFromString } from "utils/parseUtils";
 import { CliLog } from "models/cliModel";
 import logger from "utils/logger";
 
@@ -68,7 +68,7 @@ export const rpcSlice = createSlice({
   reducers: {
     receivedCliLog(slice, action: PayloadAction<TauriLogEvent>) {
       const buffer = action.payload.buffer;
-      const logs = getLogsAndStringsFromRawFileString(buffer);
+      const logs = parseLogsFromString(buffer);
       const logsWithoutExisting = logs.filter(log => !slice.logs.includes(log));
       slice.logs = slice.logs.concat(logsWithoutExisting);
     },

--- a/src-gui/src/utils/parseUtils.ts
+++ b/src-gui/src/utils/parseUtils.ts
@@ -52,7 +52,7 @@ export function getLinesOfString(data: string): string[] {
     .filter((l) => l.length > 0);
 }
 
-export function getLogsAndStringsFromRawFileString(
+export function parseLogsFromString(
   rawFileData: string,
 ): (CliLog | string)[] {
   return getLinesOfString(rawFileData).map(parseCliLogString);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -9,8 +9,8 @@ use swap::cli::{
             CheckElectrumNodeResponse, CheckMoneroNodeArgs, CheckMoneroNodeResponse,
             ExportBitcoinWalletArgs, GetDataDirArgs, GetHistoryArgs, GetLogsArgs,
             GetMoneroAddressesArgs, GetSwapInfoArgs, GetSwapInfosAllArgs, ListSellersArgs,
-            MoneroRecoveryArgs, ResolveApprovalArgs, ResumeSwapArgs, SuspendCurrentSwapArgs,
-            WithdrawBtcArgs,
+            MoneroRecoveryArgs, RedactArgs, ResolveApprovalArgs, ResumeSwapArgs,
+            SuspendCurrentSwapArgs, WithdrawBtcArgs,
         },
         tauri_bindings::{TauriContextStatusEvent, TauriEmitter, TauriHandle, TauriSettings},
         Context, ContextBuilder,
@@ -187,6 +187,7 @@ pub fn run() {
             get_wallet_descriptor,
             get_data_dir,
             resolve_approval_request,
+            redact
         ])
         .setup(setup)
         .build(tauri::generate_context!())
@@ -228,6 +229,7 @@ tauri_command!(get_logs, GetLogsArgs);
 tauri_command!(list_sellers, ListSellersArgs);
 tauri_command!(cancel_and_refund, CancelAndRefundArgs);
 tauri_command!(resolve_approval_request, ResolveApprovalArgs);
+tauri_command!(redact, RedactArgs);
 
 // These commands require no arguments
 tauri_command!(get_wallet_descriptor, ExportBitcoinWalletArgs, no_args);

--- a/swap/src/cli/api/request.rs
+++ b/swap/src/cli/api/request.rs
@@ -3,7 +3,7 @@ use crate::bitcoin::{wallet, CancelTimelock, ExpiredTimelocks, PunishTimelock, T
 use crate::cli::api::tauri_bindings::{TauriEmitter, TauriSwapProgressEvent};
 use crate::cli::api::Context;
 use crate::cli::{list_sellers as list_sellers_impl, EventLoop, Seller, SellerStatus};
-use crate::common::get_logs;
+use crate::common::{get_logs, redact};
 use crate::libp2p_ext::MultiAddrExt;
 use crate::monero::wallet_rpc::MoneroDaemon;
 use crate::network::quote::{BidQuote, ZeroQuoteReceived};
@@ -417,6 +417,29 @@ impl Request for GetLogsArgs {
         }
 
         Ok(GetLogsResponse { logs })
+    }
+}
+
+/// Best effort redaction of logs, e.g. wallet addresses, swap-ids
+#[typeshare]
+#[derive(Serialize, Deserialize, Debug)]
+pub struct RedactArgs {
+    pub text: String,
+}
+
+#[typeshare]
+#[derive(Serialize, Debug)]
+pub struct RedactResponse {
+    pub text: String,
+}
+
+impl Request for RedactArgs {
+    type Response = RedactResponse;
+
+    async fn request(self, _: Arc<Context>) -> Result<Self::Response> {
+        Ok(RedactResponse {
+            text: redact(&self.text),
+        })
     }
 }
 


### PR DESCRIPTION
This PR allows users to edit the logs they can attach to feedabck messages, to check for things they don't want to send or redact them.  Closes #127.

- [X] Implement basic viewer
- [x] Add a redact button

This is how it currently looks:

https://github.com/user-attachments/assets/f40010e3-312f-4e65-889d-e6f33a8bb0f1


