### PR TITLE
fix(taker): Do not fail state machine if we fail to check tx lock status in BobState::XmrLockProofReceived

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- GUI: Fix an issue where the user would have to keep resuming if we failed to check the status of a Bitcoin timelock before we waited for the Monero lock transaction to be confirmed.
+
 ## [3.3.5] - 2025-11-15
 
 - GUI: Allow changing the password of a Monero wallet (thanks to @nabijaczleweli)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Make Bob’s XmrLockProofReceived resilient to BTC timelock status check failures by racing Monero confirmations against cancel timelock and handling insufficient XMR by waiting to cancel; update changelog.
> 
> - **Swap protocol (Bob)**
>   - `BobState::XmrLockProofReceived`:
>     - Remove strict pre-check of BTC cancel timelock; instead race Monero confirmations vs `cancel_timelock`, with explicit timelock checks deferred to `XmrLocked`.
>     - On Monero "amount mismatch", wait for `cancel_timelock` then transition to `CancelTimelockExpired`.
>     - Minor: improved logging/events and TODO notes for retries.
> - **Changelog**
>   - Add Unreleased note: GUI no longer forces repeated resume when BTC timelock status check fails before waiting for Monero lock confirmations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 830b0d08d9f1b6e582a6d91c8f5cd6070d650366. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->