### PR TITLE
feat(protocol): Add refund hash condition to TxLock script

### DIFF
--- a/swap/src/bitcoin/cancel.rs
+++ b/swap/src/bitcoin/cancel.rs
@@ -2,6 +2,7 @@ use crate::bitcoin;
 use crate::bitcoin::wallet::Watchable;
 use crate::bitcoin::{
     build_shared_output_descriptor, Address, Amount, BlockHeight, PublicKey, Transaction, TxLock,
+    DEFAULT_REFUND_HASH,
 };
 use ::bitcoin::sighash::SighashCache;
 use ::bitcoin::transaction::Version;
@@ -123,7 +124,8 @@ impl TxCancel {
         B: PublicKey,
         spending_fee: Amount,
     ) -> Result<Self> {
-        let cancel_output_descriptor = build_shared_output_descriptor(A.0, B.0)?;
+        let cancel_output_descriptor =
+            build_shared_output_descriptor(A.0, B.0, DEFAULT_REFUND_HASH)?;
 
         let tx_in = TxIn {
             previous_output: tx_lock.as_outpoint(),


### PR DESCRIPTION
## Summary
- allow specifying a preimage hash for shared output script
- use `DEFAULT_REFUND_HASH` for lock and cancel transactions
- update script size constant (approximate)

## Testing
- `cargo test --workspace --all-targets` *(fails: could not download rust toolchain)*