### PR TITLE
Release version 1.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.2] - 2025-05-24
+
 - Docs: Document `external_bitcoin_address` option for using a specific
   Bitcoin address when redeeming or punishing swaps.
 - Removed the JSON-RPC daemon and the `start-daemon` CLI command.
@@ -484,7 +486,8 @@ It is possible to migrate critical data from the old db to the sqlite but there 
 - Fixed an issue where Alice would not verify if Bob's Bitcoin lock transaction is semantically correct, i.e. pays the agreed upon amount to an output owned by both of them.
   Fixing this required a **breaking change** on the network layer and hence old versions are not compatible with this version.
 
-[unreleased]: https://github.com/UnstoppableSwap/core/compare/1.1.1...HEAD
+[unreleased]: https://github.com/UnstoppableSwap/core/compare/1.1.2...HEAD
+[1.1.2]: https://github.com/UnstoppableSwap/core/compare/1.1.1...1.1.2
 [1.1.1]: https://github.com/UnstoppableSwap/core/compare/1.1.0...1.1.1
 [1.1.0]: https://github.com/UnstoppableSwap/core/compare/1.1.0-rc.3...1.1.0
 [1.1.0-rc.3]: https://github.com/UnstoppableSwap/core/compare/1.1.0-rc.2...1.1.0-rc.3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9131,7 +9131,7 @@ checksum = "734676eb262c623cec13c3155096e08d1f8f29adce39ba17948b18dad1e54142"
 
 [[package]]
 name = "swap"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "anyhow",
  "arti-client",
@@ -11584,7 +11584,7 @@ dependencies = [
 
 [[package]]
 name = "unstoppableswap-gui-rs"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "anyhow",
  "rustls 0.23.27",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "unstoppableswap-gui-rs"
-version = "1.1.1"
+version = "1.1.2"
 authors = [ "binarybaron", "einliterflasche", "unstoppableswap" ]
 edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "UnstoppableSwap",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "identifier": "net.unstoppableswap.gui",
   "build": {
     "devUrl": "http://localhost:1420",

--- a/swap/Cargo.toml
+++ b/swap/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "swap"
-version = "1.1.1"
+version = "1.1.2"
 authors = [ "The COMIT guys <hello@comit.network>" ]
 edition = "2021"
 description = "XMR/BTC trustless atomic swaps."


### PR DESCRIPTION
Hi @binarybaron!

This PR was created in response to a manual trigger of the release workflow here: https://github.com/UnstoppableSwap/core/actions/runs/15229195065.
I've updated the changelog and bumped the versions in the manifest files in this commit: 1808644cc7de74627a58c81783f77bc03ae87315.

Merging this PR will create a GitHub release and upload any assets that are created as part of the release build.