### PR TITLE
Fix typos and await aborted tasks

### DIFF
--- a/dev-docs/asb/README.md
+++ b/dev-docs/asb/README.md
@@ -89,7 +89,7 @@ The `ASB` depicted in the diagram actually consists of multiple components (prot
 #### Monero Wallet Setup
 
 The ASB uses the running Monero wallet RPC to create / open Monero wallets.
-Currently you cannot connect to an existing Monero wallet, but the ASB will create the wallet `asb-wallet` upon intial startup.
+Currently you cannot connect to an existing Monero wallet, but the ASB will create the wallet `asb-wallet` upon initial startup.
 In order to accept trades with a CLI you will have to send XMR to that wallet.
 The wallet's address is printed upon startup of the ASB.
 Currently the `asb-wallet` does not have a password.

--- a/docs/pages/usage/first_swap.mdx
+++ b/docs/pages/usage/first_swap.mdx
@@ -43,7 +43,7 @@ Once you've selected a _maker_, you can start the swap by clicking the `Swap` bu
 This will open a new window where you need to enter two addresses:
 
 1. the Monero address you want to receive the Monero to
-2. the Bitcoin address where you want to receive the Bitcoin refund incase the swap is not completed successfully. 
+2. the Bitcoin address where you want to receive the Bitcoin refund in case the swap is not completed successfully.
 
 ![image](/first_swap_2.png)
 

--- a/swap/src/asb/event_loop.rs
+++ b/swap/src/asb/event_loop.rs
@@ -1,7 +1,7 @@
 use crate::asb::{Behaviour, OutEvent, Rate};
 use crate::monero::Amount;
 use crate::network::cooperative_xmr_redeem_after_punish::CooperativeXmrRedeemRejectReason;
-use crate::network::cooperative_xmr_redeem_after_punish::Response::{Fullfilled, Rejected};
+use crate::network::cooperative_xmr_redeem_after_punish::Response::{Fulfilled, Rejected};
 use crate::network::quote::BidQuote;
 use crate::network::swap_setup::alice::WalletSnapshot;
 use crate::network::transfer_proof;
@@ -392,12 +392,12 @@ where
                                 continue;
                             };
 
-                            if self.swarm.behaviour_mut().cooperative_xmr_redeem.send_response(channel, Fullfilled { swap_id, s_a: state3.s_a }).is_err() {
+                            if self.swarm.behaviour_mut().cooperative_xmr_redeem.send_response(channel, Fulfilled { swap_id, s_a: state3.s_a }).is_err() {
                                 tracing::error!(peer = %peer, "Failed to respond to cooperative XMR redeem request");
                                 continue;
                             }
 
-                            tracing::info!(swap_id = %swap_id, peer = %peer, "Fullfilled cooperative XMR redeem request");
+                            tracing::info!(swap_id = %swap_id, peer = %peer, "Fulfilled cooperative XMR redeem request");
                         }
                         SwarmEvent::Behaviour(OutEvent::Rendezvous(libp2p::rendezvous::client::Event::Registered { rendezvous_node, ttl, namespace })) => {
                             tracing::trace!("Successfully registered with rendezvous node: {} with namespace: {} and TTL: {:?}", rendezvous_node, namespace, ttl);

--- a/swap/src/cli/event_loop.rs
+++ b/swap/src/cli/event_loop.rs
@@ -227,7 +227,7 @@ impl EventLoop {
                         }
                         SwarmEvent::Behaviour(OutEvent::CooperativeXmrRedeemFulfilled { id, swap_id, s_a }) => {
                             if let Some(responder) = self.inflight_cooperative_xmr_redeem_requests.remove(&id) {
-                                let _ = responder.respond(Ok(Response::Fullfilled { s_a, swap_id }));
+                                let _ = responder.respond(Ok(Response::Fulfilled { s_a, swap_id }));
                             }
                         }
                         SwarmEvent::Behaviour(OutEvent::CooperativeXmrRedeemRejected { id, swap_id, reason }) => {
@@ -384,8 +384,8 @@ pub struct EventLoopHandle {
 
     /// When a () is sent into this channel, the EventLoop will:
     /// 1. Request Alice's cooperation in redeeming the Monero
-    /// 2. Return the a response object (Fullfilled or Rejected), if the network request is successful
-    ///    The Fullfilled object contains the keys required to redeem the Monero
+    /// 2. Return the a response object (Fulfilled or Rejected), if the network request is successful
+    ///    The Fulfilled object contains the keys required to redeem the Monero
     /// 3. Return an OutboundFailure error if the network request fails
     cooperative_xmr_redeem_sender: bmrng::RequestSender<
         (),

--- a/swap/src/network/cooperative_xmr_redeem_after_punish.rs
+++ b/swap/src/network/cooperative_xmr_redeem_after_punish.rs
@@ -38,7 +38,7 @@ pub struct Request {
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum Response {
-    Fullfilled {
+    Fulfilled {
         swap_id: Uuid,
         s_a: Scalar,
     },
@@ -93,7 +93,7 @@ impl From<(PeerId, Message)> for cli::OutEvent {
                 response,
                 request_id,
             } => match response {
-                Response::Fullfilled { swap_id, s_a } => Self::CooperativeXmrRedeemFulfilled {
+                Response::Fulfilled { swap_id, s_a } => Self::CooperativeXmrRedeemFulfilled {
                     id: request_id,
                     swap_id,
                     s_a,

--- a/swap/src/protocol/bob/swap.rs
+++ b/swap/src/protocol/bob/swap.rs
@@ -5,7 +5,7 @@ use crate::cli::api::tauri_bindings::{
     LockBitcoinDetails, TauriEmitter, TauriHandle, TauriSwapProgressEvent,
 };
 use crate::cli::EventLoopHandle;
-use crate::network::cooperative_xmr_redeem_after_punish::Response::{Fullfilled, Rejected};
+use crate::network::cooperative_xmr_redeem_after_punish::Response::{Fulfilled, Rejected};
 use crate::network::swap_setup::bob::NewSwap;
 use crate::protocol::bob::state::*;
 use crate::protocol::{bob, Database};
@@ -532,7 +532,7 @@ async fn next_state(
             let response = event_loop_handle.request_cooperative_xmr_redeem().await;
 
             match response {
-                Ok(Fullfilled { s_a, .. }) => {
+                Ok(Fulfilled { s_a, .. }) => {
                     tracing::info!(
                         "Alice has accepted our request to cooperatively redeem the XMR"
                     );

--- a/swap/tests/alice_and_bob_refund_using_cancel_and_refund_command.rs
+++ b/swap/tests/alice_and_bob_refund_using_cancel_and_refund_command.rs
@@ -49,7 +49,7 @@ async fn given_alice_and_bob_manually_refund_after_funds_locked_both_refund() {
         }
 
         // Bob manually cancels
-        bob_join_handle.abort();
+        bob_join_handle.abort_and_wait().await;
         let (_, state) = cli::cancel(bob_swap.id, bob_swap.bitcoin_wallet, bob_swap.db).await?;
         assert!(matches!(state, BobState::BtcCancelled { .. }));
 
@@ -59,7 +59,7 @@ async fn given_alice_and_bob_manually_refund_after_funds_locked_both_refund() {
         assert!(matches!(bob_swap.state, BobState::BtcCancelled { .. }));
 
         // Bob manually refunds
-        bob_join_handle.abort();
+        bob_join_handle.abort_and_wait().await;
         let bob_state = cli::refund(bob_swap.id, bob_swap.bitcoin_wallet, bob_swap.db).await?;
 
         ctx.assert_bob_refunded(bob_state).await;

--- a/swap/tests/alice_and_bob_refund_using_cancel_then_refund_command.rs
+++ b/swap/tests/alice_and_bob_refund_using_cancel_then_refund_command.rs
@@ -49,7 +49,7 @@ async fn given_alice_and_bob_manually_cancel_and_refund_after_funds_locked_both_
         }
 
         // Bob manually cancels and refunds
-        bob_join_handle.abort();
+        bob_join_handle.abort_and_wait().await;
         let bob_state =
             cli::cancel_and_refund(bob_swap.id, bob_swap.bitcoin_wallet, bob_swap.db).await?;
 

--- a/swap/tests/alice_manually_punishes_after_bob_dead_and_bob_cancels.rs
+++ b/swap/tests/alice_manually_punishes_after_bob_dead_and_bob_cancels.rs
@@ -74,7 +74,7 @@ async fn alice_manually_punishes_after_bob_dead_and_bob_cancels() {
             .stop_and_resume_bob_from_db(bob_join_handle, bob_swap_id)
             .await;
         assert!(matches!(bob_swap.state, BobState::BtcLocked { .. }));
-        bob_join_handle.abort();
+        bob_join_handle.abort_and_wait().await;
 
         let (_, state) = cli::cancel(bob_swap_id, bob_swap.bitcoin_wallet, bob_swap.db).await?;
         // Bob should be in BtcCancelled state now.

--- a/swap/tests/concurrent_bobs_after_xmr_lock_proof_sent.rs
+++ b/swap/tests/concurrent_bobs_after_xmr_lock_proof_sent.rs
@@ -23,7 +23,7 @@ async fn concurrent_bobs_after_xmr_lock_proof_sent() {
         assert!(matches!(bob_state_1, BobState::XmrLocked { .. }));
 
         // make sure bob_swap_1's event loop is gone
-        bob_join_handle_1.abort();
+        bob_join_handle_1.abort_and_wait().await;
 
         let (bob_swap_2, bob_join_handle_2) = ctx.bob_swap().await;
         let bob_swap_2 = tokio::spawn(bob::run(bob_swap_2));

--- a/swap/tests/concurrent_bobs_before_xmr_lock_proof_sent.rs
+++ b/swap/tests/concurrent_bobs_before_xmr_lock_proof_sent.rs
@@ -23,7 +23,7 @@ async fn concurrent_bobs_before_xmr_lock_proof_sent() {
         assert!(matches!(bob_state_1, BobState::BtcLocked { .. }));
 
         // make sure bob_swap_1's event loop is gone
-        bob_join_handle_1.abort();
+        bob_join_handle_1.abort_and_wait().await;
 
         let (bob_swap_2, bob_join_handle_2) = ctx.bob_swap().await;
         let bob_swap_2 = tokio::spawn(bob::run(bob_swap_2));
@@ -45,7 +45,7 @@ async fn concurrent_bobs_before_xmr_lock_proof_sent() {
             .await;
         assert!(matches!(bob_state_1, BobState::BtcLocked { .. }));
 
-        // The 1st (paused) swap is expected to finish successfully because the transfer proof is buffered when it is receives while another swap is running.
+        // The 1st (paused) swap is expected to finish successfully because the transfer proof is buffered when it is received while another swap is running.
 
         let bob_state_1 = bob::run(bob_swap_1).await?;
         assert!(matches!(bob_state_1, BobState::XmrRedeemed { .. }));

--- a/swap/tests/harness/mod.rs
+++ b/swap/tests/harness/mod.rs
@@ -517,6 +517,11 @@ impl BobApplicationHandle {
     pub fn abort(&self) {
         self.0.abort()
     }
+
+    pub async fn abort_and_wait(self) {
+        self.0.abort();
+        let _ = self.0.await;
+    }
 }
 
 pub struct AliceApplicationHandle {
@@ -527,6 +532,11 @@ pub struct AliceApplicationHandle {
 impl AliceApplicationHandle {
     pub fn abort(&self) {
         self.handle.abort()
+    }
+
+    pub async fn abort_and_wait(self) {
+        self.handle.abort();
+        let _ = self.handle.await;
     }
 }
 
@@ -565,7 +575,7 @@ impl TestContext {
     }
 
     pub async fn restart_alice(&mut self) {
-        self.alice_handle.abort();
+        self.alice_handle.abort_and_wait().await;
 
         let (alice_handle, alice_swap_handle) = start_alice(
             &self.alice_seed,
@@ -604,7 +614,7 @@ impl TestContext {
         join_handle: BobApplicationHandle,
         swap_id: Uuid,
     ) -> (bob::Swap, BobApplicationHandle) {
-        join_handle.abort();
+        join_handle.abort_and_wait().await;
 
         let (swap, event_loop) = self.bob_params.new_swap_from_db(swap_id).await.unwrap();
 


### PR DESCRIPTION
## Summary
- fix typos in ASB README and first swap docs
- rename `Fullfilled` variant to `Fulfilled`
- correct grammar in test comment
- add `abort_and_wait` to test harness handles
- update tests to use new abort method

## Testing
- `RUSTUP_TOOLCHAIN=stable cargo test --workspace -- --test-threads=1` *(fails: failed to load source for dependency `bdk_chain`)*