### PR TITLE
tests(ci): redial behaviour

### DIFF
--- a/swap-p2p/src/protocols/rendezvous.rs
+++ b/swap-p2p/src/protocols/rendezvous.rs
@@ -550,7 +550,9 @@ pub mod register {
             let handle = tokio::spawn(async move {
                 loop {
                     if let SwarmEvent::Behaviour(InnerBehaviourEvent::Rendezvous(
-                        rendezvous::client::Event::Registered { rendezvous_node, .. },
+                        rendezvous::client::Event::Registered {
+                            rendezvous_node, ..
+                        },
                     )) = asb.select_next_some().await
                     {
                         registrations


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Integrates the redial behaviour into the rendezvous registration flow, adds address-aware peer addition, updates event queuing, and introduces targeted tests.
> 
> - **Redial behaviour (`protocols/redial.rs`)**:
>   - Switch `to_swarm` to `VecDeque<ToSwarm<Event, Void>>` and wrap internal events with `ToSwarm::GenerateEvent`.
>   - Add `add_peer_with_address(peer, address)` that emits `NewExternalAddrOfPeer` and caches the address.
>   - Factor out `insert_address(&peer, address)` and use it on external address discovery.
>   - Preserve exponential backoff redial scheduling; `poll` now returns queued `ToSwarm` items directly.
>   - Add unit test validating immediate dial and retry after a dial failure.
> - **Rendezvous register behaviour (`protocols/rendezvous.rs`)**:
>   - Compose new `InnerBehaviour` combining `rendezvous::client::Behaviour` and `redial::Behaviour`.
>   - Initialize redial with constants and register rendezvous peers/addresses via `add_peer_with_address`.
>   - Remove custom dial scheduling/backoff; rely on `redial` for reconnection logic.
>   - Adjust `ToSwarm`/event handling to `InnerBehaviourEvent` and update handler passthroughs (incl. pending inbound).
>   - Update tests to expect `InnerBehaviourEvent::Rendezvous` events; add multiple registration and auto re-register validations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e29f3684daec6654150fca2d6e97ec0a45301a2f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->