### PR TITLE
feat(gui): route http requests over internal Tor client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4131,9 +4131,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497bbc33a26fdd4af9ed9c70d63f61cf56a938375fbb32df34db9b1cd6d643f2"
+checksum = "cf9f1e950e0d9d1d3c47184416723cf29c0d1f93bd8cccf37e4beb6b44f31710"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -10136,9 +10136,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.45.0"
+version = "1.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2513ca694ef9ede0fb23fe71a4ee4107cb102b9dc1930f6d0fd77aae068ae165"
+checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
 dependencies = [
  "backtrace",
  "bytes",
@@ -11744,6 +11744,9 @@ name = "unstoppableswap-gui-rs"
 version = "1.1.2"
 dependencies = [
  "anyhow",
+ "http-body-util",
+ "hyper 1.6.0",
+ "hyper-util",
  "rustls 0.23.27",
  "serde",
  "serde_json",
@@ -11760,6 +11763,7 @@ dependencies = [
  "tauri-plugin-single-instance",
  "tauri-plugin-store",
  "tauri-plugin-updater",
+ "tokio",
  "tracing",
  "uuid",
  "zip 4.0.0",

--- a/justfile
+++ b/justfile
@@ -17,9 +17,13 @@ monero_sys:
 	just update_submodules
 	cd monero-sys && cargo build
 
-# Start the Tauri app
+# Start the Tauri app on testnet
 tauri:
 	cd src-tauri && cargo tauri dev --no-watch -- -- --testnet
+
+# Start the Tauri app on mainnet
+tauri_mainnet:
+	cd src-tauri && cargo tauri dev --no-watch
 
 # Install the GUI dependencies
 gui_install:

--- a/src-gui/src/renderer/components/theme.tsx
+++ b/src-gui/src/renderer/components/theme.tsx
@@ -7,44 +7,211 @@ export enum Theme {
   Darker = "darker"
 }
 
+const baseThemeConfig = {
+  spacing: 12, // Increased from default 8px to 12px for more generous spacing
+  shape: {
+    borderRadius: 12, // More rounded corners (default is 4px)
+  },
+  typography: {
+    fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", sans-serif',
+    h1: {
+      fontWeight: 600,
+      letterSpacing: '-0.02em',
+    },
+    h2: {
+      fontWeight: 600,
+      letterSpacing: '-0.01em',
+    },
+    h3: {
+      fontWeight: 600,
+      letterSpacing: '-0.01em',
+    },
+    h4: {
+      fontWeight: 600,
+    },
+    h5: {
+      fontWeight: 600,
+    },
+    h6: {
+      fontWeight: 600,
+    },
+    body1: {
+      lineHeight: 1.6,
+    },
+    body2: {
+      lineHeight: 1.5,
+    },
+    button: {
+      fontWeight: 600,
+      textTransform: "none" as const, // Prevent all caps
+      letterSpacing: '0.02em',
+    },
+    overline: {
+      textTransform: "none" as const, // This prevents the text from being all caps
+      fontFamily: "monospace",
+      letterSpacing: '0.1em',
+    },
+  },
+  overrides: {
+    MuiButton: {
+      root: {
+        borderRadius: 12,
+        padding: '12px 24px',
+        boxShadow: 'none',
+        '&:hover': {
+          boxShadow: '0 4px 12px rgba(0, 0, 0, 0.15)',
+        },
+      },
+      contained: {
+        boxShadow: '0 2px 8px rgba(0, 0, 0, 0.1)',
+        '&:hover': {
+          boxShadow: '0 4px 16px rgba(0, 0, 0, 0.2)',
+        },
+      },
+    },
+    MuiCard: {
+      root: {
+        borderRadius: 16,
+        boxShadow: '0 4px 20px rgba(0, 0, 0, 0.08)',
+      },
+    },
+    MuiPaper: {
+      root: {
+        borderRadius: 12,
+      },
+      elevation1: {
+        boxShadow: '0 2px 8px rgba(0, 0, 0, 0.08)',
+      },
+      elevation2: {
+        boxShadow: '0 4px 12px rgba(0, 0, 0, 0.1)',
+      },
+      elevation3: {
+        boxShadow: '0 6px 16px rgba(0, 0, 0, 0.12)',
+      },
+    },
+    MuiTextField: {
+      root: {
+        '& .MuiOutlinedInput-root': {
+          borderRadius: 12,
+        },
+      },
+    },
+    MuiChip: {
+      root: {
+        borderRadius: 20,
+      },
+    },
+  },
+};
+
 const darkTheme = createTheme({
+  ...baseThemeConfig,
   palette: {
     type: "dark",
     primary: {
       main: "#f4511e", // Monero orange
+      light: "#ff7043",
+      dark: "#d84315",
     },
     secondary: indigo,
-  },
-  typography: {
-    overline: {
-      textTransform: "none", // This prevents the text from being all caps
-      fontFamily: "monospace"
+    background: {
+      default: "#121212",
+      paper: "#1e1e1e",
+    },
+    text: {
+      primary: "rgba(255, 255, 255, 0.95)",
+      secondary: "rgba(255, 255, 255, 0.7)",
     },
   },
 });
 
 const lightTheme = createTheme({
-  ...darkTheme,
+  ...baseThemeConfig,
   palette: {
     type: "light",
     primary: {
       main: "#f4511e", // Monero orange
+      light: "#ff7043",
+      dark: "#d84315",
     },
     secondary: indigo,
+    background: {
+      default: "#fafafa",
+      paper: "#ffffff",
+    },
+    text: {
+      primary: "rgba(0, 0, 0, 0.87)",
+      secondary: "rgba(0, 0, 0, 0.6)",
+    },
+  },
+  overrides: {
+    ...baseThemeConfig.overrides,
+    MuiCard: {
+      root: {
+        borderRadius: 16,
+        boxShadow: '0 2px 12px rgba(0, 0, 0, 0.04)',
+        border: '1px solid rgba(0, 0, 0, 0.06)',
+      },
+    },
+    MuiPaper: {
+      root: {
+        borderRadius: 12,
+      },
+      elevation1: {
+        boxShadow: '0 1px 4px rgba(0, 0, 0, 0.04)',
+      },
+      elevation2: {
+        boxShadow: '0 2px 8px rgba(0, 0, 0, 0.06)',
+      },
+      elevation3: {
+        boxShadow: '0 4px 12px rgba(0, 0, 0, 0.08)',
+      },
+    },
   },
 });
 
 const darkerTheme = createTheme({
-  ...darkTheme,
+  ...baseThemeConfig,
   palette: {
     type: 'dark',
     primary: {
       main: "#f4511e",
+      light: "#ff7043",
+      dark: "#d84315",
     },
     secondary: indigo,
     background: {
       default: "#080808",
       paper: "#181818",
+    },
+    text: {
+      primary: "rgba(255, 255, 255, 0.95)",
+      secondary: "rgba(255, 255, 255, 0.65)",
+    },
+  },
+  overrides: {
+    ...baseThemeConfig.overrides,
+    MuiCard: {
+      root: {
+        borderRadius: 16,
+        boxShadow: '0 4px 20px rgba(0, 0, 0, 0.3)',
+        border: '1px solid rgba(255, 255, 255, 0.08)',
+      },
+    },
+    MuiPaper: {
+      root: {
+        borderRadius: 12,
+        backgroundColor: "#181818",
+      },
+      elevation1: {
+        boxShadow: '0 2px 8px rgba(0, 0, 0, 0.4)',
+      },
+      elevation2: {
+        boxShadow: '0 4px 12px rgba(0, 0, 0, 0.5)',
+      },
+      elevation3: {
+        boxShadow: '0 6px 16px rgba(0, 0, 0, 0.6)',
+      },
     },
   },
 });

--- a/src-gui/src/renderer/rpc.ts
+++ b/src-gui/src/renderer/rpc.ts
@@ -71,6 +71,10 @@ async function invokeNoArgs<RESPONSE>(command: string): Promise<RESPONSE> {
   return invokeUnsafe(command) as Promise<RESPONSE>;
 }
 
+export async function fetchTor() {
+  await invokeNoArgs<void>("fetch");
+}
+
 export async function checkBitcoinBalance() {
   // If we are already syncing, don't start a new sync
   if (Object.values(store.getState().rpc?.state.background ?? {}).some(progress => progress.componentName === "SyncingBitcoinWallet" && progress.progress.type === "Pending")) {
@@ -250,6 +254,9 @@ export async function initializeContext() {
     settings: tauriSettings,
     testnet,
   });
+
+  await fetchTor();
+  console.info("Tor fetched");
 }
 
 export async function getWalletDescriptor() {

--- a/src-gui/src/renderer/rpc.ts
+++ b/src-gui/src/renderer/rpc.ts
@@ -27,6 +27,8 @@ import {
   ResolveApprovalResponse,
   RedactArgs,
   RedactResponse,
+  FetchArgs,
+  FetchResponse,
 } from "models/tauriModel";
 import {
   rpcSetBalance,
@@ -71,8 +73,10 @@ async function invokeNoArgs<RESPONSE>(command: string): Promise<RESPONSE> {
   return invokeUnsafe(command) as Promise<RESPONSE>;
 }
 
-export async function fetchTor() {
-  await invokeNoArgs<void>("fetch");
+export async function fetch(url: string): Promise<string> {
+  const response = await invoke<FetchArgs, FetchResponse>("fetch", { url });
+
+  return response.response;
 }
 
 export async function checkBitcoinBalance() {
@@ -240,7 +244,6 @@ export async function initializeContext() {
   }),
   );
 
-
   // Initialize Tauri settings with null values
   const tauriSettings: TauriSettings = {
     electrum_rpc_url: bitcoinNode,
@@ -255,8 +258,8 @@ export async function initializeContext() {
     testnet,
   });
 
-  await fetchTor();
-  console.info("Tor fetched");
+  let response = await fetch("api.unstoppableswap.net/api/list");
+  console.info("Tor fetched", response);
 }
 
 export async function getWalletDescriptor() {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "unstoppableswap-gui-rs"
 version = "1.1.2"
-authors = [ "binarybaron", "einliterflasche", "unstoppableswap" ]
+authors = ["binarybaron", "einliterflasche", "unstoppableswap"]
 edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -9,19 +9,22 @@ description = "GUI for XMR<>BTC Atomic Swaps written in Rust"
 
 [lib]
 name = "unstoppableswap_gui_rs_lib"
-crate-type = [ "lib", "cdylib", "staticlib" ]
+crate-type = ["lib", "cdylib", "staticlib"]
 
 [build-dependencies]
-tauri-build = { version = "^2.0.0", features = [ "config-json5" ] }
+tauri-build = { version = "^2.0.0", features = ["config-json5"] }
 
 [dependencies]
 anyhow = "1"
+http-body-util = "0.1.3"
+hyper = { version = "1.6.0", features = ["client", "http1"] }
+hyper-util = "0.1.12"
 rustls = { version = "0.23.26", default-features = false, features = ["ring"] }
-serde = { version = "1", features = [ "derive" ] }
+serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-swap = { path = "../swap", features = [ "tauri" ] }
+swap = { path = "../swap", features = ["tauri"] }
 sysinfo = "=0.32.1"
-tauri = { version = "^2.0.0", features = [ "config-json5" ] }
+tauri = { version = "^2.0.0", features = ["config-json5"] }
 tauri-plugin-clipboard-manager = "^2.0.0"
 tauri-plugin-dialog = "2.2.2"
 tauri-plugin-opener = "^2.0.0"
@@ -29,6 +32,7 @@ tauri-plugin-process = "^2.0.0"
 tauri-plugin-shell = "^2.0.0"
 tauri-plugin-store = "^2.0.0"
 tauri-plugin-updater = "^2.0.0"
+tokio = { version = "1.45.1", features = ["full"] }
 tracing = "0.1"
 uuid = "1.16.0"
 zip = "4.0.0"

--- a/swap/src/cli/api.rs
+++ b/swap/src/cli/api.rs
@@ -188,7 +188,7 @@ pub struct Context {
     bitcoin_wallet: Option<Arc<bitcoin::Wallet>>,
     monero_wallet: Option<Arc<TokioMutex<monero::Wallet>>>,
     monero_rpc_process: Option<Arc<SyncMutex<monero::WalletRpcProcess>>>,
-    tor_client: Option<Arc<TorClient<TokioRustlsRuntime>>>,
+    pub tor_client: Option<Arc<TorClient<TokioRustlsRuntime>>>,
 }
 
 /// A conveniant builder struct for [`Context`].

--- a/swap/src/cli/api/request.rs
+++ b/swap/src/cli/api/request.rs
@@ -431,6 +431,18 @@ impl Request for RedactArgs {
 }
 
 #[typeshare]
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct FetchArgs {
+    pub url: String,
+}
+
+#[typeshare]
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct FetchResponse {
+    pub response: String,
+}
+
+#[typeshare]
 #[derive(Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct GetMoneroAddressesArgs;
 

--- a/swap/src/common/tracing_util.rs
+++ b/swap/src/common/tracing_util.rs
@@ -35,7 +35,7 @@ pub fn init(
         "swap",
         "asb",
         "libp2p_community_tor",
-        "unstoppableswap-gui-rs",
+        "unstoppableswap_gui_rs",
         "arti",
     ];
     let OUR_CRATES: Vec<&str> = vec!["swap", "asb"];


### PR DESCRIPTION
Currently, we're not able to use Tor for i.e. fetching current exchange rates. This PR works on using our internal Tor client to make those requests and exposing a `fetch`-like api to the frontend code.