### PR TITLE
feat(env): Temporarily require 12 Monero confirmations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ASB + CONTROLLER: Add a `monero_seed` command to the controller shell. You can use it to export the seed and restore height of the internal Monero wallet. You can use those to import the wallet into a wallet software of your own choosing.
 - GUI: You can now change the Monero Node without having to restart.
 - GUI: You can now export the seed phrase of the Monero wallet.
+- GUI + CLI: Temporarily require a minimum of 12 confirmations for Monero transactions. Just a pre-caution given the Qubic shenanigans.
 
 ## [3.0.0-beta.8] - 2025-08-10
 

--- a/swap-env/src/env.rs
+++ b/swap-env/src/env.rs
@@ -60,8 +60,8 @@ impl GetConfig for Mainnet {
             // If Alice cannot lock her Monero within this timeout,
             // she will initiate an early refund of Bobs Bitcoin
             monero_lock_retry_timeout: 10.std_minutes(),
-            monero_finality_confirmations: 10,
-            monero_double_spend_safe_confirmations: 2,
+            monero_finality_confirmations: 12,
+            monero_double_spend_safe_confirmations: 12,
             monero_network: monero::Network::Mainnet,
         }
     }
@@ -79,8 +79,8 @@ impl GetConfig for Testnet {
             bitcoin_network: bitcoin::Network::Testnet,
             monero_avg_block_time: 2.std_minutes(),
             monero_lock_retry_timeout: 10.std_minutes(),
-            monero_finality_confirmations: 10,
-            monero_double_spend_safe_confirmations: 2,
+            monero_finality_confirmations: 12,
+            monero_double_spend_safe_confirmations: 12,
             monero_network: monero::Network::Stagenet,
         }
     }
@@ -98,8 +98,8 @@ impl GetConfig for Regtest {
             bitcoin_network: bitcoin::Network::Regtest,
             monero_avg_block_time: 1.std_seconds(),
             monero_lock_retry_timeout: 1.std_minutes(),
-            monero_finality_confirmations: 10,
-            monero_double_spend_safe_confirmations: 2,
+            monero_finality_confirmations: 12,
+            monero_double_spend_safe_confirmations: 12,
             monero_network: monero::Network::Mainnet, // yes this is strange
         }
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an Unreleased changelog entry noting that the GUI and CLI now require a minimum of 12 confirmations for Monero transactions.

* **Chores**
  * Increased Monero confirmation thresholds across all environments: finality confirmations raised from 10 to 12, and double-spend-safe confirmations raised from 2 to 12. Users may experience slightly longer waiting times before transactions are considered final in both GUI and CLI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->