### PR TITLE
Embed version into flatpaks. Export them as stable branch from CI

### DIFF
--- a/.github/workflows/build-gui-release-binaries.yml
+++ b/.github/workflows/build-gui-release-binaries.yml
@@ -163,22 +163,19 @@ jobs:
           set -euxo pipefail
 
           deb=$(find "$PWD" -name *.deb -print -quit)
-          read -r sum _ < <(sha256sum "$deb")
-          jq --arg deb_url "file://$deb" --arg deb_sha256 "$sum" '
-            .modules[0].sources = [
-              {
-                "type": "file",
-                "url": $deb_url,
-                "sha256": $deb_sha256
-              }
-            ]
+          jq --arg deb_path "$deb" --arg PWD "$PWD" '
+            .modules[0].sources = {
+              "type": "file",
+              "path": $deb_path
+            } |
+            .modules[0].sources[1].path = $PWD + "/" + .modules[0].sources[1].path
           ' < flatpak/org.eigenwallet.app.json > target/manifest.json
 
           outdir=target/flatpak-repo
           flatpak remote-add --user --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
           flatpak-builder build-dir --gpg-sign="$GPG_FPR" --user --install-deps-from=flathub --disable-rofiles-fuse --disable-updates --repo="$outdir" target/manifest.json
           flatpak build-update-repo --gpg-sign="$GPG_FPR" --generate-static-deltas --prune "$outdir"
-          flatpak build-bundle      --gpg-sign="$GPG_FPR" "$outdir" "$outdir/org.eigenwallet.app.flatpak" org.eigenwallet.app
+          flatpak build-bundle      --gpg-sign="$GPG_FPR" "$outdir" "$outdir/org.eigenwallet.app.flatpak" org.eigenwallet.app stable
 
           ln flatpak/index.html flatpak/*.flatpakre* src-tauri/icons/icon.png README.md "$outdir/"
           > "$outdir/.nojekyll"

--- a/.github/workflows/draft-new-release.yml
+++ b/.github/workflows/draft-new-release.yml
@@ -62,6 +62,11 @@ jobs:
         run: |
           sed -i 's/"version": "[^"]*"/"version": "${{ github.event.inputs.version }}"/' src-tauri/tauri.conf.json
 
+      - name: Update version in flatpak AppStream metadata for GUI
+        run: |
+          sed -i '/<releases>/a\
+              <release version="${{ github.event.inputs.version }}" date="'"$(date -I)"'" />' flatpak/*.appdata.xml
+
       - name: Update Cargo.lock
         run: cargo update --workspace
 

--- a/dev-scripts/publish_flatpak.sh
+++ b/dev-scripts/publish_flatpak.sh
@@ -225,22 +225,15 @@ else
     echo "✅  Local build completed: $DEB_FILE"
 fi
 
-# Calculate SHA256 hash of the .deb file
-echo "🔢  Calculating SHA256 hash..."
-read -r DEB_SHA256 _ < <(sha256sum "$DEB_FILE")
-echo "   Hash: $DEB_SHA256"
-
 echo "📝  Creating manifest with local .deb..."
 
 # Modify the manifest to use the local file
-jq --arg deb_path "file://$DEB_FILE" --arg deb_hash "$DEB_SHA256" '
-    .modules[0].sources = [
-        {
-            "type": "file",
-            "url": $deb_path,
-            "sha256": $deb_hash
-        }
-    ]
+jq --arg deb_path "$DEB_FILE" --arg PWD "$PWD" '
+    .modules[0].sources[0] = {
+        "type": "file",
+        "path": $deb_path
+    } |
+    .modules[0].sources[1].path = $PWD + "/" + .modules[0].sources[1].path
 ' "$MANIFEST_FILE" > "$TEMP_MANIFEST"
 
 MANIFEST_FILE="$TEMP_MANIFEST"

--- a/flatpak/org.eigenwallet.app.appdata.xml
+++ b/flatpak/org.eigenwallet.app.appdata.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop">
+  <id>org.eigenwallet.app</id>
+  <launchable type="desktop-id">org.eigenwallet.app</launchable>
+  <name>eigenwallet GUI</name>
+  <summary>GUI for XMR&lt;&gt;BTC Atomic Swaps written in Rust</summary>
+  <description><p>GUI for XMR&lt;&gt;BTC Atomic Swaps written in Rust</p></description>
+  <metadata_license>CC0-1.0</metadata_license>
+  <icon type="stock">unstoppableswap-gui-rs</icon>
+  <categories>
+    <category>Utility</category>
+  </categories>
+  <releases>
+    <release version="3.2.11" date="2025-11-09" />
+  </releases>
+</component>

--- a/flatpak/org.eigenwallet.app.json
+++ b/flatpak/org.eigenwallet.app.json
@@ -24,12 +24,18 @@
           "url": "https://cdn.crabnebula.app/download/unstoppableswap/unstoppableswap-gui-rs/latest/platform/debian-x86_64",
           "sha256": "f1fdb9dc164ed45e31fbba7209da23fa4cb1d461442c9dd0b6bc763b8bf1bb59",
           "only-arches": ["x86_64"]
+        },
+        {
+          "type": "file",
+          "path": "flatpak/org.eigenwallet.app.appdata.xml"
         }
       ],
       "build-commands": [
         "ar -x *.deb",
         "tar -xf data.tar.gz",
-        "install -Dm755 usr/bin/unstoppableswap-gui-rs /app/bin/unstoppableswap-gui-rs"
+        "install -Dm755 usr/bin/unstoppableswap-gui-rs -t /app/bin",
+        "install -Dm644 *.appdata.xml                  -t /app/share/metainfo",
+        "mv             usr/share/icons                   /app/share"
       ]
     }
   ]


### PR DESCRIPTION
Closes: #693

<img width="2093" height="742" alt="image" src="https://github.com/user-attachments/assets/42ddd828-4d0d-4738-a109-48c5b0b82486" />

This is the absolute minimal working AppStream that still allows a flatpak to be built. Yes there's a lot of stuff in there. No I don't know why the infrastructure is so hateful-by-design.