### PR TITLE
Release version 1.0.0-rc.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0-rc.18] - 2025-04-28
+
 - GUI: Feedback submitted can be responded to by the core developers. The responses will be displayed under the "Feedback" tab.
 
 ## [1.0.0-rc.17] - 2025-04-18
@@ -454,7 +456,8 @@ It is possible to migrate critical data from the old db to the sqlite but there 
 - Fixed an issue where Alice would not verify if Bob's Bitcoin lock transaction is semantically correct, i.e. pays the agreed upon amount to an output owned by both of them.
   Fixing this required a **breaking change** on the network layer and hence old versions are not compatible with this version.
 
-[unreleased]: https://github.com/UnstoppableSwap/core/compare/1.0.0-rc.17...HEAD
+[unreleased]: https://github.com/UnstoppableSwap/core/compare/1.0.0-rc.18...HEAD
+[1.0.0-rc.18]: https://github.com/UnstoppableSwap/core/compare/1.0.0-rc.17...1.0.0-rc.18
 [1.0.0-rc.17]: https://github.com/UnstoppableSwap/core/compare/1.0.0-rc.16...1.0.0-rc.17
 [1.0.0-rc.16]: https://github.com/UnstoppableSwap/core/compare/1.0.0-rc.14...1.0.0-rc.16
 [1.0.0-rc.14]: https://github.com/UnstoppableSwap/core/compare/1.0.0-rc.13...1.0.0-rc.14

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9018,7 +9018,7 @@ checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
 
 [[package]]
 name = "swap"
-version = "1.0.0-rc.17"
+version = "1.0.0-rc.18"
 dependencies = [
  "anyhow",
  "arti-client",
@@ -11463,7 +11463,7 @@ dependencies = [
 
 [[package]]
 name = "unstoppableswap-gui-rs"
-version = "1.0.0-rc.17"
+version = "1.0.0-rc.18"
 dependencies = [
  "anyhow",
  "serde",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unstoppableswap-gui-rs"
-version = "1.0.0-rc.17"
+version = "1.0.0-rc.18"
 authors = [ "binarybaron", "einliterflasche", "unstoppableswap" ]
 edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "UnstoppableSwap",
-  "version": "1.0.0-rc.17",
+  "version": "1.0.0-rc.18",
   "identifier": "net.unstoppableswap.gui",
   "build": {
     "devUrl": "http://localhost:1420",

--- a/swap/Cargo.toml
+++ b/swap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swap"
-version = "1.0.0-rc.17"
+version = "1.0.0-rc.18"
 authors = [ "The COMIT guys <hello@comit.network>" ]
 edition = "2021"
 description = "XMR/BTC trustless atomic swaps."


### PR DESCRIPTION
Hi @binarybaron!

This PR was created in response to a manual trigger of the release workflow here: https://github.com/UnstoppableSwap/core/actions/runs/14709382145.
I've updated the changelog and bumped the versions in the manifest files in this commit: 4c342839e038a08964b26ea4657d2ca78f29fd7f.

Merging this PR will create a GitHub release and upload any assets that are created as part of the release build.