### PR TITLE
Add context logging for CLI and ASB

### DIFF
--- a/swap/src/bin/asb.rs
+++ b/swap/src/bin/asb.rs
@@ -86,6 +86,13 @@ pub async fn main() -> Result<()> {
     let log_dir = config.data.dir.join("logs");
     common::tracing_util::init(LevelFilter::DEBUG, format, log_dir, None)
         .expect("initialize tracing");
+    tracing::info!(
+        binary = "asb",
+        version = env!("VERGEN_GIT_DESCRIBE"),
+        os = std::env::consts::OS,
+        arch = std::env::consts::ARCH,
+        "Setting up context"
+    );
 
     // Check for conflicting env / config values
     if config.monero.network != env_config.monero_network {

--- a/swap/src/cli/api.rs
+++ b/swap/src/cli/api.rs
@@ -300,6 +300,13 @@ impl ContextBuilder {
                 data_dir.join("logs"),
                 self.tauri_handle.clone(),
             );
+            tracing::info!(
+                binary = "cli",
+                version = env!("VERGEN_GIT_DESCRIBE"),
+                os = std::env::consts::OS,
+                arch = std::env::consts::ARCH,
+                "Setting up context"
+            );
         });
 
         // Create the data structure we use to manage the swap lock


### PR DESCRIPTION
## Summary
- log environment information during CLI context setup
- log environment information during ASB setup

## Testing
- `npx dprint fmt` *(fails: EHOSTUNREACH)*
- `cargo clippy --workspace --all-targets -- -D warnings` *(fails: could not download Rust toolchain)*