### PR TITLE
refactor(ci): use cross image with glibc 2.35

### DIFF
--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -69,7 +69,7 @@ jobs:
           toolchain: "1.82"
 
       - name: Cross Build ${{ matrix.target }} ${{ matrix.bin }} binary
-        if: matrix.target == 'armv7-unknown-linux-gnueabihf'
+        if: matrix.target == 'armv7-unknown-linux-gnueabihf' || matrix.target == 'x86_64-unknown-linux-gnu'
         run: |
           curl -L "https://github.com/cross-rs/cross/releases/download/v0.2.5/cross-x86_64-unknown-linux-gnu.tar.gz" | tar xzv
           sudo mv cross /usr/bin
@@ -77,7 +77,7 @@ jobs:
           cross build --target=${{ matrix.target }} --release --package swap --bin ${{ matrix.bin }}
 
       - name: Build ${{ matrix.target }} ${{ matrix.bin }} release binary
-        if: matrix.target != 'armv7-unknown-linux-gnueabihf'
+        if: matrix.target != 'armv7-unknown-linux-gnueabihf' && matrix.target != 'x86_64-unknown-linux-gnu'
         run: cargo build --target=${{ matrix.target }} --release --package swap --bin ${{ matrix.bin }}
 
       - name: Smoke test the binary

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,8 +145,16 @@ jobs:
             librsvg2-dev
 
       - name: Build binary
-        if: matrix.target != 'armv7-unknown-linux-gnueabihf'
+        if: matrix.target != 'armv7-unknown-linux-gnueabihf' && matrix.target != 'x86_64-unknown-linux-gnu'
         run: cargo build -p swap --target ${{ matrix.target }}
+
+      - name: Install cross (x86_64)
+        if: matrix.target == 'x86_64-unknown-linux-gnu'
+        run: cargo install cross --locked
+
+      - name: Build binary (x86_64)
+        if: matrix.target == 'x86_64-unknown-linux-gnu'
+        run: cross build -p swap --target ${{ matrix.target }}
 
       - name: Install cross (armv7)
         if: matrix.target == 'armv7-unknown-linux-gnueabihf'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Running your own [electrs](https://github.com/romanz/electrs/) server
   - Optionally providing 2-5 fallback servers. The order of the servers does matter. Electrum servers at the front of the list have priority and will be tried first. You should place your own server at the front of the list.
   - A list of public Electrum servers can be found [here](https://1209k.com/bitcoin-eye/ele.php?chain=btc)
+- CI: Linux binaries are now built using `cross` to target glibc 2.35 for Ubuntu 22.04 compatibility
+- CI: The `Cross.toml` config pins the Docker image to `glibc-2.35`
 
 ## [1.1.7] - 2025-06-04
 

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,2 @@
+[target.x86_64-unknown-linux-gnu]
+image = "ghcr.io/cross-rs/x86_64-unknown-linux-gnu:glibc-2.35"


### PR DESCRIPTION
## Summary
- pin Cross image to glibc 2.35 in new Cross.toml
- document pinned Cross image in CHANGELOG

## Testing
- `npx -y dprint@0.50.0 check` *(fails: rustfmt is not installed)*

------
https://chatgpt.com/codex/tasks/task_b_6849e8244cf8832c875e5dbd818861f5