### PR TITLE
fix(cli, gui): Use 0-1 for address pool

### DIFF
--- a/swap/migrations/20250625160448_scale_monero_pool_to_0_to_1_if_above_1.sql
+++ b/swap/migrations/20250625160448_scale_monero_pool_to_0_to_1_if_above_1.sql
@@ -1,0 +1,11 @@
+-- Fix percentage values that are stored as 0-100 instead of 0-1
+-- This migration converts percentage values for swap_ids where the sum > 1.0
+-- by scaling all percentages for that swap_id by dividing by 100
+UPDATE monero_addresses 
+SET percentage = percentage / 100.0 
+WHERE swap_id IN (
+    SELECT swap_id 
+    FROM monero_addresses 
+    GROUP BY swap_id 
+    HAVING SUM(percentage) > 1.0
+); 

--- a/swap/src/monero.rs
+++ b/swap/src/monero.rs
@@ -307,7 +307,7 @@ impl MoneroAddressPool {
         self.0.iter().map(|address| address.address()).collect()
     }
 
-    /// Returns a vector of all percentages as f64 values.
+    /// Returns a vector of all percentages as f64 values (0-1 range).
     pub fn percentages(&self) -> Vec<f64> {
         self.0
             .iter()
@@ -903,10 +903,11 @@ mod tests {
 
         let address = "53gEuGZUhP9JMEBZoGaFNzhwEgiG7hwQdMCqFxiyiTeFPmkbt1mAoNybEUvYBKHcnrSgxnVWgZsTvRBaHBNXPa8tHiCU51a".parse().unwrap();
 
-        // Valid percentages should work
+        // Valid percentages should work (0-1 range)
         assert!(LabeledMoneroAddress::new(address, Decimal::ZERO, "test".to_string()).is_ok());
         assert!(LabeledMoneroAddress::new(address, Decimal::ONE, "test".to_string()).is_ok());
         assert!(LabeledMoneroAddress::new(address, Decimal::new(5, 1), "test".to_string()).is_ok()); // 0.5
+        assert!(LabeledMoneroAddress::new(address, Decimal::new(9925, 4), "test".to_string()).is_ok()); // 0.9925
 
         // Invalid percentages should fail
         assert!(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected logic and validation for Monero balance distribution to use ratios summing to 1.0 instead of percentages summing to 100.0.
	- Fixed stored percentage values in the database to ensure they are properly normalized between 0 and 1.

- **Documentation**
	- Updated documentation and comments to clarify that percentage values are now expected in the 0-1 range.

- **Tests**
	- Adjusted test cases to use ratios in the 0-1 range and added a test for high-precision values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->