### PR TITLE
fix(swap): Add retry logic for Bitcoin wallet sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- CLI + GUI: Retry the Bitcoin wallet sync up to three times to
-  avoid transient database lock errors.
+- CLI + GUI + ASB: Retry the Bitcoin wallet sync up to 15 seconds to work around transient errors.
 
 ## [1.1.0] - 2025-05-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- CLI + GUI: Retry the Bitcoin wallet sync up to three times to
+  avoid transient database lock errors.
+
 ## [1.1.0] - 2025-05-19
 
 - GUI: Discourage swapping with makers running `< 1.1.0-rc.3` because the bdk upgrade introduced a breaking change.

--- a/swap/src/bitcoin/wallet.rs
+++ b/swap/src/bitcoin/wallet.rs
@@ -929,6 +929,9 @@ impl Wallet {
 
     /// Sync the wallet with the blockchain and emit progress events to the UI.
     /// This will retry a couple of times to mitigate transient errors.
+    /// TOOD: Find the underlying issue for these transient errors:
+    /// - Made or multiple attempts, all failed... (unexpected EOF in rustls)
+    /// - Made or multiple attempts, all failed... (os error 32)
     pub async fn sync(&self) -> Result<()> {
         const MAX_ATTEMPTS: usize = 5;
 

--- a/swap/src/bitcoin/wallet.rs
+++ b/swap/src/bitcoin/wallet.rs
@@ -908,7 +908,12 @@ impl Wallet {
                 Ok(()) => return Ok(()),
                 Err(error) => {
                     let attempts_left = max_attempts - attempt;
-                    tracing::warn!(attempt, ?error, attempts_left, "Failed to sync Bitcoin wallet");
+                    tracing::warn!(
+                        attempt,
+                        ?error,
+                        attempts_left,
+                        "Failed to sync Bitcoin wallet"
+                    );
 
                     if attempts_left == 0 {
                         return Err(error);

--- a/swap/src/bitcoin/wallet.rs
+++ b/swap/src/bitcoin/wallet.rs
@@ -930,7 +930,7 @@ impl Wallet {
     /// Sync the wallet with the blockchain and emit progress events to the UI.
     /// This will retry a couple of times to mitigate transient errors.
     pub async fn sync(&self) -> Result<()> {
-        const MAX_ATTEMPTS: usize = 3;
+        const MAX_ATTEMPTS: usize = 5;
 
         self.sync_with_retry(MAX_ATTEMPTS).await
     }


### PR DESCRIPTION
## Summary
- prevent transient failures by adding retry logic to Bitcoin wallet sync
- note new behaviour in changelog

## Testing
- `dprint check` *(fails: command not found)*
- `cargo clippy --workspace --locked --all-targets --all-features -- -D warnings` *(fails: could not download file due to network restrictions)*