### PR TITLE
refactor(workspace): extract logic into `electrum-pool` crate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- internal: Electrum load balancer moved into new `electrum-pool` crate.
 - ASB + GUI + CLI: We now cache fee estimates for the Bitcoin wallet for up to 2 minutes. This improves the speed of fee estimation and reduces the number of requests to the Electrum servers.
 
 ## [2.3.0-beta.1] - 2025-06-19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- internal: Electrum load balancer moved into new `electrum-pool` crate.
 - ASB + GUI + CLI: We now cache fee estimates for the Bitcoin wallet for up to 2 minutes. This improves the speed of fee estimation and reduces the number of requests to the Electrum servers.
 
 ## [2.3.0-beta.1] - 2025-06-19

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -461,7 +461,7 @@ checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
  "synstructure 0.13.2",
 ]
 
@@ -473,7 +473,7 @@ checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
  "synstructure 0.13.2",
 ]
 
@@ -496,7 +496,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -644,7 +644,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -684,7 +684,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -701,7 +701,7 @@ checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -913,7 +913,7 @@ checksum = "57d123550fa8d071b7255cb0cc04dc302baa6c8c4a79f55701552684d8399bce"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1011,9 +1011,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
-version = "1.6.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
 
 [[package]]
 name = "bdk"
@@ -1163,7 +1163,7 @@ dependencies = [
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.103",
+ "syn 2.0.104",
  "which",
 ]
 
@@ -1338,7 +1338,7 @@ checksum = "e0b121a9fe0df916e362fb3271088d071159cdf11db0e4182d02152850756eff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1430,7 +1430,7 @@ dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -1839,7 +1839,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2238,7 +2238,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
 dependencies = [
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2248,7 +2248,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
 dependencies = [
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2298,7 +2298,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2340,7 +2340,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2353,7 +2353,7 @@ dependencies = [
  "codespan-reporting",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2371,7 +2371,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2443,7 +2443,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2476,7 +2476,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2502,7 +2502,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2609,7 +2609,7 @@ dependencies = [
  "quote",
  "sha3",
  "strum 0.27.1",
- "syn 2.0.103",
+ "syn 2.0.104",
  "void",
 ]
 
@@ -2627,7 +2627,7 @@ dependencies = [
  "quote",
  "sha3",
  "strum 0.27.1",
- "syn 2.0.103",
+ "syn 2.0.104",
  "void",
 ]
 
@@ -2639,7 +2639,7 @@ checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2660,7 +2660,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2691,7 +2691,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2714,7 +2714,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2744,7 +2744,7 @@ dependencies = [
  "convert_case 0.6.0",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
  "unicode-xid",
 ]
 
@@ -2757,7 +2757,7 @@ dependencies = [
  "convert_case 0.7.1",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
  "unicode-xid",
 ]
 
@@ -2912,7 +2912,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2935,7 +2935,7 @@ checksum = "788160fb30de9cdd857af31c6a2675904b16ece8fc2737b2c7127ba368c9d0f4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3124,6 +3124,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "electrum-pool"
+version = "0.1.0"
+dependencies = [
+ "backoff",
+ "bdk_electrum",
+ "bitcoin 0.32.6",
+ "futures",
+ "once_cell",
+ "serde_json",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "elliptic-curve"
 version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3192,7 +3206,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3205,7 +3219,7 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3226,7 +3240,7 @@ checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3468,7 +3482,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -3678,7 +3692,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -4032,7 +4046,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -4140,7 +4154,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -5067,9 +5081,9 @@ dependencies = [
 
 [[package]]
 name = "jpeg-decoder"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5d4a7da358eff58addd2877a45865158f0d78c911d43a5784ceb7bbf52833b0"
+checksum = "00810f1d8b74be64b13dbf3db89ac67740615d6c891f0e7b6179326533011a07"
 
 [[package]]
 name = "js-sys"
@@ -5730,7 +5744,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -6664,23 +6678,24 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e613fc340b2220f734a8595782c551f1250e969d87d3be1ae0579e8d4065179"
+checksum = "a973b4e44ce6cad84ce69d797acf9a044532e4184c4f267913d1b546a0727b7a"
 dependencies = [
  "num_enum_derive",
+ "rustversion",
 ]
 
 [[package]]
 name = "num_enum_derive"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
+checksum = "77e878c846a8abae00dd069496dbe8751b16ac1c3d6bd2a7283a938e8228f90d"
 dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -7007,7 +7022,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -7287,7 +7302,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -7414,7 +7429,7 @@ dependencies = [
  "phf_shared 0.11.3",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -7461,7 +7476,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -7631,12 +7646,12 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "prettyplease"
-version = "0.2.34"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6837b9e10d61f45f987d50808f83d1ee3d206c66acf650c3e4ae2e1f6ddedf55"
+checksum = "061c1221631e079b26479d25bbf2275bfe5917ae8419cd7e34f13bfc2aa7539a"
 dependencies = [
  "proc-macro2",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -7756,7 +7771,7 @@ checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -8190,7 +8205,7 @@ checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -8476,7 +8491,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6268b74858287e1a062271b988a0c534bf85bbeb567fe09331bf40ed78113d5"
 dependencies = [
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -8776,7 +8791,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -8838,7 +8853,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -9092,7 +9107,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -9103,7 +9118,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -9145,7 +9160,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -9219,7 +9234,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -9244,7 +9259,7 @@ checksum = "5d69265a08751de7844521fd15003ae0a888e035773ba05695c5c759a6f89eef"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -9684,7 +9699,7 @@ dependencies = [
  "quote",
  "sqlx-core",
  "sqlx-macros-core",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -9707,7 +9722,7 @@ dependencies = [
  "sqlx-mysql",
  "sqlx-postgres",
  "sqlx-sqlite",
- "syn 2.0.103",
+ "syn 2.0.104",
  "tokio",
  "url",
 ]
@@ -9977,7 +9992,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -9990,7 +10005,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -10035,6 +10050,7 @@ dependencies = [
  "directories-next",
  "ecdsa_fun",
  "ed25519-dalek 1.0.1",
+ "electrum-pool",
  "futures",
  "get-port",
  "hex",
@@ -10118,9 +10134,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.103"
+version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10156,7 +10172,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -10260,7 +10276,7 @@ checksum = "f4e16beb8b2ac17db28eab8bca40e62dbfbb34c0fcdc6d9826b11b7b5d047dfd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -10377,7 +10393,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "syn 2.0.103",
+ "syn 2.0.104",
  "tauri-utils",
  "thiserror 2.0.12",
  "time 0.3.41",
@@ -10395,7 +10411,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
  "tauri-codegen",
  "tauri-utils",
 ]
@@ -10600,7 +10616,7 @@ dependencies = [
  "tokio",
  "url",
  "windows-sys 0.60.2",
- "zip 4.1.0",
+ "zip 4.2.0",
 ]
 
 [[package]]
@@ -10793,7 +10809,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -10804,7 +10820,7 @@ checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -10932,7 +10948,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -13066,7 +13082,7 @@ checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -13140,7 +13156,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04659ddb06c87d233c566112c1c9c5b9e98256d9af50ec3bc9c8327f873a7568"
 dependencies = [
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -13243,7 +13259,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a615d6c2764852a2e88a4f16e9ce1ea49bb776b5872956309e170d63a042a34f"
 dependencies = [
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -13443,7 +13459,7 @@ dependencies = [
  "tauri-plugin-updater",
  "tracing",
  "uuid",
- "zip 4.1.0",
+ "zip 4.2.0",
 ]
 
 [[package]]
@@ -13575,7 +13591,7 @@ checksum = "d674d135b4a8c1d7e813e2f8d1c9a58308aee4a680323066025e53132218bd91"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -13696,7 +13712,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
  "wasm-bindgen-shared",
 ]
 
@@ -13731,7 +13747,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -13982,7 +13998,7 @@ checksum = "1d228f15bba3b9d56dde8bddbee66fa24545bd17b48d5128ccf4a8742b18e431"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -14172,7 +14188,7 @@ checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -14183,7 +14199,7 @@ checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -14194,7 +14210,7 @@ checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -14205,7 +14221,7 @@ checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -14877,7 +14893,7 @@ checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
  "synstructure 0.13.2",
 ]
 
@@ -14924,7 +14940,7 @@ dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
  "zbus_names",
  "zvariant",
  "zvariant_utils",
@@ -14959,7 +14975,7 @@ checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -14979,7 +14995,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
  "synstructure 0.13.2",
 ]
 
@@ -15000,7 +15016,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -15033,7 +15049,7 @@ checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -15052,9 +15068,9 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "4.1.0"
+version = "4.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af7dcdb4229c0e79c2531a24de7726a0e980417a74fb4d030a35f535665439a0"
+checksum = "95ab361742de920c5535880f89bbd611ee62002bf11341d16a5f057bb8ba6899"
 dependencies = [
  "aes",
  "arbitrary",
@@ -15146,7 +15162,7 @@ dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
- "syn 2.0.103",
+ "syn 2.0.104",
  "zvariant_utils",
 ]
 
@@ -15160,6 +15176,6 @@ dependencies = [
  "quote",
  "serde",
  "static_assertions",
- "syn 2.0.103",
+ "syn 2.0.104",
  "winnow 0.7.11",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2912,6 +2912,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "electrum-pool"
+version = "0.1.0"
+dependencies = [
+ "backoff",
+ "bdk_electrum",
+ "bitcoin 0.32.6",
+ "futures",
+ "once_cell",
+ "serde_json",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "elliptic-curve"
 version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5973,13 +5987,11 @@ dependencies = [
  "cxx-build",
  "futures",
  "monero",
- "serde",
  "tempfile",
  "testcontainers",
  "tokio",
  "tracing",
  "tracing-subscriber",
- "typeshare",
  "uuid",
 ]
 
@@ -7478,6 +7490,15 @@ dependencies = [
  "libc",
  "paste",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "qrcode"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d68782463e408eb1e668cf6152704bd856c78c5b6417adaee3203d8f4c1fc9ec"
+dependencies = [
+ "image",
 ]
 
 [[package]]
@@ -9655,6 +9676,7 @@ dependencies = [
  "directories-next",
  "ecdsa_fun",
  "ed25519-dalek 1.0.1",
+ "electrum-pool",
  "futures",
  "get-port",
  "hex",
@@ -9670,6 +9692,7 @@ dependencies = [
  "once_cell",
  "pem",
  "proptest",
+ "qrcode",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "regex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -282,12 +282,12 @@ checksum = "f95c20af995ff4593368e3ab2db9f0784f310993fe34ee502115c134f8604e06"
 dependencies = [
  "async-trait",
  "cfg-if",
- "derive-deftly 0.14.6",
+ "derive-deftly",
  "derive_builder_fork_arti",
  "derive_more 1.0.0",
- "directories 5.0.1",
+ "directories",
  "educe",
- "fs-mistrust 0.8.3",
+ "fs-mistrust",
  "futures",
  "hostname-validator",
  "humantime",
@@ -299,73 +299,27 @@ dependencies = [
  "safelog",
  "serde",
  "thiserror 2.0.12",
- "tor-async-utils 0.25.0",
- "tor-basic-utils 0.25.0",
- "tor-chanmgr 0.25.0",
- "tor-circmgr 0.25.0",
- "tor-config 0.25.0",
- "tor-config-path 0.25.0",
- "tor-dirmgr 0.25.0",
- "tor-error 0.25.0",
- "tor-guardmgr 0.25.0",
- "tor-keymgr 0.25.0",
- "tor-linkspec 0.25.0",
- "tor-llcrypto 0.25.0",
- "tor-memquota 0.25.0",
- "tor-netdir 0.25.0",
- "tor-netdoc 0.25.0",
- "tor-persist 0.25.0",
- "tor-proto 0.25.0",
- "tor-rtcompat 0.25.0",
- "tracing",
- "void",
-]
-
-[[package]]
-name = "arti-client"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32ef6ce4ca6686d6a8561872d01791f0b9f23ea4455a7f1340850d0fac049817"
-dependencies = [
- "async-trait",
- "cfg-if",
- "derive-deftly 1.0.1",
- "derive_builder_fork_arti",
- "derive_more 2.0.1",
- "educe",
- "fs-mistrust 0.9.3",
- "futures",
- "hostname-validator",
- "humantime",
- "humantime-serde",
- "libc",
- "once_cell",
- "postage",
- "rand 0.9.1",
- "safelog",
- "serde",
- "thiserror 2.0.12",
- "tor-async-utils 0.29.0",
- "tor-basic-utils 0.29.0",
- "tor-chanmgr 0.29.0",
- "tor-circmgr 0.29.0",
- "tor-config 0.29.0",
- "tor-config-path 0.29.0",
- "tor-dirmgr 0.29.0",
- "tor-error 0.29.0",
- "tor-guardmgr 0.29.0",
+ "tor-async-utils",
+ "tor-basic-utils",
+ "tor-chanmgr",
+ "tor-circmgr",
+ "tor-config",
+ "tor-config-path",
+ "tor-dirmgr",
+ "tor-error",
+ "tor-guardmgr",
  "tor-hsclient",
- "tor-hscrypto 0.29.0",
+ "tor-hscrypto",
  "tor-hsservice",
- "tor-keymgr 0.29.0",
- "tor-linkspec 0.29.0",
- "tor-llcrypto 0.29.0",
- "tor-memquota 0.29.0",
- "tor-netdir 0.29.0",
- "tor-netdoc 0.29.0",
- "tor-persist 0.29.0",
- "tor-proto 0.29.0",
- "tor-rtcompat 0.29.0",
+ "tor-keymgr",
+ "tor-linkspec",
+ "tor-llcrypto",
+ "tor-memquota",
+ "tor-netdir",
+ "tor-netdoc",
+ "tor-persist",
+ "tor-proto",
+ "tor-rtcompat",
  "tracing",
  "void",
 ]
@@ -427,21 +381,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "asn1-rs"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56624a96882bb8c26d61312ae18cb45868e5a9992ea73c58e45c3101e56a1e60"
-dependencies = [
- "asn1-rs-derive 0.6.0",
- "asn1-rs-impl 0.2.0",
- "displaydoc",
- "nom",
- "num-traits",
- "rusticata-macros",
- "thiserror 2.0.12",
-]
-
-[[package]]
 name = "asn1-rs-derive"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -461,19 +400,7 @@ checksum = "965c2d33e53cb6b267e148a4cb0760bc01f4904c1cd4bb4002a085bb016d1490"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
- "synstructure 0.13.2",
-]
-
-[[package]]
-name = "asn1-rs-derive"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.104",
+ "syn 2.0.103",
  "synstructure 0.13.2",
 ]
 
@@ -496,7 +423,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -514,12 +441,6 @@ dependencies = [
  "serde",
  "serde_json",
 ]
-
-[[package]]
-name = "assert_matches"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
 name = "async-broadcast"
@@ -644,7 +565,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -684,7 +605,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -701,7 +622,7 @@ checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -827,29 +748,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
-name = "aws-lc-rs"
-version = "1.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fcc8f365936c834db5514fc45aee5b1202d677e6b40e48468aaaa8183ca8c7"
-dependencies = [
- "aws-lc-sys",
- "zeroize",
-]
-
-[[package]]
-name = "aws-lc-sys"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61b1d86e7705efe1be1b569bab41d4fa1e14e220b60a160f78de2db687add079"
-dependencies = [
- "bindgen",
- "cc",
- "cmake",
- "dunce",
- "fs_extra",
-]
-
-[[package]]
 name = "axum"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -913,7 +811,7 @@ checksum = "57d123550fa8d071b7255cb0cc04dc302baa6c8c4a79f55701552684d8399bce"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -967,15 +865,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "base58-monero"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978e81a45367d2409ecd33369a45dda2e9a3ca516153ec194de1fbda4b9fb79d"
-dependencies = [
- "thiserror 1.0.69",
-]
-
-[[package]]
 name = "base58ck"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1011,9 +900,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
-version = "1.8.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
+checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
 name = "bdk"
@@ -1142,29 +1031,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf95709a440f45e986983918d0e8a1f30a9b1df04918fc828670606804ac3c09"
 dependencies = [
  "virtue",
-]
-
-[[package]]
-name = "bindgen"
-version = "0.69.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
-dependencies = [
- "bitflags 2.9.1",
- "cexpr",
- "clang-sys",
- "itertools 0.12.1",
- "lazy_static",
- "lazycell",
- "log",
- "prettyplease",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash 1.1.0",
- "shlex",
- "syn 2.0.104",
- "which",
 ]
 
 [[package]]
@@ -1338,7 +1204,7 @@ checksum = "e0b121a9fe0df916e362fb3271088d071159cdf11db0e4182d02152850756eff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -1430,7 +1296,7 @@ dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -1691,15 +1557,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
-name = "cexpr"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
-dependencies = [
- "nom",
-]
-
-[[package]]
 name = "cfb"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1783,17 +1640,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "clang-sys"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
-dependencies = [
- "glob",
- "libc",
- "libloading 0.8.8",
-]
-
-[[package]]
 name = "clap"
 version = "2.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1839,7 +1685,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -2238,7 +2084,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
 dependencies = [
  "quote",
- "syn 2.0.104",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -2248,7 +2094,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
 dependencies = [
  "quote",
- "syn 2.0.104",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -2269,7 +2115,6 @@ dependencies = [
  "byteorder",
  "digest 0.9.0",
  "rand_core 0.5.1",
- "serde",
  "subtle",
  "zeroize",
 ]
@@ -2298,7 +2143,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -2340,7 +2185,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn 2.0.104",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -2353,7 +2198,7 @@ dependencies = [
  "codespan-reporting",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -2371,7 +2216,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.104",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -2443,7 +2288,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.104",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -2476,7 +2321,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -2502,7 +2347,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
- "syn 2.0.104",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -2552,20 +2397,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "der-parser"
-version = "10.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07da5016415d5a3c4dd39b11ed26f915f52fc4e0dc197d87908bc916e51bc1a6"
-dependencies = [
- "asn1-rs 0.7.1",
- "cookie-factory",
- "displaydoc",
- "nom",
- "num-traits",
- "rusticata-macros",
-]
-
-[[package]]
 name = "deranged"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2581,17 +2412,7 @@ version = "0.14.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8ea84d0109517cc2253d4a679bdda1e8989e9bd86987e9e4f75ffdda0095fd1"
 dependencies = [
- "derive-deftly-macros 0.14.6",
- "heck 0.5.0",
-]
-
-[[package]]
-name = "derive-deftly"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0015cb20a284ec944852820598af3aef6309ea8dc317a0304441272ed620f196"
-dependencies = [
- "derive-deftly-macros 1.0.1",
+ "derive-deftly-macros",
  "heck 0.5.0",
 ]
 
@@ -2609,25 +2430,7 @@ dependencies = [
  "quote",
  "sha3",
  "strum 0.27.1",
- "syn 2.0.104",
- "void",
-]
-
-[[package]]
-name = "derive-deftly-macros"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b48e8e38a4aa565da767322b5ca55fb0f8347983c5bc7f7647db069405420479"
-dependencies = [
- "heck 0.5.0",
- "indexmap 2.9.0",
- "itertools 0.14.0",
- "proc-macro-crate 3.3.0",
- "proc-macro2",
- "quote",
- "sha3",
- "strum 0.27.1",
- "syn 2.0.104",
+ "syn 2.0.103",
  "void",
 ]
 
@@ -2639,7 +2442,7 @@ checksum = "30542c1ad912e0e3d22a1935c290e12e8a29d704a420177a31faad4a601a0800"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -2660,7 +2463,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -2691,7 +2494,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.104",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -2714,7 +2517,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.104",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -2744,7 +2547,7 @@ dependencies = [
  "convert_case 0.6.0",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.103",
  "unicode-xid",
 ]
 
@@ -2757,7 +2560,7 @@ dependencies = [
  "convert_case 0.7.1",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.103",
  "unicode-xid",
 ]
 
@@ -2802,15 +2605,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a49173b84e034382284f27f1af4dcbbd231ffa358c0fe316541a7337f376a35"
 dependencies = [
  "dirs-sys 0.4.1",
-]
-
-[[package]]
-name = "directories"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16f5094c54661b38d03bd7e50df373292118db60b585c08a411c6d840017fe7d"
-dependencies = [
- "dirs-sys 0.5.0",
 ]
 
 [[package]]
@@ -2912,7 +2706,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -2935,7 +2729,7 @@ checksum = "788160fb30de9cdd857af31c6a2675904b16ece8fc2737b2c7127ba368c9d0f4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -2949,12 +2743,6 @@ name = "downcast-rs"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75b325c5dbd37f80359721ad39aca5a29fb04c89279657cffdda8736d0c0b9d2"
-
-[[package]]
-name = "downcast-rs"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea8a8b81cacc08888170eef4d13b775126db426d0b348bee9d18c2c1eaf123cf"
 
 [[package]]
 name = "dpi"
@@ -3124,20 +2912,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "electrum-pool"
-version = "0.1.0"
-dependencies = [
- "backoff",
- "bdk_electrum",
- "bitcoin 0.32.6",
- "futures",
- "once_cell",
- "serde_json",
- "tokio",
- "tracing",
-]
-
-[[package]]
 name = "elliptic-curve"
 version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3206,7 +2980,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -3219,7 +2993,7 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -3240,7 +3014,7 @@ checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -3398,18 +3172,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fixed-hash"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
-dependencies = [
- "byteorder",
- "rand 0.8.5",
- "rustc-hex",
- "static_assertions",
-]
-
-[[package]]
 name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3482,7 +3244,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -3523,22 +3285,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fs-mistrust"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bac926cebf23b68e62f518086eb5671f3d24daa00c395e2142840adef3dc476"
-dependencies = [
- "derive_builder_fork_arti",
- "dirs 6.0.0",
- "libc",
- "once_cell",
- "pwd-grp",
- "serde",
- "thiserror 2.0.12",
- "walkdir",
-]
-
-[[package]]
 name = "fs2"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3547,12 +3293,6 @@ dependencies = [
  "libc",
  "winapi",
 ]
-
-[[package]]
-name = "fs_extra"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "fslock"
@@ -3692,7 +3432,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -4046,7 +3786,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -4154,7 +3894,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -4877,17 +4617,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "inotify"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f37dccff2791ab604f9babef0ba14fbe0be30bd368dc541e2b08d07c8aa908f3"
-dependencies = [
- "bitflags 2.9.1",
- "inotify-sys",
- "libc",
-]
-
-[[package]]
 name = "inotify-sys"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4987,15 +4716,6 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
@@ -5081,9 +4801,9 @@ dependencies = [
 
 [[package]]
 name = "jpeg-decoder"
-version = "0.3.2"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00810f1d8b74be64b13dbf3db89ac67740615d6c891f0e7b6179326533011a07"
+checksum = "f5d4a7da358eff58addd2877a45865158f0d78c911d43a5784ceb7bbf52833b0"
 
 [[package]]
 name = "js-sys"
@@ -5233,12 +4953,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
 name = "libappindicator"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5258,7 +4972,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e9ec52138abedcc58dc17a7c6c0c00a2bdb4f3427c7f63fa97fd0d859155caf"
 dependencies = [
  "gtk-sys",
- "libloading 0.7.4",
+ "libloading",
  "once_cell",
 ]
 
@@ -5288,16 +5002,6 @@ checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
 dependencies = [
  "cfg-if",
  "winapi",
-]
-
-[[package]]
-name = "libloading"
-version = "0.8.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
-dependencies = [
- "cfg-if",
- "windows-targets 0.53.2",
 ]
 
 [[package]]
@@ -5379,19 +5083,19 @@ dependencies = [
 [[package]]
 name = "libp2p-community-tor"
 version = "0.5.0"
-source = "git+https://github.com/umgefahren/libp2p-tor?branch=main#bce21996c7c3cfcc9f640244aa14d51f8ea8d9ee"
+source = "git+https://github.com/umgefahren/libp2p-tor?rev=e6b913e0f1ac1fc90b3ee4dd31b5511140c4a9af#e6b913e0f1ac1fc90b3ee4dd31b5511140c4a9af"
 dependencies = [
  "anyhow",
- "arti-client 0.29.0",
+ "arti-client",
  "data-encoding",
  "futures",
  "libp2p",
  "thiserror 1.0.69",
  "tokio",
- "tor-cell 0.29.0",
+ "tor-cell",
  "tor-hsservice",
- "tor-proto 0.29.0",
- "tor-rtcompat 0.29.0",
+ "tor-proto",
+ "tor-rtcompat",
  "tracing",
 ]
 
@@ -5744,7 +5448,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -6169,34 +5873,17 @@ dependencies = [
 [[package]]
 name = "monero"
 version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c73108ba5cf025e437600990935234241f95ada3c4621960d50912cde739af6"
+source = "git+https://github.com/comit-network/monero-rs?rev=818f38b#818f38b043e2a9fa38d74fec5310a270f510844e"
 dependencies = [
- "base58-monero 0.3.2",
- "curve25519-dalek 3.2.0",
- "fixed-hash 0.7.0",
+ "base58-monero",
+ "curve25519-dalek-ng",
+ "fixed-hash",
  "hex",
  "hex-literal 0.3.4",
  "keccak-hash",
  "serde",
  "serde-big-array",
  "thiserror 1.0.69",
-]
-
-[[package]]
-name = "monero"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f25218523ad4a171ddda05251669afb788cdc2f0df94082aab856a2b09541c3f"
-dependencies = [
- "base58-monero 2.0.0",
- "curve25519-dalek 4.1.3",
- "fixed-hash 0.8.0",
- "hex",
- "hex-literal 0.4.1",
- "sealed",
- "thiserror 1.0.69",
- "tiny-keccak",
 ]
 
 [[package]]
@@ -6215,7 +5902,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "futures",
- "monero 0.12.0",
+ "monero",
  "monero-rpc",
  "monero-sys",
  "rand 0.7.3",
@@ -6235,7 +5922,7 @@ dependencies = [
  "hex",
  "hex-literal 0.4.1",
  "jsonrpc_client",
- "monero 0.12.0",
+ "monero",
  "monero-epee-bin-serde",
  "rand 0.7.3",
  "reqwest",
@@ -6256,7 +5943,7 @@ dependencies = [
  "clap 4.5.40",
  "dirs 5.0.1",
  "futures",
- "monero 0.12.0",
+ "monero",
  "monero-rpc",
  "rand 0.8.5",
  "regex",
@@ -6285,12 +5972,14 @@ dependencies = [
  "cxx",
  "cxx-build",
  "futures",
- "monero 0.12.0",
+ "monero",
+ "serde",
  "tempfile",
  "testcontainers",
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "typeshare",
  "uuid",
 ]
 
@@ -6541,32 +6230,14 @@ checksum = "c533b4c39709f9ba5005d8002048266593c1cfaf3c5f0739d5b8ab0c6c504009"
 dependencies = [
  "bitflags 2.9.1",
  "filetime",
- "inotify 0.10.2",
+ "inotify",
  "kqueue",
  "libc",
  "log",
  "mio",
- "notify-types 1.0.1",
+ "notify-types",
  "walkdir",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "notify"
-version = "8.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fee8403b3d66ac7b26aee6e40a897d85dc5ce26f44da36b8b73e987cc52e943"
-dependencies = [
- "bitflags 2.9.1",
- "filetime",
- "inotify 0.11.0",
- "kqueue",
- "libc",
- "log",
- "mio",
- "notify-types 2.0.0",
- "walkdir",
- "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6577,12 +6248,6 @@ checksum = "585d3cb5e12e01aed9e8a1f70d5c6b5e86fe2a6e48fc8cd0b3e0b8df6f6eb174"
 dependencies = [
  "instant",
 ]
-
-[[package]]
-name = "notify-types"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e0826a989adedc2a244799e823aece04662b66609d96af8dff7ac6df9a8925d"
 
 [[package]]
 name = "ntapi"
@@ -6678,24 +6343,23 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.7.4"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a973b4e44ce6cad84ce69d797acf9a044532e4184c4f267913d1b546a0727b7a"
+checksum = "4e613fc340b2220f734a8595782c551f1250e969d87d3be1ae0579e8d4065179"
 dependencies = [
  "num_enum_derive",
- "rustversion",
 ]
 
 [[package]]
 name = "num_enum_derive"
-version = "0.7.4"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77e878c846a8abae00dd069496dbe8751b16ac1c3d6bd2a7283a938e8228f90d"
+checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -7022,7 +6686,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -7302,7 +6966,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -7429,7 +7093,7 @@ dependencies = [
  "phf_shared 0.11.3",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -7476,7 +7140,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -7645,16 +7309,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
-name = "prettyplease"
-version = "0.2.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "061c1221631e079b26479d25bbf2275bfe5917ae8419cd7e34f13bfc2aa7539a"
-dependencies = [
- "proc-macro2",
- "syn 2.0.104",
-]
-
-[[package]]
 name = "primeorder"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7669,7 +7323,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06345ee39fbccfb06ab45f3a1a5798d9dafa04cb8921a76d227040003a234b0e"
 dependencies = [
- "fixed-hash 0.7.0",
+ "fixed-hash",
  "uint",
 ]
 
@@ -7771,7 +7425,7 @@ checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -7820,19 +7474,10 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b94fdf3867b7f2889a736f0022ea9386766280d2cca4bdbe41629ada9e4f3b8f"
 dependencies = [
- "derive-deftly 0.14.6",
+ "derive-deftly",
  "libc",
  "paste",
  "thiserror 1.0.69",
-]
-
-[[package]]
-name = "qrcode"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d68782463e408eb1e668cf6152704bd856c78c5b6417adaee3203d8f4c1fc9ec"
-dependencies = [
- "image",
 ]
 
 [[package]]
@@ -7897,7 +7542,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "rustls 0.23.28",
  "socket2",
  "thiserror 2.0.12",
@@ -7917,7 +7562,7 @@ dependencies = [
  "lru-slab",
  "rand 0.9.1",
  "ring 0.17.14",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "rustls 0.23.28",
  "rustls-pki-types",
  "slab",
@@ -8064,17 +7709,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_jitter"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b16df48f071248e67b8fc5e866d9448d45c08ad8b672baaaf796e2f15e606ff0"
-dependencies = [
- "libc",
- "rand_core 0.9.3",
- "winapi",
-]
-
-[[package]]
 name = "rand_pcg"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8128,15 +7762,6 @@ dependencies = [
  "ring 0.16.20",
  "time 0.3.41",
  "yasna",
-]
-
-[[package]]
-name = "rdrand"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d92195228612ac8eed47adbc2ed0f04e513a4ccb98175b6f2bd04d963b533655"
-dependencies = [
- "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -8205,7 +7830,7 @@ checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -8491,7 +8116,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6268b74858287e1a062271b988a0c534bf85bbeb567fe09331bf40ed78113d5"
 dependencies = [
  "quote",
- "syn 2.0.104",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -8499,12 +8124,6 @@ name = "rustc-demangle"
 version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
-
-[[package]]
-name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
@@ -8605,7 +8224,6 @@ version = "0.23.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7160e3e10bf4535308537f3c4e1641468cd0e485175d6163087c0393c7d46643"
 dependencies = [
- "aws-lc-rs",
  "log",
  "once_cell",
  "ring 0.17.14",
@@ -8665,7 +8283,6 @@ version = "0.103.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435"
 dependencies = [
- "aws-lc-rs",
  "ring 0.17.14",
  "rustls-pki-types",
  "untrusted 0.9.0",
@@ -8791,7 +8408,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.104",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -8843,18 +8460,6 @@ name = "seahash"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
-
-[[package]]
-name = "sealed"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4a8caec23b7800fb97971a1c6ae365b6239aaeddfb934d6265f8505e795699d"
-dependencies = [
- "heck 0.4.1",
- "proc-macro2",
- "quote",
- "syn 2.0.104",
-]
 
 [[package]]
 name = "sec1"
@@ -9107,7 +8712,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -9118,7 +8723,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -9160,7 +8765,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -9234,7 +8839,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -9259,7 +8864,7 @@ checksum = "5d69265a08751de7844521fd15003ae0a888e035773ba05695c5c759a6f89eef"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -9699,7 +9304,7 @@ dependencies = [
  "quote",
  "sqlx-core",
  "sqlx-macros-core",
- "syn 2.0.104",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -9722,7 +9327,7 @@ dependencies = [
  "sqlx-mysql",
  "sqlx-postgres",
  "sqlx-sqlite",
- "syn 2.0.104",
+ "syn 2.0.103",
  "tokio",
  "url",
 ]
@@ -9992,7 +9597,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.104",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -10005,7 +9610,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.104",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -10025,7 +9630,7 @@ name = "swap"
 version = "2.3.0-beta.1"
 dependencies = [
  "anyhow",
- "arti-client 0.25.0",
+ "arti-client",
  "async-compression 0.3.15",
  "async-trait",
  "asynchronous-codec 0.7.0",
@@ -10050,7 +9655,6 @@ dependencies = [
  "directories-next",
  "ecdsa_fun",
  "ed25519-dalek 1.0.1",
- "electrum-pool",
  "futures",
  "get-port",
  "hex",
@@ -10058,7 +9662,7 @@ dependencies = [
  "libp2p-community-tor",
  "mockito",
  "moka",
- "monero 0.21.0",
+ "monero",
  "monero-harness",
  "monero-rpc",
  "monero-rpc-pool",
@@ -10066,7 +9670,6 @@ dependencies = [
  "once_cell",
  "pem",
  "proptest",
- "qrcode",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "regex",
@@ -10095,7 +9698,7 @@ dependencies = [
  "tokio-tungstenite",
  "tokio-util",
  "toml",
- "tor-rtcompat 0.25.0",
+ "tor-rtcompat",
  "tower 0.4.13",
  "tower-http 0.3.5",
  "tracing",
@@ -10134,9 +9737,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.104"
+version = "2.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
+checksum = "e4307e30089d6fd6aff212f2da3a1f9e32f3223b1f010fb09b7c95f90f3ca1e8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -10172,7 +9775,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -10276,7 +9879,7 @@ checksum = "f4e16beb8b2ac17db28eab8bca40e62dbfbb34c0fcdc6d9826b11b7b5d047dfd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -10393,7 +9996,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "syn 2.0.104",
+ "syn 2.0.103",
  "tauri-utils",
  "thiserror 2.0.12",
  "time 0.3.41",
@@ -10411,7 +10014,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.103",
  "tauri-codegen",
  "tauri-utils",
 ]
@@ -10616,7 +10219,7 @@ dependencies = [
  "tokio",
  "url",
  "windows-sys 0.60.2",
- "zip 4.2.0",
+ "zip 4.1.0",
 ]
 
 [[package]]
@@ -10809,7 +10412,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -10820,7 +10423,7 @@ checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -10948,7 +10551,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -11121,23 +10724,7 @@ version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4be3bd618574a23e0039e34db64d1ea15a8550fc3c70bfdb9e67715861827253"
 dependencies = [
- "derive-deftly 0.14.6",
- "educe",
- "futures",
- "oneshot-fused-workaround",
- "pin-project",
- "postage",
- "thiserror 2.0.12",
- "void",
-]
-
-[[package]]
-name = "tor-async-utils"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8af0bcb05f22eea7c8d4015082019963c592e300de1c692af6c3c418c080eb0"
-dependencies = [
- "derive-deftly 1.0.1",
+ "derive-deftly",
  "educe",
  "futures",
  "oneshot-fused-workaround",
@@ -11167,57 +10754,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "tor-basic-utils"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "182be53685e694cf90ce7e696e116cc0b01434522f17f12ce374b51f7a40bfc9"
-dependencies = [
- "derive_more 2.0.1",
- "hex",
- "itertools 0.14.0",
- "libc",
- "paste",
- "rand 0.9.1",
- "rand_chacha 0.9.0",
- "serde",
- "slab",
- "smallvec",
- "thiserror 2.0.12",
-]
-
-[[package]]
 name = "tor-bytes"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e763faf9664e373cf1171d739af939ec327d04fa5afba142f6b37651a1531a6a"
 dependencies = [
  "bytes",
- "derive-deftly 0.14.6",
+ "derive-deftly",
  "digest 0.10.7",
  "educe",
  "getrandom 0.2.16",
  "safelog",
  "thiserror 2.0.12",
- "tor-error 0.25.0",
- "tor-llcrypto 0.25.0",
- "zeroize",
-]
-
-[[package]]
-name = "tor-bytes"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea40884e6a999280e985e758a230366c9e976da70df899574751151631b4c864"
-dependencies = [
- "bytes",
- "derive-deftly 1.0.1",
- "digest 0.10.7",
- "educe",
- "getrandom 0.3.3",
- "safelog",
- "thiserror 2.0.12",
- "tor-error 0.29.0",
- "tor-llcrypto 0.29.0",
+ "tor-error",
+ "tor-llcrypto",
  "zeroize",
 ]
 
@@ -11231,50 +10781,22 @@ dependencies = [
  "bitflags 2.9.1",
  "bytes",
  "caret",
- "derive-deftly 0.14.6",
+ "derive-deftly",
  "derive_more 1.0.0",
  "educe",
  "paste",
  "rand 0.8.5",
  "smallvec",
  "thiserror 2.0.12",
- "tor-basic-utils 0.25.0",
- "tor-bytes 0.25.0",
- "tor-cert 0.25.0",
- "tor-error 0.25.0",
- "tor-linkspec 0.25.0",
- "tor-llcrypto 0.25.0",
- "tor-memquota 0.25.0",
- "tor-units 0.25.0",
- "void",
-]
-
-[[package]]
-name = "tor-cell"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcda4d1dcfdd9a8954a3ff569f3ab3217bb3686c90d3acf5fb3f9576cae47431"
-dependencies = [
- "amplify",
- "bitflags 2.9.1",
- "bytes",
- "caret",
- "derive-deftly 1.0.1",
- "derive_more 2.0.1",
- "educe",
- "paste",
- "rand 0.9.1",
- "smallvec",
- "thiserror 2.0.12",
- "tor-basic-utils 0.29.0",
- "tor-bytes 0.29.0",
- "tor-cert 0.29.0",
- "tor-error 0.29.0",
- "tor-hscrypto 0.29.0",
- "tor-linkspec 0.29.0",
- "tor-llcrypto 0.29.0",
- "tor-memquota 0.29.0",
- "tor-units 0.29.0",
+ "tor-basic-utils",
+ "tor-bytes",
+ "tor-cert",
+ "tor-error",
+ "tor-hscrypto",
+ "tor-linkspec",
+ "tor-llcrypto",
+ "tor-memquota",
+ "tor-units",
  "void",
 ]
 
@@ -11285,28 +10807,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73504fa89511021b1f681b51db714d789d96da01911d090755e1d26e5f05d623"
 dependencies = [
  "caret",
+ "derive_builder_fork_arti",
  "derive_more 1.0.0",
  "digest 0.10.7",
  "thiserror 2.0.12",
- "tor-bytes 0.25.0",
- "tor-checkable 0.25.0",
- "tor-llcrypto 0.25.0",
-]
-
-[[package]]
-name = "tor-cert"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7042c22afc733f256947042bcaaffc28c6ec51d53cb6ecef6d5b1ad6fd3989bd"
-dependencies = [
- "caret",
- "derive_builder_fork_arti",
- "derive_more 2.0.1",
- "digest 0.10.7",
- "thiserror 2.0.12",
- "tor-bytes 0.29.0",
- "tor-checkable 0.29.0",
- "tor-llcrypto 0.29.0",
+ "tor-bytes",
+ "tor-checkable",
+ "tor-llcrypto",
 ]
 
 [[package]]
@@ -11326,54 +10833,19 @@ dependencies = [
  "safelog",
  "serde",
  "thiserror 2.0.12",
- "tor-async-utils 0.25.0",
- "tor-basic-utils 0.25.0",
- "tor-cell 0.25.0",
- "tor-config 0.25.0",
- "tor-error 0.25.0",
- "tor-linkspec 0.25.0",
- "tor-llcrypto 0.25.0",
- "tor-memquota 0.25.0",
- "tor-netdir 0.25.0",
- "tor-proto 0.25.0",
- "tor-rtcompat 0.25.0",
- "tor-socksproto 0.25.0",
- "tor-units 0.25.0",
- "tracing",
- "void",
-]
-
-[[package]]
-name = "tor-chanmgr"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf904041fcecc51eb6b4d2b18f6b7265b474b7fe8a3a6f5e9189daa357dbb7b0"
-dependencies = [
- "async-trait",
- "caret",
- "derive_builder_fork_arti",
- "derive_more 2.0.1",
- "educe",
- "futures",
- "oneshot-fused-workaround",
- "postage",
- "rand 0.9.1",
- "safelog",
- "serde",
- "thiserror 2.0.12",
- "tor-async-utils 0.29.0",
- "tor-basic-utils 0.29.0",
- "tor-cell 0.29.0",
- "tor-config 0.29.0",
- "tor-error 0.29.0",
- "tor-linkspec 0.29.0",
- "tor-llcrypto 0.29.0",
- "tor-memquota 0.29.0",
- "tor-netdir 0.29.0",
- "tor-proto 0.29.0",
- "tor-rtcompat 0.29.0",
- "tor-socksproto 0.29.0",
- "tor-units 0.29.0",
+ "tor-async-utils",
+ "tor-basic-utils",
+ "tor-cell",
+ "tor-config",
+ "tor-error",
+ "tor-linkspec",
+ "tor-llcrypto",
+ "tor-memquota",
+ "tor-netdir",
+ "tor-proto",
+ "tor-rtcompat",
+ "tor-socksproto",
+ "tor-units",
  "tracing",
  "void",
 ]
@@ -11387,19 +10859,7 @@ dependencies = [
  "humantime",
  "signature 2.2.0",
  "thiserror 2.0.12",
- "tor-llcrypto 0.25.0",
-]
-
-[[package]]
-name = "tor-checkable"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3f44a30f1c7c924bfdc9e358ed197ed3bd0a6fa9b7a3271d6dc367a5e08f3fd"
-dependencies = [
- "humantime",
- "signature 2.2.0",
- "thiserror 2.0.12",
- "tor-llcrypto 0.29.0",
+ "tor-llcrypto",
 ]
 
 [[package]]
@@ -11414,7 +10874,7 @@ dependencies = [
  "cfg-if",
  "derive_builder_fork_arti",
  "derive_more 1.0.0",
- "downcast-rs 1.2.1",
+ "downcast-rs",
  "dyn-clone",
  "educe",
  "futures",
@@ -11429,69 +10889,21 @@ dependencies = [
  "serde",
  "static_assertions",
  "thiserror 2.0.12",
- "tor-async-utils 0.25.0",
- "tor-basic-utils 0.25.0",
- "tor-chanmgr 0.25.0",
- "tor-config 0.25.0",
- "tor-error 0.25.0",
- "tor-guardmgr 0.25.0",
- "tor-linkspec 0.25.0",
- "tor-memquota 0.25.0",
- "tor-netdir 0.25.0",
- "tor-netdoc 0.25.0",
- "tor-persist 0.25.0",
- "tor-proto 0.25.0",
- "tor-protover 0.25.0",
- "tor-relay-selection 0.25.0",
- "tor-rtcompat 0.25.0",
- "tracing",
- "void",
- "weak-table",
-]
-
-[[package]]
-name = "tor-circmgr"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e36a9a7d2c457482ce17ba086c623ddc7109fb9f2143170d65cbefc0ee3474ef"
-dependencies = [
- "amplify",
- "async-trait",
- "bounded-vec-deque",
- "cfg-if",
- "derive_builder_fork_arti",
- "derive_more 2.0.1",
- "downcast-rs 2.0.1",
- "dyn-clone",
- "educe",
- "futures",
- "humantime-serde",
- "itertools 0.14.0",
- "once_cell",
- "oneshot-fused-workaround",
- "pin-project",
- "rand 0.9.1",
- "retry-error",
- "safelog",
- "serde",
- "static_assertions",
- "thiserror 2.0.12",
- "tor-async-utils 0.29.0",
- "tor-basic-utils 0.29.0",
- "tor-chanmgr 0.29.0",
- "tor-config 0.29.0",
- "tor-error 0.29.0",
- "tor-guardmgr 0.29.0",
- "tor-linkspec 0.29.0",
- "tor-memquota 0.29.0",
- "tor-netdir 0.29.0",
- "tor-netdoc 0.29.0",
- "tor-persist 0.29.0",
- "tor-proto 0.29.0",
- "tor-protover 0.29.0",
- "tor-relay-selection 0.29.0",
- "tor-rtcompat 0.29.0",
- "tor-units 0.29.0",
+ "tor-async-utils",
+ "tor-basic-utils",
+ "tor-chanmgr",
+ "tor-config",
+ "tor-error",
+ "tor-guardmgr",
+ "tor-linkspec",
+ "tor-memquota",
+ "tor-netdir",
+ "tor-netdoc",
+ "tor-persist",
+ "tor-proto",
+ "tor-protover",
+ "tor-relay-selection",
+ "tor-rtcompat",
  "tracing",
  "void",
  "weak-table",
@@ -11505,15 +10917,15 @@ checksum = "9e8282abe3e4a7e800f0a826acc6f2815887c8b3804b3061b5181223e53be37b"
 dependencies = [
  "amplify",
  "cfg-if",
- "derive-deftly 0.14.6",
+ "derive-deftly",
  "derive_builder_fork_arti",
  "educe",
  "either",
  "figment",
- "fs-mistrust 0.8.3",
+ "fs-mistrust",
  "futures",
  "itertools 0.13.0",
- "notify 7.0.0",
+ "notify",
  "once_cell",
  "paste",
  "postage",
@@ -11524,43 +10936,9 @@ dependencies = [
  "strum 0.26.3",
  "thiserror 2.0.12",
  "toml",
- "tor-basic-utils 0.25.0",
- "tor-error 0.25.0",
- "tor-rtcompat 0.25.0",
- "tracing",
- "void",
-]
-
-[[package]]
-name = "tor-config"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74c04314fef18dd6ea027c4dbe64e34bd9b5f2c900fa6b8fe331b68ced55591d"
-dependencies = [
- "amplify",
- "cfg-if",
- "derive-deftly 1.0.1",
- "derive_builder_fork_arti",
- "educe",
- "either",
- "figment",
- "fs-mistrust 0.9.3",
- "futures",
- "itertools 0.14.0",
- "notify 8.0.0",
- "once_cell",
- "paste",
- "postage",
- "regex",
- "serde",
- "serde-value",
- "serde_ignored",
- "strum 0.27.1",
- "thiserror 2.0.12",
- "toml",
- "tor-basic-utils 0.29.0",
- "tor-error 0.29.0",
- "tor-rtcompat 0.29.0",
+ "tor-basic-utils",
+ "tor-error",
+ "tor-rtcompat",
  "tracing",
  "void",
 ]
@@ -11571,28 +10949,13 @@ version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca216bb068d03dc260c821bac24d0b0efdb838bb16117eb57475bb5fa43dfe16"
 dependencies = [
- "directories 5.0.1",
+ "directories",
  "once_cell",
  "serde",
  "shellexpand",
  "thiserror 2.0.12",
- "tor-error 0.25.0",
- "tor-general-addr 0.25.0",
-]
-
-[[package]]
-name = "tor-config-path"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6162c71d9cdab7a8cd249be2c0c922f6a4ac926fc32d03b320696f426260d9cc"
-dependencies = [
- "directories 6.0.0",
- "once_cell",
- "serde",
- "shellexpand",
- "thiserror 2.0.12",
- "tor-error 0.29.0",
- "tor-general-addr 0.29.0",
+ "tor-error",
+ "tor-general-addr",
 ]
 
 [[package]]
@@ -11604,19 +10967,7 @@ dependencies = [
  "digest 0.10.7",
  "hex",
  "thiserror 2.0.12",
- "tor-llcrypto 0.25.0",
-]
-
-[[package]]
-name = "tor-consdiff"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a0b9697be65ba2e9dae30f536e5dff4d3489d30ea1f5df862afacb91dfdca9"
-dependencies = [
- "digest 0.10.7",
- "hex",
- "thiserror 2.0.12",
- "tor-llcrypto 0.29.0",
+ "tor-llcrypto",
 ]
 
 [[package]]
@@ -11636,41 +10987,14 @@ dependencies = [
  "itertools 0.13.0",
  "memchr",
  "thiserror 2.0.12",
- "tor-circmgr 0.25.0",
- "tor-error 0.25.0",
- "tor-linkspec 0.25.0",
- "tor-llcrypto 0.25.0",
- "tor-netdoc 0.25.0",
- "tor-proto 0.25.0",
- "tor-rtcompat 0.25.0",
- "tracing",
-]
-
-[[package]]
-name = "tor-dirclient"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4416c5031e75625b620c2a56e1051993076b3e8574f79ec0251e2b736da2f1e"
-dependencies = [
- "async-compression 0.4.25",
- "base64ct",
- "derive_more 2.0.1",
- "futures",
- "hex",
- "http 1.3.1",
- "httparse",
- "httpdate",
- "itertools 0.14.0",
- "memchr",
- "thiserror 2.0.12",
- "tor-circmgr 0.29.0",
- "tor-error 0.29.0",
- "tor-hscrypto 0.29.0",
- "tor-linkspec 0.29.0",
- "tor-llcrypto 0.29.0",
- "tor-netdoc 0.29.0",
- "tor-proto 0.29.0",
- "tor-rtcompat 0.29.0",
+ "tor-circmgr",
+ "tor-error",
+ "tor-hscrypto",
+ "tor-linkspec",
+ "tor-llcrypto",
+ "tor-netdoc",
+ "tor-proto",
+ "tor-rtcompat",
  "tracing",
 ]
 
@@ -11687,7 +11011,7 @@ dependencies = [
  "digest 0.10.7",
  "educe",
  "event-listener",
- "fs-mistrust 0.8.3",
+ "fs-mistrust",
  "fslock",
  "futures",
  "hex",
@@ -11708,74 +11032,21 @@ dependencies = [
  "strum 0.26.3",
  "thiserror 2.0.12",
  "time 0.3.41",
- "tor-async-utils 0.25.0",
- "tor-basic-utils 0.25.0",
- "tor-checkable 0.25.0",
- "tor-circmgr 0.25.0",
- "tor-config 0.25.0",
- "tor-consdiff 0.25.0",
- "tor-dirclient 0.25.0",
- "tor-error 0.25.0",
- "tor-guardmgr 0.25.0",
- "tor-llcrypto 0.25.0",
- "tor-netdir 0.25.0",
- "tor-netdoc 0.25.0",
- "tor-persist 0.25.0",
- "tor-proto 0.25.0",
- "tor-rtcompat 0.25.0",
- "tracing",
-]
-
-[[package]]
-name = "tor-dirmgr"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97978e4080932866d8a8cae042fd20a72f3fa91095834dced74bd4f6ceaa4180"
-dependencies = [
- "async-trait",
- "base64ct",
- "derive_builder_fork_arti",
- "derive_more 2.0.1",
- "digest 0.10.7",
- "educe",
- "event-listener",
- "fs-mistrust 0.9.3",
- "fslock",
- "futures",
- "hex",
- "humantime",
- "humantime-serde",
- "itertools 0.14.0",
- "memmap2",
- "once_cell",
- "oneshot-fused-workaround",
- "paste",
- "postage",
- "rand 0.9.1",
- "rusqlite",
- "safelog",
- "scopeguard",
- "serde",
- "signature 2.2.0",
- "static_assertions",
- "strum 0.27.1",
- "thiserror 2.0.12",
- "time 0.3.41",
- "tor-async-utils 0.29.0",
- "tor-basic-utils 0.29.0",
- "tor-checkable 0.29.0",
- "tor-circmgr 0.29.0",
- "tor-config 0.29.0",
- "tor-consdiff 0.29.0",
- "tor-dirclient 0.29.0",
- "tor-error 0.29.0",
- "tor-guardmgr 0.29.0",
- "tor-llcrypto 0.29.0",
- "tor-netdir 0.29.0",
- "tor-netdoc 0.29.0",
- "tor-persist 0.29.0",
- "tor-proto 0.29.0",
- "tor-rtcompat 0.29.0",
+ "tor-async-utils",
+ "tor-basic-utils",
+ "tor-checkable",
+ "tor-circmgr",
+ "tor-config",
+ "tor-consdiff",
+ "tor-dirclient",
+ "tor-error",
+ "tor-guardmgr",
+ "tor-llcrypto",
+ "tor-netdir",
+ "tor-netdoc",
+ "tor-persist",
+ "tor-proto",
+ "tor-rtcompat",
  "tracing",
 ]
 
@@ -11798,41 +11069,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "tor-error"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6488b3bf0c82b1880505ea060bfa8dc24d380e16efe354e3449a283f4212b73"
-dependencies = [
- "derive_more 2.0.1",
- "futures",
- "once_cell",
- "paste",
- "retry-error",
- "static_assertions",
- "strum 0.27.1",
- "thiserror 2.0.12",
- "tracing",
- "void",
-]
-
-[[package]]
 name = "tor-general-addr"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60b135845a8c4546cdb4da673123e5ae3daf4597d9857fd7d720350efac173c"
 dependencies = [
  "derive_more 1.0.0",
- "thiserror 2.0.12",
- "void",
-]
-
-[[package]]
-name = "tor-general-addr"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7551ba9b4449958e5f072d85501e9f2c32ae8002f438c5383465c2369e642813"
-dependencies = [
- "derive_more 2.0.1",
  "thiserror 2.0.12",
  "void",
 ]
@@ -11845,7 +11087,7 @@ checksum = "79fe4522964d1e843cc8f9d265ee66c99a54ac135d85c70a0d619a11317bf32a"
 dependencies = [
  "amplify",
  "base64ct",
- "derive-deftly 0.14.6",
+ "derive-deftly",
  "derive_builder_fork_arti",
  "derive_more 1.0.0",
  "dyn-clone",
@@ -11863,104 +11105,62 @@ dependencies = [
  "serde",
  "strum 0.26.3",
  "thiserror 2.0.12",
- "tor-async-utils 0.25.0",
- "tor-basic-utils 0.25.0",
- "tor-config 0.25.0",
- "tor-error 0.25.0",
- "tor-linkspec 0.25.0",
- "tor-llcrypto 0.25.0",
- "tor-netdir 0.25.0",
- "tor-netdoc 0.25.0",
- "tor-persist 0.25.0",
- "tor-proto 0.25.0",
- "tor-relay-selection 0.25.0",
- "tor-rtcompat 0.25.0",
- "tor-units 0.25.0",
- "tracing",
-]
-
-[[package]]
-name = "tor-guardmgr"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1d0877a98542eaa2b9f669336c9132fe35cb8ee530af94ad50bce407af23088"
-dependencies = [
- "amplify",
- "base64ct",
- "derive-deftly 1.0.1",
- "derive_builder_fork_arti",
- "derive_more 2.0.1",
- "dyn-clone",
- "educe",
- "futures",
- "humantime",
- "humantime-serde",
- "itertools 0.14.0",
- "num_enum",
- "oneshot-fused-workaround",
- "pin-project",
- "postage",
- "rand 0.9.1",
- "safelog",
- "serde",
- "strum 0.27.1",
- "thiserror 2.0.12",
- "tor-async-utils 0.29.0",
- "tor-basic-utils 0.29.0",
- "tor-config 0.29.0",
- "tor-error 0.29.0",
- "tor-linkspec 0.29.0",
- "tor-llcrypto 0.29.0",
- "tor-netdir 0.29.0",
- "tor-netdoc 0.29.0",
- "tor-persist 0.29.0",
- "tor-proto 0.29.0",
- "tor-relay-selection 0.29.0",
- "tor-rtcompat 0.29.0",
- "tor-units 0.29.0",
+ "tor-async-utils",
+ "tor-basic-utils",
+ "tor-config",
+ "tor-error",
+ "tor-linkspec",
+ "tor-llcrypto",
+ "tor-netdir",
+ "tor-netdoc",
+ "tor-persist",
+ "tor-proto",
+ "tor-relay-selection",
+ "tor-rtcompat",
+ "tor-units",
  "tracing",
 ]
 
 [[package]]
 name = "tor-hsclient"
-version = "0.29.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6fc936ee17c88f83bab968c21e6f631904fc441cd01e1d0b219b12668134dbe"
+checksum = "9304ea1bcfe46baffd1d0307e56520c855541e54623ca1afe0746a6701f53722"
 dependencies = [
  "async-trait",
- "derive-deftly 1.0.1",
- "derive_more 2.0.1",
+ "derive-deftly",
+ "derive_more 1.0.0",
  "educe",
  "either",
  "futures",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "oneshot-fused-workaround",
  "postage",
- "rand 0.9.1",
+ "rand 0.8.5",
  "retry-error",
  "safelog",
  "slotmap-careful",
- "strum 0.27.1",
+ "strum 0.26.3",
  "thiserror 2.0.12",
- "tor-async-utils 0.29.0",
- "tor-basic-utils 0.29.0",
- "tor-bytes 0.29.0",
- "tor-cell 0.29.0",
- "tor-checkable 0.29.0",
- "tor-circmgr 0.29.0",
- "tor-config 0.29.0",
- "tor-dirclient 0.29.0",
- "tor-error 0.29.0",
- "tor-hscrypto 0.29.0",
- "tor-keymgr 0.29.0",
- "tor-linkspec 0.29.0",
- "tor-llcrypto 0.29.0",
- "tor-memquota 0.29.0",
- "tor-netdir 0.29.0",
- "tor-netdoc 0.29.0",
- "tor-persist 0.29.0",
- "tor-proto 0.29.0",
- "tor-rtcompat 0.29.0",
+ "tor-async-utils",
+ "tor-basic-utils",
+ "tor-bytes",
+ "tor-cell",
+ "tor-checkable",
+ "tor-circmgr",
+ "tor-config",
+ "tor-dirclient",
+ "tor-error",
+ "tor-hscrypto",
+ "tor-keymgr",
+ "tor-linkspec",
+ "tor-llcrypto",
+ "tor-memquota",
+ "tor-netdir",
+ "tor-netdoc",
+ "tor-persist",
+ "tor-proto",
+ "tor-rtcompat",
  "tracing",
 ]
 
@@ -11970,7 +11170,9 @@ version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4538644fce1b94d650fb5f9cbb82133ceb32c7dfab44c01da2aa6747c655730"
 dependencies = [
+ "cipher",
  "data-encoding",
+ "derive-deftly",
  "derive_more 1.0.0",
  "digest 0.10.7",
  "itertools 0.13.0",
@@ -11980,98 +11182,70 @@ dependencies = [
  "signature 2.2.0",
  "subtle",
  "thiserror 2.0.12",
- "tor-basic-utils 0.25.0",
- "tor-bytes 0.25.0",
- "tor-error 0.25.0",
- "tor-llcrypto 0.25.0",
- "tor-units 0.25.0",
- "void",
-]
-
-[[package]]
-name = "tor-hscrypto"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e2ddacd739dd691bb3623e045ef07d8660d157f5a882e9b996b79f5e3803fa0"
-dependencies = [
- "cipher",
- "data-encoding",
- "derive-deftly 1.0.1",
- "derive_more 2.0.1",
- "digest 0.10.7",
- "humantime",
- "itertools 0.14.0",
- "paste",
- "rand 0.9.1",
- "safelog",
- "signature 2.2.0",
- "subtle",
- "thiserror 2.0.12",
- "tor-basic-utils 0.29.0",
- "tor-bytes 0.29.0",
- "tor-error 0.29.0",
- "tor-key-forge 0.29.0",
- "tor-llcrypto 0.29.0",
- "tor-memquota 0.29.0",
- "tor-units 0.29.0",
+ "tor-basic-utils",
+ "tor-bytes",
+ "tor-error",
+ "tor-llcrypto",
+ "tor-memquota",
+ "tor-units",
  "void",
  "zeroize",
 ]
 
 [[package]]
 name = "tor-hsservice"
-version = "0.29.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52e6609424df5d0830d0182ee4f77df5f8246767b0433993e2d7a0816914ac48"
+checksum = "3b4573677a829ab940cfd005f1b13867cb818148c9bfb7d61b2f30fc3005b6cf"
 dependencies = [
  "amplify",
  "async-trait",
  "base64ct",
  "cfg-if",
- "derive-deftly 1.0.1",
+ "derive-deftly",
  "derive_builder_fork_arti",
- "derive_more 2.0.1",
+ "derive_more 1.0.0",
  "digest 0.10.7",
  "educe",
- "fs-mistrust 0.9.3",
+ "fs-mistrust",
  "futures",
  "growable-bloom-filter",
  "hex",
  "humantime",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "k12",
  "once_cell",
  "oneshot-fused-workaround",
  "postage",
- "rand 0.9.1",
- "rand_core 0.9.3",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "retry-error",
  "safelog",
  "serde",
  "serde_with 3.13.0",
- "strum 0.27.1",
+ "strum 0.26.3",
  "thiserror 2.0.12",
- "tor-async-utils 0.29.0",
- "tor-basic-utils 0.29.0",
- "tor-bytes 0.29.0",
- "tor-cell 0.29.0",
- "tor-circmgr 0.29.0",
- "tor-config 0.29.0",
- "tor-config-path 0.29.0",
- "tor-dirclient 0.29.0",
- "tor-error 0.29.0",
- "tor-hscrypto 0.29.0",
- "tor-keymgr 0.29.0",
- "tor-linkspec 0.29.0",
- "tor-llcrypto 0.29.0",
- "tor-log-ratelim 0.29.0",
- "tor-netdir 0.29.0",
- "tor-netdoc 0.29.0",
- "tor-persist 0.29.0",
- "tor-proto 0.29.0",
- "tor-protover 0.29.0",
- "tor-relay-selection 0.29.0",
- "tor-rtcompat 0.29.0",
+ "tor-async-utils",
+ "tor-basic-utils",
+ "tor-bytes",
+ "tor-cell",
+ "tor-circmgr",
+ "tor-config",
+ "tor-config-path",
+ "tor-dirclient",
+ "tor-error",
+ "tor-hscrypto",
+ "tor-keymgr",
+ "tor-linkspec",
+ "tor-llcrypto",
+ "tor-log-ratelim",
+ "tor-netdir",
+ "tor-netdoc",
+ "tor-persist",
+ "tor-proto",
+ "tor-protover",
+ "tor-relay-selection",
+ "tor-rtcompat",
  "tracing",
  "void",
 ]
@@ -12082,38 +11256,17 @@ version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "288909e7e606ae44577857b2b1fcd13d82af8f2cf9d6128a49f2960bd00ea2d0"
 dependencies = [
- "derive-deftly 0.14.6",
+ "derive-deftly",
  "derive_more 1.0.0",
- "downcast-rs 1.2.1",
+ "downcast-rs",
  "paste",
  "rand 0.8.5",
  "signature 2.2.0",
  "ssh-key",
  "thiserror 2.0.12",
- "tor-error 0.25.0",
- "tor-hscrypto 0.25.0",
- "tor-llcrypto 0.25.0",
-]
-
-[[package]]
-name = "tor-key-forge"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac47ab4aff8c0af8cf92b5dd3984e830c4da564bb48f06630aa7f951c688f0ba"
-dependencies = [
- "derive-deftly 1.0.1",
- "derive_more 2.0.1",
- "downcast-rs 2.0.1",
- "paste",
- "rand 0.9.1",
- "signature 2.2.0",
- "ssh-key",
- "thiserror 2.0.12",
- "tor-bytes 0.29.0",
- "tor-cert 0.29.0",
- "tor-checkable 0.29.0",
- "tor-error 0.29.0",
- "tor-llcrypto 0.29.0",
+ "tor-error",
+ "tor-hscrypto",
+ "tor-llcrypto",
 ]
 
 [[package]]
@@ -12125,12 +11278,12 @@ dependencies = [
  "amplify",
  "arrayvec",
  "cfg-if",
- "derive-deftly 0.14.6",
+ "derive-deftly",
  "derive_builder_fork_arti",
  "derive_more 1.0.0",
- "downcast-rs 1.2.1",
+ "downcast-rs",
  "dyn-clone",
- "fs-mistrust 0.8.3",
+ "fs-mistrust",
  "glob-match",
  "humantime",
  "inventory",
@@ -12140,52 +11293,14 @@ dependencies = [
  "signature 2.2.0",
  "ssh-key",
  "thiserror 2.0.12",
- "tor-basic-utils 0.25.0",
- "tor-config 0.25.0",
- "tor-config-path 0.25.0",
- "tor-error 0.25.0",
- "tor-hscrypto 0.25.0",
- "tor-key-forge 0.25.0",
- "tor-llcrypto 0.25.0",
- "tor-persist 0.25.0",
- "tracing",
- "walkdir",
- "zeroize",
-]
-
-[[package]]
-name = "tor-keymgr"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a0bc40b735b3d1e04d8ac550bce66d40ea84ef5fc47a76fc8f64713b4abe3f"
-dependencies = [
- "amplify",
- "arrayvec",
- "cfg-if",
- "derive-deftly 1.0.1",
- "derive_builder_fork_arti",
- "derive_more 2.0.1",
- "downcast-rs 2.0.1",
- "dyn-clone",
- "fs-mistrust 0.9.3",
- "glob-match",
- "humantime",
- "inventory",
- "itertools 0.14.0",
- "rand 0.9.1",
- "serde",
- "signature 2.2.0",
- "ssh-key",
- "thiserror 2.0.12",
- "tor-basic-utils 0.29.0",
- "tor-bytes 0.29.0",
- "tor-config 0.29.0",
- "tor-config-path 0.29.0",
- "tor-error 0.29.0",
- "tor-hscrypto 0.29.0",
- "tor-key-forge 0.29.0",
- "tor-llcrypto 0.29.0",
- "tor-persist 0.29.0",
+ "tor-basic-utils",
+ "tor-config",
+ "tor-config-path",
+ "tor-error",
+ "tor-hscrypto",
+ "tor-key-forge",
+ "tor-llcrypto",
+ "tor-persist",
  "tracing",
  "walkdir",
  "zeroize",
@@ -12200,7 +11315,7 @@ dependencies = [
  "base64ct",
  "by_address",
  "caret",
- "derive-deftly 0.14.6",
+ "derive-deftly",
  "derive_builder_fork_arti",
  "derive_more 1.0.0",
  "hex",
@@ -12210,39 +11325,12 @@ dependencies = [
  "serde_with 3.13.0",
  "strum 0.26.3",
  "thiserror 2.0.12",
- "tor-basic-utils 0.25.0",
- "tor-bytes 0.25.0",
- "tor-config 0.25.0",
- "tor-llcrypto 0.25.0",
- "tor-memquota 0.25.0",
- "tor-protover 0.25.0",
-]
-
-[[package]]
-name = "tor-linkspec"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b12f5be8e6077b66ec04e64b7e1a779e77af44893b5454cd0928289c45767780"
-dependencies = [
- "base64ct",
- "by_address",
- "caret",
- "derive-deftly 1.0.1",
- "derive_builder_fork_arti",
- "derive_more 2.0.1",
- "hex",
- "itertools 0.14.0",
- "safelog",
- "serde",
- "serde_with 3.13.0",
- "strum 0.27.1",
- "thiserror 2.0.12",
- "tor-basic-utils 0.29.0",
- "tor-bytes 0.29.0",
- "tor-config 0.29.0",
- "tor-llcrypto 0.29.0",
- "tor-memquota 0.29.0",
- "tor-protover 0.29.0",
+ "tor-basic-utils",
+ "tor-bytes",
+ "tor-config",
+ "tor-llcrypto",
+ "tor-memquota",
+ "tor-protover",
 ]
 
 [[package]]
@@ -12256,7 +11344,7 @@ dependencies = [
  "ctr",
  "curve25519-dalek 4.1.3",
  "der-parser 9.0.0",
- "derive-deftly 0.14.6",
+ "derive-deftly",
  "derive_more 1.0.0",
  "digest 0.10.7",
  "ed25519-dalek 2.1.1",
@@ -12273,47 +11361,7 @@ dependencies = [
  "signature 2.2.0",
  "subtle",
  "thiserror 2.0.12",
- "tor-memquota 0.25.0",
- "visibility",
- "x25519-dalek",
- "zeroize",
-]
-
-[[package]]
-name = "tor-llcrypto"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "057afeb075f0689c40465646a1b7671baffebd3c8dd40e62ed5013a5ab157e76"
-dependencies = [
- "aes",
- "base64ct",
- "ctr",
- "curve25519-dalek 4.1.3",
- "der-parser 10.0.0",
- "derive-deftly 1.0.1",
- "derive_more 2.0.1",
- "digest 0.10.7",
- "ed25519-dalek 2.1.1",
- "educe",
- "getrandom 0.3.3",
- "hex",
- "once_cell",
- "rand 0.9.1",
- "rand_chacha 0.9.0",
- "rand_core 0.6.4",
- "rand_core 0.9.3",
- "rand_jitter",
- "rdrand",
- "rsa",
- "safelog",
- "serde",
- "sha1",
- "sha2 0.10.9",
- "sha3",
- "signature 2.2.0",
- "subtle",
- "thiserror 2.0.12",
- "tor-memquota 0.29.0",
+ "tor-memquota",
  "visibility",
  "x25519-dalek",
  "zeroize",
@@ -12329,24 +11377,8 @@ dependencies = [
  "humantime",
  "once_cell",
  "thiserror 2.0.12",
- "tor-error 0.25.0",
- "tor-rtcompat 0.25.0",
- "tracing",
- "weak-table",
-]
-
-[[package]]
-name = "tor-log-ratelim"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b4f7d6adb39d73c414e891b37abd380a1e1eb1545735da422581128b1a9274"
-dependencies = [
- "futures",
- "humantime",
- "once_cell",
- "thiserror 2.0.12",
- "tor-error 0.29.0",
- "tor-rtcompat 0.29.0",
+ "tor-error",
+ "tor-rtcompat",
  "tracing",
  "weak-table",
 ]
@@ -12357,7 +11389,7 @@ version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9210e16890a34c549cc7ba9cb6c85788c345010c00ef10a0c78853dee9910b38"
 dependencies = [
- "derive-deftly 0.14.6",
+ "derive-deftly",
  "derive_more 1.0.0",
  "dyn-clone",
  "educe",
@@ -12369,40 +11401,12 @@ dependencies = [
  "slotmap-careful",
  "static_assertions",
  "thiserror 2.0.12",
- "tor-async-utils 0.25.0",
- "tor-basic-utils 0.25.0",
- "tor-config 0.25.0",
- "tor-error 0.25.0",
- "tor-log-ratelim 0.25.0",
- "tor-rtcompat 0.25.0",
- "tracing",
- "void",
-]
-
-[[package]]
-name = "tor-memquota"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c86c061032e8d1b2922016fbe40b48a967dc7a3c09cd5bb0e3a33a00dad210ef"
-dependencies = [
- "derive-deftly 1.0.1",
- "derive_more 2.0.1",
- "dyn-clone",
- "educe",
- "futures",
- "itertools 0.14.0",
- "paste",
- "pin-project",
- "serde",
- "slotmap-careful",
- "static_assertions",
- "thiserror 2.0.12",
- "tor-async-utils 0.29.0",
- "tor-basic-utils 0.29.0",
- "tor-config 0.29.0",
- "tor-error 0.29.0",
- "tor-log-ratelim 0.29.0",
- "tor-rtcompat 0.29.0",
+ "tor-async-utils",
+ "tor-basic-utils",
+ "tor-config",
+ "tor-error",
+ "tor-log-ratelim",
+ "tor-rtcompat",
  "tracing",
  "void",
 ]
@@ -12416,7 +11420,9 @@ dependencies = [
  "async-trait",
  "bitflags 2.9.1",
  "derive_more 1.0.0",
+ "digest 0.10.7",
  "futures",
+ "hex",
  "humantime",
  "itertools 0.13.0",
  "num_enum",
@@ -12425,46 +11431,15 @@ dependencies = [
  "static_assertions",
  "strum 0.26.3",
  "thiserror 2.0.12",
- "tor-basic-utils 0.25.0",
- "tor-error 0.25.0",
- "tor-linkspec 0.25.0",
- "tor-llcrypto 0.25.0",
- "tor-netdoc 0.25.0",
- "tor-protover 0.25.0",
- "tor-units 0.25.0",
- "tracing",
- "typed-index-collections",
-]
-
-[[package]]
-name = "tor-netdir"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a7a1ff78d5bc186836ffe50012dfdd7e9a137a692201d5e8dd204df2c1f608"
-dependencies = [
- "async-trait",
- "bitflags 2.9.1",
- "derive_more 2.0.1",
- "digest 0.10.7",
- "futures",
- "hex",
- "humantime",
- "itertools 0.14.0",
- "num_enum",
- "rand 0.9.1",
- "serde",
- "static_assertions",
- "strum 0.27.1",
- "thiserror 2.0.12",
  "time 0.3.41",
- "tor-basic-utils 0.29.0",
- "tor-error 0.29.0",
- "tor-hscrypto 0.29.0",
- "tor-linkspec 0.29.0",
- "tor-llcrypto 0.29.0",
- "tor-netdoc 0.29.0",
- "tor-protover 0.29.0",
- "tor-units 0.29.0",
+ "tor-basic-utils",
+ "tor-error",
+ "tor-hscrypto",
+ "tor-linkspec",
+ "tor-llcrypto",
+ "tor-netdoc",
+ "tor-protover",
+ "tor-units",
  "tracing",
  "typed-index-collections",
 ]
@@ -12488,6 +11463,7 @@ dependencies = [
  "itertools 0.13.0",
  "once_cell",
  "phf 0.11.3",
+ "rand 0.8.5",
  "serde",
  "serde_with 3.13.0",
  "signature 2.2.0",
@@ -12496,59 +11472,17 @@ dependencies = [
  "thiserror 2.0.12",
  "time 0.3.41",
  "tinystr",
- "tor-basic-utils 0.25.0",
- "tor-bytes 0.25.0",
- "tor-cell 0.25.0",
- "tor-cert 0.25.0",
- "tor-checkable 0.25.0",
- "tor-error 0.25.0",
- "tor-llcrypto 0.25.0",
- "tor-protover 0.25.0",
- "void",
- "weak-table",
- "zeroize",
-]
-
-[[package]]
-name = "tor-netdoc"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bafcb9dc0ac3ef8ab6e2006ab892699797cb8381e18a0248e138027a6817c8b"
-dependencies = [
- "amplify",
- "base64ct",
- "bitflags 2.9.1",
- "cipher",
- "derive_builder_fork_arti",
- "derive_more 2.0.1",
- "digest 0.10.7",
- "educe",
- "hex",
- "humantime",
- "itertools 0.14.0",
- "memchr",
- "once_cell",
- "phf 0.11.3",
- "rand 0.9.1",
- "serde",
- "serde_with 3.13.0",
- "signature 2.2.0",
- "smallvec",
- "subtle",
- "thiserror 2.0.12",
- "time 0.3.41",
- "tinystr",
- "tor-basic-utils 0.29.0",
- "tor-bytes 0.29.0",
- "tor-cell 0.29.0",
- "tor-cert 0.29.0",
- "tor-checkable 0.29.0",
- "tor-error 0.29.0",
- "tor-hscrypto 0.29.0",
- "tor-linkspec 0.29.0",
- "tor-llcrypto 0.29.0",
- "tor-protover 0.29.0",
- "tor-units 0.29.0",
+ "tor-basic-utils",
+ "tor-bytes",
+ "tor-cell",
+ "tor-cert",
+ "tor-checkable",
+ "tor-error",
+ "tor-hscrypto",
+ "tor-linkspec",
+ "tor-llcrypto",
+ "tor-protover",
+ "tor-units",
  "void",
  "weak-table",
  "zeroize",
@@ -12560,11 +11494,13 @@ version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d30502ee9a3652ac37e9bba74959fa763a16b096e34c45b8e91b297f0e2d458"
 dependencies = [
- "derive-deftly 0.14.6",
+ "amplify",
+ "derive-deftly",
  "derive_more 1.0.0",
  "filetime",
- "fs-mistrust 0.8.3",
+ "fs-mistrust",
  "fslock",
+ "fslock-guard",
  "futures",
  "itertools 0.13.0",
  "oneshot-fused-workaround",
@@ -12574,38 +11510,9 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.12",
  "time 0.3.41",
- "tor-async-utils 0.25.0",
- "tor-basic-utils 0.25.0",
- "tor-error 0.25.0",
- "tracing",
- "void",
-]
-
-[[package]]
-name = "tor-persist"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a245023c2109228264d03ef7c1c549e41052b9a2a8b193acb8f98d82ad5982bf"
-dependencies = [
- "amplify",
- "derive-deftly 1.0.1",
- "derive_more 2.0.1",
- "filetime",
- "fs-mistrust 0.9.3",
- "fslock",
- "fslock-guard",
- "futures",
- "itertools 0.14.0",
- "oneshot-fused-workaround",
- "paste",
- "sanitize-filename",
- "serde",
- "serde_json",
- "thiserror 2.0.12",
- "time 0.3.41",
- "tor-async-utils 0.29.0",
- "tor-basic-utils 0.29.0",
- "tor-error 0.29.0",
+ "tor-async-utils",
+ "tor-basic-utils",
+ "tor-error",
  "tracing",
  "void",
 ]
@@ -12621,7 +11528,7 @@ dependencies = [
  "bytes",
  "cipher",
  "coarsetime",
- "derive-deftly 0.14.6",
+ "derive-deftly",
  "derive_builder_fork_arti",
  "derive_more 1.0.0",
  "digest 0.10.7",
@@ -12638,76 +11545,22 @@ dependencies = [
  "thiserror 2.0.12",
  "tokio",
  "tokio-util",
- "tor-async-utils 0.25.0",
- "tor-basic-utils 0.25.0",
- "tor-bytes 0.25.0",
- "tor-cell 0.25.0",
- "tor-cert 0.25.0",
- "tor-checkable 0.25.0",
- "tor-config 0.25.0",
- "tor-error 0.25.0",
- "tor-linkspec 0.25.0",
- "tor-llcrypto 0.25.0",
- "tor-log-ratelim 0.25.0",
- "tor-memquota 0.25.0",
- "tor-rtcompat 0.25.0",
- "tor-rtmock 0.25.0",
- "tor-units 0.25.0",
- "tracing",
- "typenum",
- "void",
- "zeroize",
-]
-
-[[package]]
-name = "tor-proto"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ea421e41f1e2cc5ac8b990610d0a69a330532a863b344c44812a815af25811a"
-dependencies = [
- "amplify",
- "asynchronous-codec 0.7.0",
- "bitvec",
- "bytes",
- "caret",
- "cipher",
- "coarsetime",
- "derive-deftly 1.0.1",
- "derive_builder_fork_arti",
- "derive_more 2.0.1",
- "digest 0.10.7",
- "educe",
- "futures",
- "futures-util",
- "hkdf",
- "hmac",
- "oneshot-fused-workaround",
- "pin-project",
- "rand 0.9.1",
- "rand_core 0.9.3",
- "safelog",
- "slotmap-careful",
- "static_assertions",
- "subtle",
- "thiserror 2.0.12",
- "tokio",
- "tokio-util",
- "tor-async-utils 0.29.0",
- "tor-basic-utils 0.29.0",
- "tor-bytes 0.29.0",
- "tor-cell 0.29.0",
- "tor-cert 0.29.0",
- "tor-checkable 0.29.0",
- "tor-config 0.29.0",
- "tor-error 0.29.0",
- "tor-hscrypto 0.29.0",
- "tor-linkspec 0.29.0",
- "tor-llcrypto 0.29.0",
- "tor-log-ratelim 0.29.0",
- "tor-memquota 0.29.0",
- "tor-rtcompat 0.29.0",
- "tor-rtmock 0.29.0",
- "tor-units 0.29.0",
+ "tor-async-utils",
+ "tor-basic-utils",
+ "tor-bytes",
+ "tor-cell",
+ "tor-cert",
+ "tor-checkable",
+ "tor-config",
+ "tor-error",
+ "tor-hscrypto",
+ "tor-linkspec",
+ "tor-llcrypto",
+ "tor-log-ratelim",
+ "tor-memquota",
+ "tor-rtcompat",
+ "tor-rtmock",
+ "tor-units",
  "tracing",
  "typenum",
  "visibility",
@@ -12726,17 +11579,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tor-protover"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a887114e6ed2f2e2b291c16cfcf751e26298fb2be4599b0a44cae47a588dc4ae"
-dependencies = [
- "caret",
- "paste",
- "thiserror 2.0.12",
-]
-
-[[package]]
 name = "tor-relay-selection"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12744,24 +11586,10 @@ checksum = "420da7174f565a75cefb65c3beac5401cca2785d44b192ff2a87edeaddf4d52f"
 dependencies = [
  "rand 0.8.5",
  "serde",
- "tor-basic-utils 0.25.0",
- "tor-linkspec 0.25.0",
- "tor-netdir 0.25.0",
- "tor-netdoc 0.25.0",
-]
-
-[[package]]
-name = "tor-relay-selection"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba0d8a53a12c0fbdb1b842f0705629bacf11ab2c99531a58952c53fa619f830f"
-dependencies = [
- "rand 0.9.1",
- "serde",
- "tor-basic-utils 0.29.0",
- "tor-linkspec 0.29.0",
- "tor-netdir 0.29.0",
- "tor-netdoc 0.29.0",
+ "tor-basic-utils",
+ "tor-linkspec",
+ "tor-netdir",
+ "tor-netdoc",
 ]
 
 [[package]]
@@ -12784,42 +11612,11 @@ dependencies = [
  "thiserror 2.0.12",
  "tokio",
  "tokio-util",
- "tor-error 0.25.0",
- "tor-general-addr 0.25.0",
+ "tor-error",
+ "tor-general-addr",
  "tracing",
  "void",
  "x509-signature",
-]
-
-[[package]]
-name = "tor-rtcompat"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f62271c3dcae0a80cea669d37ea6e45fc60d5a59b48b9a4fb2caeb8346e3be4"
-dependencies = [
- "async-trait",
- "async_executors",
- "asynchronous-codec 0.7.0",
- "coarsetime",
- "derive_more 2.0.1",
- "dyn-clone",
- "educe",
- "futures",
- "futures-rustls 0.26.0",
- "hex",
- "libc",
- "paste",
- "pin-project",
- "rustls 0.23.28",
- "rustls-pki-types",
- "rustls-webpki 0.103.3",
- "thiserror 2.0.12",
- "tokio",
- "tokio-util",
- "tor-error 0.29.0",
- "tor-general-addr 0.29.0",
- "tracing",
- "void",
 ]
 
 [[package]]
@@ -12830,7 +11627,7 @@ checksum = "34efd1ca1ed977e0155cf63df7dc81322970155f299950a1127e80b6bab74192"
 dependencies = [
  "amplify",
  "async-trait",
- "derive-deftly 0.14.6",
+ "derive-deftly",
  "derive_more 1.0.0",
  "educe",
  "futures",
@@ -12842,38 +11639,9 @@ dependencies = [
  "slotmap-careful",
  "strum 0.26.3",
  "thiserror 2.0.12",
- "tor-error 0.25.0",
- "tor-general-addr 0.25.0",
- "tor-rtcompat 0.25.0",
- "tracing",
- "tracing-test",
- "void",
-]
-
-[[package]]
-name = "tor-rtmock"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f85a9db27e18e1141340183249999404ea0dfaead0117e2535705dbed59d04e4"
-dependencies = [
- "amplify",
- "assert_matches",
- "async-trait",
- "derive-deftly 1.0.1",
- "derive_more 2.0.1",
- "educe",
- "futures",
- "humantime",
- "itertools 0.14.0",
- "oneshot-fused-workaround",
- "pin-project",
- "priority-queue",
- "slotmap-careful",
- "strum 0.27.1",
- "thiserror 2.0.12",
- "tor-error 0.29.0",
- "tor-general-addr 0.29.0",
- "tor-rtcompat 0.29.0",
+ "tor-error",
+ "tor-general-addr",
+ "tor-rtcompat",
  "tracing",
  "tracing-test",
  "void",
@@ -12887,30 +11655,13 @@ checksum = "f59ccd382fc36b4414f9b7a9511ffb323573a09110248a338b2443d302bdcd26"
 dependencies = [
  "amplify",
  "caret",
- "derive-deftly 0.14.6",
+ "derive-deftly",
  "educe",
  "safelog",
  "subtle",
  "thiserror 2.0.12",
- "tor-bytes 0.25.0",
- "tor-error 0.25.0",
-]
-
-[[package]]
-name = "tor-socksproto"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9ca35781e3eea82b6b2c1a68c8be87a53157bb6ce6c12401f825745d4fac9b"
-dependencies = [
- "amplify",
- "caret",
- "derive-deftly 1.0.1",
- "educe",
- "safelog",
- "subtle",
- "thiserror 2.0.12",
- "tor-bytes 0.29.0",
- "tor-error 0.29.0",
+ "tor-bytes",
+ "tor-error",
 ]
 
 [[package]]
@@ -12919,22 +11670,10 @@ version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bdeb3e823e4d194227eab21dff65c738c6ce1755a41395538e4e48e04f37c7f"
 dependencies = [
- "derive-deftly 0.14.6",
+ "derive-deftly",
  "derive_more 1.0.0",
  "thiserror 2.0.12",
- "tor-memquota 0.25.0",
-]
-
-[[package]]
-name = "tor-units"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddc10f6c42aa268a8b680e68063f7f26da10fd71200d973659c55328b42845b"
-dependencies = [
- "derive-deftly 1.0.1",
- "derive_more 2.0.1",
- "thiserror 2.0.12",
- "tor-memquota 0.29.0",
+ "tor-memquota",
 ]
 
 [[package]]
@@ -13082,7 +11821,7 @@ checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -13156,7 +11895,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04659ddb06c87d233c566112c1c9c5b9e98256d9af50ec3bc9c8327f873a7568"
 dependencies = [
  "quote",
- "syn 2.0.104",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -13259,7 +11998,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a615d6c2764852a2e88a4f16e9ce1ea49bb776b5872956309e170d63a042a34f"
 dependencies = [
  "quote",
- "syn 2.0.104",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -13459,7 +12198,7 @@ dependencies = [
  "tauri-plugin-updater",
  "tracing",
  "uuid",
- "zip 4.2.0",
+ "zip 4.1.0",
 ]
 
 [[package]]
@@ -13591,7 +12330,7 @@ checksum = "d674d135b4a8c1d7e813e2f8d1c9a58308aee4a680323066025e53132218bd91"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -13712,7 +12451,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.103",
  "wasm-bindgen-shared",
 ]
 
@@ -13747,7 +12486,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.103",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -13781,7 +12520,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe770181423e5fc79d3e2a7f4410b7799d5aab1de4372853de3c6aa13ca24121"
 dependencies = [
  "cc",
- "downcast-rs 1.2.1",
+ "downcast-rs",
  "rustix 0.38.44",
  "smallvec",
  "wayland-sys",
@@ -13998,7 +12737,7 @@ checksum = "1d228f15bba3b9d56dde8bddbee66fa24545bd17b48d5128ccf4a8742b18e431"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -14017,18 +12756,6 @@ name = "weezl"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a751b3277700db47d3e574514de2eced5e54dc8a5436a3bf7a0b248b2cee16f3"
-
-[[package]]
-name = "which"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
-dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix 0.38.44",
-]
 
 [[package]]
 name = "whoami"
@@ -14188,7 +12915,7 @@ checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -14199,7 +12926,7 @@ checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -14210,7 +12937,7 @@ checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -14221,7 +12948,7 @@ checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -14893,7 +13620,7 @@ checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.103",
  "synstructure 0.13.2",
 ]
 
@@ -14940,7 +13667,7 @@ dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.103",
  "zbus_names",
  "zvariant",
  "zvariant_utils",
@@ -14975,7 +13702,7 @@ checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -14995,7 +13722,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.103",
  "synstructure 0.13.2",
 ]
 
@@ -15016,7 +13743,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -15049,7 +13776,7 @@ checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.103",
 ]
 
 [[package]]
@@ -15068,9 +13795,9 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "4.2.0"
+version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95ab361742de920c5535880f89bbd611ee62002bf11341d16a5f057bb8ba6899"
+checksum = "af7dcdb4229c0e79c2531a24de7726a0e980417a74fb4d030a35f535665439a0"
 dependencies = [
  "aes",
  "arbitrary",
@@ -15162,7 +13889,7 @@ dependencies = [
  "proc-macro-crate 3.3.0",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.103",
  "zvariant_utils",
 ]
 
@@ -15176,6 +13903,6 @@ dependencies = [
  "quote",
  "serde",
  "static_assertions",
- "syn 2.0.104",
+ "syn 2.0.103",
  "winnow 0.7.11",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ opt-level = 0
 [patch.crates-io]
 # patch until new release https://github.com/thomaseizinger/rust-jsonrpc-client/pull/51
 jsonrpc_client = { git = "https://github.com/delta1/rust-jsonrpc-client.git", rev = "3b6081697cd616c952acb9c2f02d546357d35506" }
+monero = { git = "https://github.com/comit-network/monero-rs", rev = "818f38b" }
 
 # patch until new release https://github.com/bitcoindevkit/bdk/pull/1766
 bdk_wallet = { git = "https://github.com/Einliterflasche/bdk", branch = "bump/rusqlite-0.32", package = "bdk_wallet" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["monero-rpc", "monero-rpc-pool", "monero-sys", "src-tauri", "swap"]
+members = ["monero-rpc", "monero-rpc-pool", "monero-sys", "src-tauri", "swap", "electrum-pool"]
 
 [profile.release]
 opt-level = 0

--- a/electrum-pool/Cargo.toml
+++ b/electrum-pool/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "electrum-pool"
+version = "0.1.0"
+edition = "2021"
+authors = ["UnstoppableSwap Team <help@unstoppableswap.net>"]
+
+[dependencies]
+backoff = { version = "0.4", features = ["tokio"] }
+bdk_electrum = { version = "0.19", default-features = false, features = ["use-rustls-ring"] }
+bitcoin = { version = "0.32", features = ["rand", "serde"] }
+futures = { version = "0.3", default-features = false, features = ["std"] }
+once_cell = "1.19"
+tokio = { version = "1", features = ["rt-multi-thread", "time", "macros", "sync"] }
+tracing = { version = "0.1", features = ["attributes"] }
+
+[dev-dependencies]
+serde_json = "1"

--- a/electrum-pool/src/lib.rs
+++ b/electrum-pool/src/lib.rs
@@ -197,7 +197,7 @@ where
         &self,
         kind: &str,
         f: F,
-    ) -> Result<T, crate::bitcoin::electrum_balancer::MultiError>
+    ) -> Result<T, MultiError>
     where
         F: Fn(&C) -> Result<T, Error> + Send + Sync + Clone + 'static,
         T: Send + 'static,

--- a/src-gui/package.json
+++ b/src-gui/package.json
@@ -4,9 +4,9 @@
   "version": "0.7.0",
   "type": "module",
   "scripts": {
-    "check-bindings": "typeshare --lang=typescript --output-file __temp_bindings.ts ../swap/src ../monero-rpc-pool/src && dprint fmt __temp_bindings.ts && diff -wbB __temp_bindings.ts ./src/models/tauriModel.ts && rm __temp_bindings.ts",
-    "gen-bindings-verbose": "RUST_LOG=debug RUST_BACKTRACE=1 typeshare --lang=typescript --output-file ./src/models/tauriModel.ts ../swap/src ../monero-rpc-pool/src && dprint fmt ./src/models/tauriModel.ts",
-    "gen-bindings": "typeshare --lang=typescript --output-file ./src/models/tauriModel.ts ../swap/src ../monero-rpc-pool/src && dprint fmt ./src/models/tauriModel.ts",
+    "check-bindings": "typeshare --lang=typescript --output-file __temp_bindings.ts ../swap/src ../monero-rpc-pool/src ../electrum-pool/src && dprint fmt __temp_bindings.ts && diff -wbB __temp_bindings.ts ./src/models/tauriModel.ts && rm __temp_bindings.ts",
+    "gen-bindings-verbose": "RUST_LOG=debug RUST_BACKTRACE=1 typeshare --lang=typescript --output-file ./src/models/tauriModel.ts ../swap/src ../monero-rpc-pool/src ../electrum-pool/src && dprint fmt ./src/models/tauriModel.ts",
+    "gen-bindings": "typeshare --lang=typescript --output-file ./src/models/tauriModel.ts ../swap/src ../monero-rpc-pool/src ../electrum-pool/src && dprint fmt ./src/models/tauriModel.ts",
     "test": "vitest",
     "test:ui": "vitest --ui",
     "dev": "vite",

--- a/swap/Cargo.toml
+++ b/swap/Cargo.toml
@@ -13,7 +13,7 @@ tauri = ["dep:tauri"]
 
 [dependencies]
 anyhow = "1"
-arti-client = { version = "0.25.0", features = ["static-sqlite", "tokio", "rustls"], default-features = false }
+arti-client = { version = "0.25.0", features = ["static-sqlite", "tokio", "rustls", "onion-service-service"], default-features = false }
 async-compression = { version = "0.3", features = ["bzip2", "tokio"] }
 async-trait = "0.1"
 asynchronous-codec = "0.7.0"
@@ -40,9 +40,9 @@ ed25519-dalek = "1"
 futures = { version = "0.3", default-features = false, features = ["std"] }
 hex = "0.4"
 libp2p = { version = "0.53.2", features = ["tcp", "yamux", "dns", "noise", "request-response", "ping", "rendezvous", "identify", "macros", "cbor", "json", "tokio", "serde", "rsa"] }
-libp2p-community-tor = { git = "https://github.com/umgefahren/libp2p-tor", branch = "main", features = ["listen-onion-service"] }
+libp2p-community-tor = { git = "https://github.com/umgefahren/libp2p-tor", rev = "e6b913e0f1ac1fc90b3ee4dd31b5511140c4a9af", features = ["listen-onion-service"] }
 moka = { version = "0.12", features = ["sync", "future"] }
-monero = { version = "0.21" }
+monero = { version = "0.12", features = ["serde_support"] }
 monero-rpc = { path = "../monero-rpc" }
 monero-rpc-pool = { path = "../monero-rpc-pool" }
 monero-sys = { path = "../monero-sys" }

--- a/swap/Cargo.toml
+++ b/swap/Cargo.toml
@@ -46,6 +46,7 @@ monero = { version = "0.21" }
 monero-rpc = { path = "../monero-rpc" }
 monero-rpc-pool = { path = "../monero-rpc-pool" }
 monero-sys = { path = "../monero-sys" }
+electrum-pool = { path = "../electrum-pool" }
 once_cell = "1.19"
 pem = "3.0"
 proptest = "1"

--- a/swap/src/bitcoin.rs
+++ b/swap/src/bitcoin.rs
@@ -1,4 +1,3 @@
-pub mod electrum_balancer;
 pub mod wallet;
 
 mod cancel;
@@ -458,7 +457,7 @@ impl From<RpcErrorCode> for i64 {
 
 pub fn parse_rpc_error_code(error: &anyhow::Error) -> anyhow::Result<i64> {
     // First try to extract an Electrum error from a MultiError if present
-    if let Some(multi_error) = error.downcast_ref::<crate::bitcoin::electrum_balancer::MultiError>()
+    if let Some(multi_error) = error.downcast_ref::<electrum_pool::MultiError>()
     {
         // Try to find the first Electrum error in the MultiError
         for single_error in multi_error.iter() {

--- a/swap/src/bitcoin/wallet.rs
+++ b/swap/src/bitcoin/wallet.rs
@@ -41,7 +41,7 @@ use tracing::{debug_span, Instrument};
 
 use super::bitcoin_address::revalidate_network;
 use super::BlockHeight;
-use crate::bitcoin::electrum_balancer::ElectrumBalancer;
+use electrum_pool::ElectrumBalancer;
 use derive_builder::Builder;
 use moka;
 
@@ -754,7 +754,7 @@ impl Wallet {
                 kind, txid, total_count
             );
 
-            let multi_error = crate::bitcoin::electrum_balancer::MultiError::new(errors, context);
+            let multi_error = electrum_pool::MultiError::new(errors, context);
             return Err(anyhow::Error::from(multi_error));
         }
 


### PR DESCRIPTION
## Summary
- add electrum-pool workspace member
- extract electrum balancer into new crate
- depend on electrum-pool in swap and update workspace members
- update typeshare bindings to include electrum-pool
- document new crate in CHANGELOG

## Testing
- `cargo generate-lockfile` *(fails: couldn't fetch monero-sys submodule)*

------
https://chatgpt.com/codex/tasks/task_b_685953daa4c4832c8509f7c15cf54630