### PR TITLE
Update docs for external bitcoin address

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -7,7 +7,7 @@ This repository hosts the core of the UnstoppableSwap project. The code base is 
 - **swap/** – contains the main Rust crate with two binaries:
   - `swap` – command line interface for performing swaps.
   - `asb` – Automated Swap Backend for market makers.
-  It also hosts library code shared between the binaries and integration tests.
+    It also hosts library code shared between the binaries and integration tests.
 - **src-tauri/** – Rust crate that exposes the `swap` functionality to the Tauri front end and bundles the application.
 - **src-gui/** – The front‑end written in TypeScript/React and bundled by Tauri. Communicates with `src-tauri` via Tauri commands.
 - **monero-rpc/** and **monero-wallet/** – helper crates for interacting with the Monero ecosystem.
@@ -18,14 +18,14 @@ This repository hosts the core of the UnstoppableSwap project. The code base is 
 
 Looking at the latest ten pull requests in `git log`, the following files appear most often:
 
-| File | Times Changed |
-| ---- | ------------- |
-| `src-tauri/Cargo.toml` | 7 |
-| `Cargo.lock` | 7 |
-| `CHANGELOG.md` | 7 |
-| `swap/Cargo.toml` | 6 |
-| `src-tauri/tauri.conf.json` | 5 |
-| `.github/workflows/ci.yml` | 3 |
+| File                        | Times Changed |
+| --------------------------- | ------------- |
+| `src-tauri/Cargo.toml`      | 7             |
+| `Cargo.lock`                | 7             |
+| `CHANGELOG.md`              | 7             |
+| `swap/Cargo.toml`           | 6             |
+| `src-tauri/tauri.conf.json` | 5             |
+| `.github/workflows/ci.yml`  | 3             |
 
 Other files such as `swap/src/bin/asb.rs`, `swap/src/cli/api.rs`, and `src-gui/package.json` showed up less frequently.
 
@@ -36,4 +36,3 @@ Other files such as `swap/src/bin/asb.rs`, `swap/src/cli/api.rs`, and `src-gui/p
 - **src-gui** is the TypeScript/React interface. It communicates with the Rust back end through the commands defined in `src-tauri`.
 - Helper crates like **monero-rpc** and **monero-wallet** provide abstractions over external services. They are used by the swap crate to interact with Monero.
 - Continuous integration and release workflows live in `.github/workflows`. They build binaries, create releases and lint the code base.
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Docs: Document `external_bitcoin_address` option for using a specific
+  Bitcoin address when redeeming or punishing swaps.
 
 ## [1.1.1] - 2025-05-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
 - Docs: Document `external_bitcoin_address` option for using a specific
   Bitcoin address when redeeming or punishing swaps.
 

--- a/dev-docs/asb/README.md
+++ b/dev-docs/asb/README.md
@@ -112,9 +112,13 @@ min_buy_btc = 0.0001
 max_buy_btc = 0.0001
 ask_spread = 0.02
 price_ticker_ws_url = "wss://ws.kraken.com"
+external_bitcoin_address = "bc1..."
 ```
 
 The minimum and maximum amount as well as a spread, that is added on top of the price fetched from a central exchange, can be configured.
+
+`external_bitcoin_address` allows to specify the Bitcoin address that the ASB will use to redeem or punish swaps.
+If the option is not set, a new address from the internal wallet is used for every swap.
 
 In order to be able to trade, the ASB must define a price to be able to agree on the amounts to be swapped with a CLI.
 The `XMR<>BTC` price is currently determined by the price from the central exchange Kraken.

--- a/docs/pages/becoming_a_maker/overview.mdx
+++ b/docs/pages/becoming_a_maker/overview.mdx
@@ -118,6 +118,7 @@ min_buy_btc = 0.001
 max_buy_btc = 0.1
 ask_spread = 0.02
 price_ticker_ws_url = "wss://ws.kraken.com/"
+external_bitcoin_address = "bc1..."
 
 # ...
 ```
@@ -130,6 +131,7 @@ Below an explanation of what each option does:
 | `max_buy_btc` | The maximum amount of Bitcoin the asb will buy from takers, in BTC. |
 | `ask_spread` | The markup the asb will charge compared to the market price, as a factor. The market price is fetched via the `price_ticker_ws_url`. A value of `0.02` means the asb will charge 2% more than the market price. |
 | `price_ticker_ws_url` | The URL of a websocket that provides the market price. The default is the Kraken API, but you can build your own websocket server which mimics the Kraken API. |
+| `external_bitcoin_address` | Bitcoin address used by the asb when redeeming or punishing swaps. If omitted, a new internal address is generated for each swap. |
 
 ### Bitcoin Section
 
@@ -247,6 +249,7 @@ min_buy_btc = 0.001
 max_buy_btc = 0.1
 ask_spread = 0.02
 price_ticker_ws_url = "wss://ws.kraken.com/"
+external_bitcoin_address = "bc1..."
 
 [bitcoin]
 electrum_rpc_url = "tcp://mainnet_electrs:50001"


### PR DESCRIPTION
## Summary
- document the `external_bitcoin_address` option in maker configuration in docs
- fix changelog entry wording

## Testing
- `dprint check` *(fails: command not found)*
- `cargo clippy --workspace --tests --all-features -- -D warnings` *(fails: could not download Rust toolchain)*