### PR TITLE
Add mobile more button with action bottom sheet

### DIFF
--- a/src-gui/src/renderer/components/modal/SwipeableActionBottomSheet.tsx
+++ b/src-gui/src/renderer/components/modal/SwipeableActionBottomSheet.tsx
@@ -1,0 +1,137 @@
+import React, { useState } from "react";
+import {
+  SwipeableDrawer,
+  List,
+  ListItem,
+  ListItemIcon,
+  ListItemText,
+  Box,
+  Typography,
+  IconButton,
+  useTheme,
+} from "@mui/material";
+import CloseIcon from "@mui/icons-material/Close";
+import AccountBalanceWalletIcon from "@mui/icons-material/AccountBalanceWallet";
+import RestoreIcon from "@mui/icons-material/Restore";
+import WithdrawDialog from "./wallet/WithdrawDialog";
+import SetRestoreHeightModal from "../pages/monero/SetRestoreHeightModal";
+import { useIsMobile } from "../../../utils/useIsMobile";
+
+interface SwipeableActionBottomSheetProps {
+  open: boolean;
+  onOpen: () => void;
+  onClose: () => void;
+}
+
+export default function SwipeableActionBottomSheet({
+  open,
+  onOpen,
+  onClose,
+}: SwipeableActionBottomSheetProps) {
+  const theme = useTheme();
+  const isMobile = useIsMobile();
+  const [withdrawDialogOpen, setWithdrawDialogOpen] = useState(false);
+  const [restoreHeightDialogOpen, setRestoreHeightDialogOpen] = useState(false);
+
+  const handleWithdrawClick = () => {
+    onClose();
+    setWithdrawDialogOpen(true);
+  };
+
+  const handleRestoreHeightClick = () => {
+    onClose();
+    setRestoreHeightDialogOpen(true);
+  };
+
+  // Only show on mobile
+  if (!isMobile) {
+    return null;
+  }
+
+  const actions = [
+    {
+      id: "withdraw-bitcoin",
+      label: "Withdraw Bitcoin",
+      icon: <AccountBalanceWalletIcon />,
+      onClick: handleWithdrawClick,
+    },
+    {
+      id: "restore-height",
+      label: "Restore Height",
+      icon: <RestoreIcon />,
+      onClick: handleRestoreHeightClick,
+    },
+  ];
+
+  return (
+    <>
+      <SwipeableDrawer
+        anchor="bottom"
+        open={open}
+        onClose={onClose}
+        onOpen={onOpen}
+        swipeAreaWidth={56}
+        disableSwipeToOpen={false}
+        sx={{
+          "& .MuiDrawer-paper": {
+            borderTopLeftRadius: 16,
+            borderTopRightRadius: 16,
+            maxHeight: "50vh",
+          },
+        }}
+      >
+        <Box
+          sx={{
+            px: 2,
+            py: 1,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            borderBottom: `1px solid ${theme.palette.divider}`,
+          }}
+        >
+          <Typography variant="h6" component="div">
+            More Actions
+          </Typography>
+          <IconButton
+            edge="end"
+            onClick={onClose}
+            aria-label="close"
+            size="small"
+          >
+            <CloseIcon />
+          </IconButton>
+        </Box>
+        
+        <List sx={{ py: 0 }}>
+          {actions.map((action) => (
+            <ListItem
+              key={action.id}
+              onClick={action.onClick}
+              sx={{
+                cursor: "pointer",
+                "&:hover": {
+                  backgroundColor: theme.palette.action.hover,
+                },
+                py: 2,
+              }}
+            >
+              <ListItemIcon>{action.icon}</ListItemIcon>
+              <ListItemText primary={action.label} />
+            </ListItem>
+          ))}
+        </List>
+      </SwipeableDrawer>
+
+      {/* Dialogs */}
+      <WithdrawDialog
+        open={withdrawDialogOpen}
+        onClose={() => setWithdrawDialogOpen(false)}
+      />
+      <SetRestoreHeightModal
+        open={restoreHeightDialogOpen}
+        onClose={() => setRestoreHeightDialogOpen(false)}
+      />
+    </>
+  );
+}

--- a/src-gui/src/renderer/layout/mobile/pages/HomePage.tsx
+++ b/src-gui/src/renderer/layout/mobile/pages/HomePage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import {
   Box,
   Typography,
@@ -15,7 +15,7 @@ import SettingsIcon from "@mui/icons-material/Settings";
 import ArrowDownwardIcon from "@mui/icons-material/ArrowDownward";
 import ArrowUpwardIcon from "@mui/icons-material/ArrowUpward";
 import SwapHorizIcon from "@mui/icons-material/SwapHoriz";
-import MoreHorizIcon from "@mui/icons-material/MoreHoriz";
+import MoreVertIcon from "@mui/icons-material/MoreVert";
 import HelpOutlineIcon from "@mui/icons-material/HelpOutline";
 import AppsIcon from "@mui/icons-material/Apps";
 import { useAppSelector } from "store/hooks";
@@ -39,6 +39,7 @@ import ReceiveButton from "renderer/components/features/wallet/ReceiveButton.mob
 import SendButton from "renderer/components/features/wallet/SendButton.mobile";
 import DFXButton from "renderer/components/pages/monero/components/DFXWidget";
 import { useNavigate } from "react-router-dom";
+import SwipeableActionBottomSheet from "renderer/components/modal/SwipeableActionBottomSheet";
 
 /**
  * Mobile HomePage - displays wallet overview with real balance and transaction data
@@ -50,6 +51,7 @@ export default function HomePage() {
     (state) => state.wallet.state,
   );
   const bitcoinBalance = useAppSelector((state) => state.rpc.state.balance);
+  const [bottomSheetOpen, setBottomSheetOpen] = useState(false);
 
   const isLoading = balance === null;
   const hasTransactions =
@@ -88,6 +90,13 @@ export default function HomePage() {
             sx={{ ml: 0.5, verticalAlign: "middle" }}
           />
         </Typography>
+        <IconButton
+          size="small"
+          color="inherit"
+          onClick={() => setBottomSheetOpen(true)}
+        >
+          <MoreVertIcon />
+        </IconButton>
         <IconButton
           size="small"
           color="inherit"
@@ -173,6 +182,13 @@ export default function HomePage() {
       >
         <HelpOutlineIcon />
       </IconButton>
+
+      {/* Mobile Action Bottom Sheet */}
+      <SwipeableActionBottomSheet
+        open={bottomSheetOpen}
+        onOpen={() => setBottomSheetOpen(true)}
+        onClose={() => setBottomSheetOpen(false)}
+      />
     </Box>
   );
 }


### PR DESCRIPTION
Add a mobile-only "More" button with a swipeable bottom sheet for quick access to "Withdraw Bitcoin" and "Restore Height" actions.

---
<a href="https://cursor.com/background-agent?bcId=bc-da82c4ac-a5cf-4f7e-a3fc-39b40d829a6a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-da82c4ac-a5cf-4f7e-a3fc-39b40d829a6a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

