### PR TITLE
docs(maker): document new electrum and fee options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - docs: add instructions for verifying Tauri signature files
+- docs: document new `electrum_rpc_urls` and `use_mempool_space_fee_estimation` options
 
 ## [2.0.0-beta.2] - 2025-06-11
 

--- a/docs/pages/becoming_a_maker/overview.mdx
+++ b/docs/pages/becoming_a_maker/overview.mdx
@@ -142,8 +142,9 @@ We do not recommend changing these settings, however we document them for comple
 # ...
 
 [bitcoin]
-target_block = 1 
-electrum_rpc_url = "tcp://mainnet_electrs:50001"
+target_block = 1
+electrum_rpc_urls = ["tcp://mainnet_electrs:50001"]
+use_mempool_space_fee_estimation = true
 network = "Mainnet"
 
 # ...
@@ -151,8 +152,9 @@ network = "Mainnet"
 
 | Option | Description |
 | --- | --- |
-| `target_block` | This determines the block height that the asb will try to get it's Bitcoin transactions confirmed at. The default value of `1` means the asb will try to get it's transactions confirmed in the next block.  |
-| `electrum_rpc_url` | The URL of the _electrs_ server the asb will connect to. The _electrs_ server is is used to interact with the Bitcoin blockchain. The default URL points to the docker-hosted _electrs_ server. |
+| `target_block` | This determines the block height that the asb will try to get it's Bitcoin transactions confirmed at. The default value of `1` means the asb will try to get it's transactions confirmed in the next block. |
+| `electrum_rpc_urls` | A list of Electrum servers used to interact with the Bitcoin blockchain. If multiple servers are specified they are tried in order. The default contains the docker-hosted _electrs_ server. |
+| `use_mempool_space_fee_estimation` | Whether the asb should fall back to the mempool.space API when fee estimation from Electrum fails. Defaults to `true`. |
 | `network` | The Bitcoin network the asb will connect to. |
 
 ### Monero Section
@@ -252,8 +254,9 @@ price_ticker_ws_url = "wss://ws.kraken.com/"
 external_bitcoin_address = "bc1..."
 
 [bitcoin]
-electrum_rpc_url = "tcp://mainnet_electrs:50001"
-target_block = 1 
+electrum_rpc_urls = ["tcp://mainnet_electrs:50001"]
+target_block = 1
+use_mempool_space_fee_estimation = true
 network = "Mainnet"
 
 [monero]


### PR DESCRIPTION
## Summary
- update maker docs to describe `electrum_rpc_urls` and `use_mempool_space_fee_estimation`
- log docs change in CHANGELOG

## Testing
- `cargo nextest run` *(fails: glib-2.0 missing)*

------
https://chatgpt.com/codex/tasks/task_b_684ab2f34bfc832cb6495adb9a87b598