### PR TITLE
feat(asb): Allow maker redeem descriptor

### DIFF
--- a/swap/src/asb/config.rs
+++ b/swap/src/asb/config.rs
@@ -212,8 +212,9 @@ pub struct Maker {
     pub max_buy_btc: bitcoin::Amount,
     pub ask_spread: Decimal,
     pub price_ticker_ws_url: Url,
-    #[serde(default, with = "crate::bitcoin::address_serde::option")]
-    pub external_bitcoin_redeem_address: Option<bitcoin::Address>,
+    #[serde(default, with = "crate::bitcoin::descriptor_serde::option")]
+    pub external_bitcoin_redeem_address:
+        Option<bdk_wallet::miniscript::Descriptor<bitcoin::PublicKey>>,
 }
 
 impl Default for TorConf {

--- a/swap/src/asb/event_loop.rs
+++ b/swap/src/asb/event_loop.rs
@@ -50,7 +50,7 @@ where
     latest_rate: LR,
     min_buy: bitcoin::Amount,
     max_buy: bitcoin::Amount,
-    external_redeem_address: Option<bitcoin::Address>,
+    external_redeem_address: Option<bdk_wallet::miniscript::Descriptor<bitcoin::PublicKey>>,
 
     /// Cache for quotes
     quote_cache: Cache<QuoteCacheKey, Result<Arc<BidQuote>, Arc<anyhow::Error>>>,
@@ -137,7 +137,7 @@ where
         latest_rate: LR,
         min_buy: bitcoin::Amount,
         max_buy: bitcoin::Amount,
-        external_redeem_address: Option<bitcoin::Address>,
+        external_redeem_address: Option<bdk_wallet::miniscript::Descriptor<bitcoin::PublicKey>>,
     ) -> Result<(Self, mpsc::Receiver<Swap>)> {
         let swap_channel = MpscChannels::default();
         let (outgoing_transfer_proofs_sender, outgoing_transfer_proofs_requests) =

--- a/swap/src/network/swap_setup/alice.rs
+++ b/swap/src/network/swap_setup/alice.rs
@@ -57,16 +57,22 @@ impl WalletSnapshot {
     pub async fn capture(
         bitcoin_wallet: &bitcoin::Wallet,
         monero_wallet: &monero::Wallet,
-        external_redeem_address: &Option<bitcoin::Address>,
+        external_redeem_address: &Option<bdk_wallet::miniscript::Descriptor<bitcoin::PublicKey>>,
         transfer_amount: bitcoin::Amount,
     ) -> Result<Self> {
         let balance = monero_wallet.get_balance().await?;
-        let redeem_address = external_redeem_address
-            .clone()
-            .unwrap_or(bitcoin_wallet.new_address().await?);
-        let punish_address = external_redeem_address
-            .clone()
-            .unwrap_or(bitcoin_wallet.new_address().await?);
+        let redeem_address = match external_redeem_address {
+            Some(descriptor) => descriptor
+                .address(bitcoin_wallet.network())
+                .expect("address from descriptor"),
+            None => bitcoin_wallet.new_address().await?,
+        };
+        let punish_address = match external_redeem_address {
+            Some(descriptor) => descriptor
+                .address(bitcoin_wallet.network())
+                .expect("address from descriptor"),
+            None => bitcoin_wallet.new_address().await?,
+        };
 
         let redeem_fee = bitcoin_wallet
             .estimate_fee(bitcoin::TxRedeem::weight(), transfer_amount)


### PR DESCRIPTION
## Summary
- allow `external_bitcoin_redeem_address` to accept a miniscript descriptor
- pass descriptor into the event loop
- derive redeem and punish addresses from the descriptor
- add serde helpers for descriptors
