### PR TITLE
feat(flatpak): work around nvidia driver compatibility by setting WEBKIT_DISABLE_DMABUF_RENDERER=1

### DIFF
--- a/.github/workflows/build-gui-release-binaries.yml
+++ b/.github/workflows/build-gui-release-binaries.yml
@@ -168,7 +168,8 @@ jobs:
               "type": "file",
               "path": $deb_path
             } |
-            .modules[0].sources[1].path = $PWD + "/" + .modules[0].sources[1].path
+            .modules[0].sources[1].path = $PWD + "/" + .modules[0].sources[1].path |
+            .modules[0].sources[2].path = $PWD + "/" + .modules[0].sources[2].path
           ' < flatpak/org.eigenwallet.app.json > target/manifest.json
 
           outdir=target/flatpak-repo

--- a/dev-scripts/publish_flatpak.sh
+++ b/dev-scripts/publish_flatpak.sh
@@ -233,7 +233,8 @@ jq --arg deb_path "$DEB_FILE" --arg PWD "$PWD" '
         "type": "file",
         "path": $deb_path
     } |
-    .modules[0].sources[1].path = $PWD + "/" + .modules[0].sources[1].path
+    .modules[0].sources[1].path = $PWD + "/" + .modules[0].sources[1].path |
+    .modules[0].sources[2].path = $PWD + "/" + .modules[0].sources[2].path
 ' "$MANIFEST_FILE" > "$TEMP_MANIFEST"
 
 MANIFEST_FILE="$TEMP_MANIFEST"

--- a/flatpak/org.eigenwallet.app.json
+++ b/flatpak/org.eigenwallet.app.json
@@ -3,7 +3,7 @@
   "runtime": "org.gnome.Platform",
   "runtime-version": "47",
   "sdk": "org.gnome.Sdk",
-  "command": "unstoppableswap-gui-rs",
+  "command": "unstoppableswap-gui-rs.flatpak.sh",
   "finish-args": [
     "--socket=wayland",
     "--socket=fallback-x11",
@@ -28,12 +28,17 @@
         {
           "type": "file",
           "path": "flatpak/org.eigenwallet.app.appdata.xml"
+        },
+        {
+          "type": "file",
+          "path": "flatpak/unstoppableswap-gui-rs.flatpak.sh"
         }
       ],
       "build-commands": [
         "ar -x *.deb",
         "tar -xf data.tar.gz",
         "install -Dm755 usr/bin/unstoppableswap-gui-rs -t /app/bin",
+        "install -Dm755 *.flatpak.sh                   -t /app/bin",
         "install -Dm644 *.appdata.xml                  -t /app/share/metainfo",
         "mv             usr/share/icons                   /app/share"
       ]

--- a/flatpak/unstoppableswap-gui-rs.flatpak.sh
+++ b/flatpak/unstoppableswap-gui-rs.flatpak.sh
@@ -1,0 +1,7 @@
+#!/bin/sh -x
+
+# Work around https://github.com/eigenwallet/core/issues/665
+WEBKIT_DISABLE_DMABUF_RENDERER=1
+export WEBKIT_DISABLE_DMABUF_RENDERER
+
+exec unstoppableswap-gui-rs "$@"


### PR DESCRIPTION
On
> GPU: NVIDIA GeForce RTX 4060 Ti
> Driver Version: 580.95.05, CUDA Version: 13.0

on Ubuntu 22.04 one sees
```
$ flatpak run org.eigenwallet.app
Gtk-Message: 12:51:00.306: Failed to load module "canberra-gtk-module"
Gtk-Message: 12:51:00.306: Failed to load module "canberra-gtk-module"
Gtk-Message: 12:51:00.551: Failed to load module "canberra-gtk-module"
Gtk-Message: 12:51:00.552: Failed to load module "canberra-gtk-module"
Failed to create GBM buffer of size 800x700: Invalid argument
2025-11-01T09:51:00.990998736Z INFO swap::common::tracing_util: swap/src/common/tracing_util.rs:225: Initialized tracing. General logs will be written to swap-all.log, and verbose logs to tracing*.log level_filter=debug logs_dir=/home/user/.var/app/org.eigenwallet.app/data/xmr-btc-swap/cli/mainnet/logs
```
and the window opens, but never populates

This is the most-commonly-mentioned workaround

Closes: #665

I was gonna hold off posting this until the #665 OP tested it, but they seem to be a little MIA at the moment, so posting but Drafted.

<img width="2560" height="1600" alt="image" src="https://github.com/user-attachments/assets/2f0c3047-c7fa-4704-8fcd-96206583f9f5" />
