### PR TITLE
feat(ci): Limit ci.yml to one concurrent running job per git branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
     branches:
       - "master" # Always build head of master for the badge in the README
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   static_analysis:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The `ci.yml` currently accounts for 99% of our monthly used Github Action minutes. This restricts the `ci.yml` workflow to one concurrent run per git branch.

If you push to a branch and `ci.yml` is still pending from your previous commit, the old run will be cancelled and the new one will be ran.

See: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/control-the-concurrency-of-workflows-and-jobs