### PR TITLE
Add manual redeem scanning

### DIFF
--- a/dev-docs/README.md
+++ b/dev-docs/README.md
@@ -4,3 +4,4 @@ This directory hosts various pieces of documentation.
 
 - [`swap` CLI](./cli/README.md)
 - [`asb` service](./asb/README.md)
+- [Manual Monero Redeem](./monero_manual_redeem.md)

--- a/dev-docs/monero_manual_redeem.md
+++ b/dev-docs/monero_manual_redeem.md
@@ -1,0 +1,11 @@
+# Manual Monero Redeem (Bob)
+
+This short guide covers how to recover the Monero funds for a swap wallet without scanning the entire chain.
+It applies when the GUI acts as **Bob** and you need to redeem the locked Monero.
+
+1. Query the current restore height from your connected `monero-wallet-rpc` using `get_height`.
+2. When opening the swap wallet, set this value as the restore height.
+3. Call `scanTransactions` with the `xmr_lock` transaction id to manually add the lock transaction to the wallet.
+   This avoids rescanning from the genesis block.
+
+After scanning the single transaction the wallet can sweep the funds normally.

--- a/monero-sys/src/bridge.h
+++ b/monero-sys/src/bridge.h
@@ -148,6 +148,12 @@ namespace Monero
     {
         return std::make_unique<std::vector<std::string>>(tx.txid());
     }
+
+    inline void scanTransaction(Wallet &wallet, const std::string &txid)
+    {
+        std::vector<std::string> txs{txid};
+        wallet.scanTransactions(txs);
+    }
 }
 
 #include "easylogging++.h"

--- a/monero-sys/src/bridge.rs
+++ b/monero-sys/src/bridge.rs
@@ -231,6 +231,9 @@ pub mod ffi {
             overwrite: bool,
         ) -> bool;
 
+        /// Scan a single transaction by id.
+        fn scanTransaction(self: Pin<&mut Wallet>, txid: &CxxString);
+    
         /// Dispose of a pending transaction object.
         unsafe fn disposeTransaction(self: Pin<&mut Wallet>, tx: *mut PendingTransaction);
     }

--- a/swap/src/monero/wallet.rs
+++ b/swap/src/monero/wallet.rs
@@ -162,6 +162,57 @@ impl Wallets {
         Ok(wallet)
     }
 
+    /// Open the swap wallet and manually scan the provided transactions.
+    pub async fn swap_wallet_manual(
+        &self,
+        swap_id: Uuid,
+        spend_key: monero::PrivateKey,
+        view_key: super::PrivateViewKey,
+        txids: Vec<super::TxHash>,
+    ) -> Result<Arc<Wallet>> {
+        let filename = swap_id.to_string();
+        let wallet_path = self.wallet_dir.join(&filename).display().to_string();
+
+        if let Some(wallet) = self.wallets.lock().await.get(&filename) {
+            if let Some(wallet) = wallet.upgrade() {
+                return Ok(wallet);
+            }
+        }
+
+        let address = {
+            let public_spend_key = monero::PublicKey::from_private_key(&spend_key);
+            let public_view_key = monero::PublicKey::from_private_key(&view_key.into());
+            monero::Address::standard(self.network, public_spend_key, public_view_key)
+        };
+
+        let txid_strings: Vec<String> = txids.into_iter().map(|h| h.0).collect();
+
+        let wallet = Wallet::open_or_create_from_keys_with_txids(
+            wallet_path.clone(),
+            None,
+            self.network,
+            address,
+            view_key.into(),
+            spend_key,
+            txid_strings,
+            self.daemon.clone(),
+        )
+        .await
+        .context(format!("Failed to open or create wallet `{}`", wallet_path))?;
+
+        if self.regtest {
+            wallet.unsafe_prepare_for_regtest().await;
+        }
+
+        let wallet = Arc::new(wallet);
+        self.wallets
+            .lock()
+            .await
+            .insert(filename, Arc::downgrade(&wallet));
+
+        Ok(wallet)
+    }
+
     /// Get the main wallet (specified when initializing the `Wallets` instance).
     pub async fn main_wallet(&self) -> Arc<Wallet> {
         self.main_wallet.clone()

--- a/swap/src/protocol/bob/state.rs
+++ b/swap/src/protocol/bob/state.rs
@@ -329,6 +329,7 @@ pub struct State2 {
     #[serde(with = "address_serde")]
     punish_address: bitcoin::Address,
     pub tx_lock: bitcoin::TxLock,
+    lock_transfer_proof: TransferProof,
     tx_cancel_sig_a: Signature,
     tx_refund_encsig: bitcoin::EncryptedSignature,
     min_monero_confirmations: u64,
@@ -436,7 +437,11 @@ impl State3 {
         }
     }
 
-    pub fn xmr_locked(self, monero_wallet_restore_blockheight: BlockHeight) -> State4 {
+    pub fn xmr_locked(
+        self,
+        monero_wallet_restore_blockheight: BlockHeight,
+        lock_transfer_proof: TransferProof,
+    ) -> State4 {
         State4 {
             A: self.A,
             b: self.b,
@@ -448,6 +453,7 @@ impl State3 {
             refund_address: self.refund_address,
             redeem_address: self.redeem_address,
             tx_lock: self.tx_lock,
+            lock_transfer_proof,
             tx_cancel_sig_a: self.tx_cancel_sig_a,
             tx_refund_encsig: self.tx_refund_encsig,
             monero_wallet_restore_blockheight,
@@ -457,7 +463,11 @@ impl State3 {
         }
     }
 
-    pub fn cancel(&self, monero_wallet_restore_blockheight: BlockHeight) -> State6 {
+    pub fn cancel(
+        &self,
+        monero_wallet_restore_blockheight: BlockHeight,
+        lock_transfer_proof: Option<TransferProof>,
+    ) -> State6 {
         State6 {
             A: self.A,
             b: self.b.clone(),
@@ -472,6 +482,7 @@ impl State3 {
             tx_refund_encsig: self.tx_refund_encsig.clone(),
             tx_refund_fee: self.tx_refund_fee,
             tx_cancel_fee: self.tx_cancel_fee,
+            lock_transfer_proof,
         }
     }
 
@@ -559,6 +570,7 @@ impl State4 {
             s_b: self.s_b,
             v: self.v,
             tx_lock: self.tx_lock.clone(),
+            lock_transfer_proof: self.lock_transfer_proof.clone(),
             monero_wallet_restore_blockheight: self.monero_wallet_restore_blockheight,
         })
     }
@@ -592,6 +604,7 @@ impl State4 {
             s_b: self.s_b,
             v: self.v,
             tx_lock: self.tx_lock.clone(),
+            lock_transfer_proof: self.lock_transfer_proof.clone(),
             monero_wallet_restore_blockheight: self.monero_wallet_restore_blockheight,
         })
     }
@@ -634,6 +647,7 @@ impl State4 {
             tx_refund_encsig: self.tx_refund_encsig,
             tx_refund_fee: self.tx_refund_fee,
             tx_cancel_fee: self.tx_cancel_fee,
+            lock_transfer_proof: Some(self.lock_transfer_proof),
         }
     }
 }
@@ -645,6 +659,7 @@ pub struct State5 {
     s_b: monero::Scalar,
     v: monero::PrivateViewKey,
     tx_lock: bitcoin::TxLock,
+    lock_transfer_proof: TransferProof,
     pub monero_wallet_restore_blockheight: BlockHeight,
 }
 
@@ -671,11 +686,11 @@ impl State5 {
         tracing::info!(%swap_id, "Generating and opening Monero wallet from the extracted keys to redeem the Monero");
 
         let wallet = monero_wallet
-            .swap_wallet(
+            .swap_wallet_manual(
                 swap_id,
                 spend_key,
                 view_key,
-                self.monero_wallet_restore_blockheight,
+                vec![self.lock_transfer_proof.tx_hash()],
             )
             .await
             .context("Failed to open Monero wallet")?;
@@ -710,6 +725,7 @@ pub struct State6 {
     pub tx_refund_fee: bitcoin::Amount,
     #[serde(with = "::bitcoin::amount::serde::as_sat")]
     pub tx_cancel_fee: bitcoin::Amount,
+    lock_transfer_proof: Option<TransferProof>,
 }
 
 impl State6 {
@@ -806,6 +822,10 @@ impl State6 {
             v: self.v,
             tx_lock: self.tx_lock.clone(),
             monero_wallet_restore_blockheight: self.monero_wallet_restore_blockheight,
+            lock_transfer_proof: self
+                .lock_transfer_proof
+                .clone()
+                .expect("missing transfer proof"),
         }
     }
 }


### PR DESCRIPTION
## Summary
- propagate Monero lock transfer proof across Bob states
- expose `scanTransaction` FFI and helpers on `WalletHandle`
- implement `open_or_create_from_keys_with_txids`
- allow manual swap wallet creation that scans txids
- use manual wallet flow in Bob redeem logic

## Testing
- `cargo test` *(fails: no network)*