### PR TITLE
docs(dev): switch test instructions to nextest

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,12 +9,14 @@ There are a couple of things we are going to look out for in PRs and knowing the
 1. We have CI checks in place that validate formatting and code style.
    Make sure `dprint check` and `cargo clippy` both finish without any warnings or errors.
    If you don't already have it installed, you can obtain in [various ways](https://dprint.dev/install/).
-2. All text document (`CHANGELOG.md`, `README.md`, etc) should follow the [semantic linebreaks](https://sembr.org/) specification.
-3. We strive for atomic commits with good commit messages.
+2. Run the test suite with [cargo-nextest](https://nexte.st/docs/running/).
+   Install it using `cargo install cargo-nextest` and execute `cargo nextest run`.
+3. All text document (`CHANGELOG.md`, `README.md`, etc) should follow the [semantic linebreaks](https://sembr.org/) specification.
+4. We strive for atomic commits with good commit messages.
    As an inspiration, read [this](https://chris.beams.io/posts/git-commit/) blogpost.
    An atomic commit is a cohesive diff with formatting checks, linter and build passing.
    Ideally, all tests are passing as well but we acknowledge that this is not always possible depending on the change you are making.
-4. If you are making any user visible changes, include a changelog entry.
+5. If you are making any user visible changes, include a changelog entry.
 
 ## Contributing issues
 

--- a/README.md
+++ b/README.md
@@ -14,3 +14,13 @@ If you're just here for the software, head over to the [releases](https://github
 Join our [Matrix room](https://matrix.to/#/#unstoppableswap-core:matrix.org) to follow development more closely.
 
 ![Screenshot 2024-11-21 at 6 19 03 PM](https://github.com/user-attachments/assets/a9fe110e-90b4-4af8-8980-d4207a5e2a71)
+
+## Running tests
+
+This repository uses [cargo-nextest](https://nexte.st/docs/running/) to run the
+test suite.
+
+```bash
+cargo install cargo-nextest
+cargo nextest run
+```

--- a/justfile
+++ b/justfile
@@ -31,11 +31,15 @@ gui:
 
 # Build the GUI
 gui_build:
-	cd src-gui && yarn build
+        cd src-gui && yarn build
+
+# Run the Rust tests
+tests:
+        cargo nextest run
 
 # Tests the Rust bindings for Monero
 test_monero_sys:
-	cd monero-sys && cargo test
+        cd monero-sys && cargo nextest run
 
 # Builds the ASB and Swap binaries
 swap:


### PR DESCRIPTION
## Summary
- document cargo-nextest usage in CONTRIBUTING
- add a small "Running tests" section in the README
- add `tests` recipe to the justfile and use nextest for `test_monero_sys`

## Testing
- `cargo nextest --version` *(fails: could not download file)*