### PR TITLE
feat(asb): Automatic Output Management

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -73,7 +73,10 @@
         "shared_mutex": "cpp",
         "source_location": "cpp",
         "strstream": "cpp",
-        "typeindex": "cpp"
+        "typeindex": "cpp",
+        "hash_map": "cpp",
+        "hash_set": "cpp",
+        "*.ipp": "cpp"
     },
     "rust-analyzer.cargo.extraEnv": {
         "CARGO_TARGET_DIR": "target-check"

--- a/monero-harness/src/lib.rs
+++ b/monero-harness/src/lib.rs
@@ -483,7 +483,7 @@ impl MoneroWallet {
         );
         let amount = Amount::from_pico(amount_pico);
         self.wallet
-            .transfer(address, amount)
+            .transfer(address, amount, false)
             .await
             .context("Failed to perform transfer")
     }

--- a/monero-sys/src/bridge.h
+++ b/monero-sys/src/bridge.h
@@ -160,22 +160,22 @@ namespace Monero
         // Build the actual multi‐dest transaction
         // No change left -> wallet drops it
         // N outputs, fee should be the same as the one estimated above
-        
+
         // Find the highest output and choose it for subtract_fee_indices
         std::set<uint32_t> subtract_fee_indices;
         auto max_it = std::max_element(amounts.begin(), amounts.end());
         size_t max_index = std::distance(amounts.begin(), max_it);
         subtract_fee_indices.insert(static_cast<uint32_t>(max_index));
-        
+
         return wallet.createTransactionMultDest(
             dest_addresses,
             "", // No Payment ID
             Monero::optional<std::vector<uint64_t>>(amounts),
             0, // No mixin count
             PendingTransaction::Priority_Default,
-            0, // subaddr_account
+            0,  // subaddr_account
             {}, // subaddr_indices
-            subtract_fee_indices); // Subtract fee from all outputs
+            subtract_fee_indices);
     }
 
     inline bool setWalletDaemon(Wallet &wallet, const std::string &daemon_address)

--- a/monero-sys/src/bridge.rs
+++ b/monero-sys/src/bridge.rs
@@ -1,7 +1,7 @@
 //! This module contains the bridge between the Monero C++ API and the Rust code.
 //! It uses the [cxx](https://cxx.rs) crate to generate the actual bindings.
 
-use cxx::CxxString;
+use cxx::{CxxString, CxxVector, UniquePtr};
 use tracing::Level;
 
 /// This is the main ffi module that exposes the Monero C++ API to Rust.
@@ -270,6 +270,7 @@ pub mod ffi {
             self: Pin<&mut Wallet>,
             tx: *mut PendingTransaction,
         ) -> Result<()>;
+
     }
 }
 

--- a/monero-sys/tests/simple.rs
+++ b/monero-sys/tests/simple.rs
@@ -62,7 +62,7 @@ async fn main() {
     tracing::info!("Transferring 1 XMR to ourselves");
 
     wallet
-        .transfer(&wallet.main_address().await, transfer_amount)
+        .transfer(&wallet.main_address().await, transfer_amount, false)
         .await
         .unwrap();
 

--- a/swap/src/protocol/alice/swap.rs
+++ b/swap/src/protocol/alice/swap.rs
@@ -163,7 +163,7 @@ where
                     let receipt = monero_wallet
                         .main_wallet()
                         .await
-                        .transfer(&address, amount)
+                        .transfer(&address, amount, true)
                         .await
                         .map_err(|e| tracing::error!(err=%e, "Failed to lock Monero"))
                         .ok();


### PR DESCRIPTION
Closes #120. On every Monero lock transaction, we split the change output into multiple smaller ones. This avoids unnecessarily blocking funds for 10 minutes.