### PR TITLE
fix(CI): request libwebkit2gtk=2.44.0-2 to fix AppImages on Fedora ~43

### DIFF
--- a/.github/actions/set-monero-env/action.yml
+++ b/.github/actions/set-monero-env/action.yml
@@ -8,7 +8,8 @@ runs:
       run: |
 
         # GUI-specific Ubuntu dependencies
-        echo "DEPS_GUI_UBUNTU_SPECIFIC=libgtk-3-dev libappindicator3-dev librsvg2-dev libwebkit2gtk-4.1-0 libwebkit2gtk-4.1-dev libjavascriptcoregtk-4.1-0 libjavascriptcoregtk-4.1-dev gir1.2-javascriptcoregtk-4.1 gir1.2-webkit2-4.1" >> $GITHUB_ENV
+        grep -q noble /etc/os-release && pin==2.44.0-2 || pin=
+        echo "DEPS_GUI_UBUNTU_SPECIFIC=libgtk-3-dev libappindicator3-dev librsvg2-dev" {libwebkit2gtk-4.1-0,libwebkit2gtk-4.1-dev,libjavascriptcoregtk-4.1-0,libjavascriptcoregtk-4.1-dev,gir1.2-javascriptcoregtk-4.1,gir1.2-webkit2-4.1}"$pin" >> $GITHUB_ENV
 
         # Build tooling (Linux)
         echo "DEPS_BUILD_LINUX=autoconf nsis mingw-w64 build-essential pkg-config libtool ccache make cmake gcc g++ git curl lbzip2 gperf g++-mingw-w64-x86-64" >> $GITHUB_ENV


### PR DESCRIPTION
The CI builds the GUI on ubuntu noble, which contains 2.44.0-2 in universe and 2.48.7-0ubuntu0.24.04.2 in security. Naturally, the bigger version is picked by default.

The same thing happens when building on bookworm (2.48.1-2~deb12u1).

This version causes the GUI to crash just after creating a blank window on some systems (like Fedora 43), yielding no logs and stderr of
```
Could not create default EGL display: EGL_BAD_PARAMETER. Aborting...
```

This is a known issue in the Tauri/AppImage world, and downgrading to 2.44 is likewise a known fix, cf. https://github.com/gitbutlerapp/gitbutler/issues/5282 and all the referencing issues.

On bookworm this can be fixed by installing 2.44.3-1 off snapshot.d.o at 20240909T145608Z.

On noble, we can just ask for the older version, since both are visible.

Closes #594
Closes #582 

Artifact from CI needs to be tested before merging.