### PR TITLE
fix(monero): Conservative Monero fee for max giveable calcuation

### DIFF
--- a/swap/src/network/swap_setup/alice.rs
+++ b/swap/src/network/swap_setup/alice.rs
@@ -77,7 +77,7 @@ impl WalletSnapshot {
 
         Ok(Self {
             balance,
-            lock_fee: monero::MONERO_FEE,
+            lock_fee: monero::CONSERVATIVE_MONERO_FEE,
             redeem_address,
             punish_address,
             redeem_fee,


### PR DESCRIPTION
Attempt at fixing https://github.com/UnstoppableSwap/core/issues/370

Increased from 0.000016 XMR to 0.003 XMR
