### PR TITLE
fix(cli): abort stray event loops

### DIFF
--- a/swap/src/cli/api/request.rs
+++ b/swap/src/cli/api/request.rs
@@ -784,6 +784,10 @@ pub async fn buy_xmr(
                 }
             },
         };
+
+        // Abort the event loop if it's still running to avoid it
+        // intercepting messages for subsequent swaps
+        event_loop.abort();
         tracing::debug!(%swap_id, "Swap completed");
 
         context
@@ -910,6 +914,9 @@ pub async fn resume_swap(
 
                 }
             }
+
+            // Ensure the event loop is not left running in the background
+            handle.abort();
             context
                 .swap_lock
                 .release_swap_lock()


### PR DESCRIPTION
## Summary
- abort asynchronous event loop tasks after swap completion to avoid leftover handlers intercepting messages for new swaps

## Testing
- `cargo test --workspace --quiet` *(fails: could not download file)*
- `cargo fmt` *(fails: could not download file)*

------
https://chatgpt.com/codex/tasks/task_b_6842e8d3dd08832ca548c8eaf359460d