### PR TITLE
fix(asb): send zero quote on failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - ASB: The maker will take Monero funds needed for ongoing swaps into consideration when making a quote. A warning will be displayed if the Monero funds do not cover all ongoing swaps.
+- ASB: Return a zero quote when quoting fails instead of letting the request time out
 
 ## [1.1.7] - 2025-06-04
 

--- a/swap/src/asb/event_loop.rs
+++ b/swap/src/asb/event_loop.rs
@@ -259,8 +259,21 @@ where
                                 // The error is already logged in the make_quote_or_use_cached function
                                 // We don't log it here to avoid spamming on each request
                                 Err(_) => {
-                                    // TODO: Respond with the error to Bob. Currently this will timeout on Bob's side.
-                                    continue;
+                                    let zero_quote = BidQuote {
+                                        price: bitcoin::Amount::ZERO,
+                                        min_quantity: bitcoin::Amount::ZERO,
+                                        max_quantity: bitcoin::Amount::ZERO,
+                                    };
+
+                                    if self
+                                        .swarm
+                                        .behaviour_mut()
+                                        .quote
+                                        .send_response(channel, zero_quote)
+                                        .is_err()
+                                    {
+                                        tracing::debug!(%peer, "Failed to respond with zero quote");
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
## Summary
- ensure the ASB does not leave quote requests hanging
- return a zero quote when quoting fails

## Testing
- `cargo check` *(fails: could not download file)*
- `cargo fmt --all -- --check` *(fails: could not download file)*


------
https://chatgpt.com/codex/tasks/task_b_6842e495f4b4832c96c0ce91680e5708