### PR TITLE
chore(ci): add flatpak build

### DIFF
--- a/.github/workflows/build-gui-release-binaries.yml
+++ b/.github/workflows/build-gui-release-binaries.yml
@@ -21,7 +21,7 @@ jobs:
           - platform: "macos-13" # for Intel based macs.
             args: "--target x86_64-apple-darwin"
           - platform: "ubuntu-24.04" # We build on an older version to support older glib versions
-            args: ""
+            args: "--bundles deb,appimage,flatpak"
           - platform: "windows-latest"
             args: ""
 
@@ -57,12 +57,21 @@ jobs:
             librsvg2-dev;
 
           sudo apt install -y \
+            flatpak flatpak-builder \
             libwebkit2gtk-4.1-0=2.44.0-2 \
             libwebkit2gtk-4.1-dev=2.44.0-2 \
             libjavascriptcoregtk-4.1-0=2.44.0-2 \
             libjavascriptcoregtk-4.1-dev=2.44.0-2 \
             gir1.2-javascriptcoregtk-4.1=2.44.0-2 \
             gir1.2-webkit2-4.1=2.44.0-2;
+
+      - name: prepare flatpak runtime
+        if: matrix.platform == 'ubuntu-24.04'
+        run: |
+          flatpak --version
+          flatpak remote-add --if-not-exists flathub \
+            https://dl.flathub.org/repo/flathub.flatpakrepo
+          flatpak update -y
 
       - name: work around spurious network errors in curl 8.0
         shell: bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- GUI: Build Flatpak bundle in release workflow
 
 ## [2.0.0-beta.2] - 2025-06-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
 - GUI: Build Flatpak bundle in release workflow
 
 ## [2.0.0-beta.2] - 2025-06-11

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -29,7 +29,22 @@
   "bundle": {
     "createUpdaterArtifacts": true,
     "active": true,
-    "targets": ["appimage", "dmg", "nsis", "app", "deb"],
+    "targets": ["appimage", "flatpak", "dmg", "nsis", "app", "deb"],
+
+    /* Flatpak-specific settings
+     * These are ignored by the other targets. */
+    "flatpak": {
+      "id": "net.unstoppableswap.UnstoppableSwap",
+      "runtime": "org.freedesktop.Platform",
+      "sdk": "org.freedesktop.Sdk",
+      "runtimeVersion": "23.08",
+      "finishArgs": [
+        "--socket=wayland",
+        "--socket=x11",
+        "--share=network",
+        "--device=all"
+      ]
+    },
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",


### PR DESCRIPTION
## Summary
- emit a Flatpak bundle via Tauri
- install Flatpak tooling on Ubuntu runner
- init flathub remote in workflow
- build deb, AppImage and Flatpak bundles
- document new bundle in the changelog

## Testing
- `cargo fmt --all -- --check`
- `cargo test --package swap --lib` *(fails: bitcoin::electrum_balancer::tests::test_call_switches_on_failure)*

------
https://chatgpt.com/codex/tasks/task_b_684a95bb3a88832ca55b7deb880da4b8