### PR TITLE
fix(tests): harness

### DIFF
--- a/monero-sys/Cargo.toml
+++ b/monero-sys/Cargo.toml
@@ -10,18 +10,13 @@ chrono = { version = "0.4", features = ["serde"] }
 cxx = "1.0.137"
 monero = { workspace = true }
 serde = { workspace = true }
-sqlx = { version = "0.8", features = [
-    "sqlite",
-    "runtime-tokio-rustls",
-    "macros",
-    "chrono",
-] }
+sqlx = { version = "0.8", features = ["sqlite", "runtime-tokio-rustls", "macros", "chrono"] }
+thiserror = "2.0.17"
 tokio = { workspace = true, features = ["sync", "time", "rt"] }
 tracing = { workspace = true }
 typeshare = { workspace = true }
 url = { workspace = true }
 uuid = { workspace = true }
-thiserror = "2.0.17"
 
 # Our crates
 swap-serde = { path = "../swap-serde" }

--- a/swap-env/src/prompt.rs
+++ b/swap-env/src/prompt.rs
@@ -1,15 +1,15 @@
 use std::path::{Path, PathBuf};
 
 use crate::defaults::{
-    DEFAULT_MAX_BUY_AMOUNT, DEFAULT_MIN_BUY_AMOUNT, DEFAULT_SPREAD, default_rendezvous_points,
+    default_rendezvous_points, DEFAULT_MAX_BUY_AMOUNT, DEFAULT_MIN_BUY_AMOUNT, DEFAULT_SPREAD,
 };
-use anyhow::{Context, Result, bail};
+use anyhow::{bail, Context, Result};
 use console::Style;
 use dialoguer::Confirm;
-use dialoguer::{Input, Select, theme::ColorfulTheme};
+use dialoguer::{theme::ColorfulTheme, Input, Select};
 use libp2p::Multiaddr;
-use rust_decimal::Decimal;
 use rust_decimal::prelude::FromPrimitive;
+use rust_decimal::Decimal;
 use url::Url;
 
 /// Prompt user for data directory

--- a/swap-p2p/src/protocols/quotes_cached.rs
+++ b/swap-p2p/src/protocols/quotes_cached.rs
@@ -1,4 +1,4 @@
-use crate::behaviour_util::{AddressTracker};
+use crate::behaviour_util::AddressTracker;
 use crate::futures_util::FuturesHashSet;
 use crate::out_event;
 use crate::protocols::quote::BidQuote;

--- a/swap-p2p/src/protocols/rendezvous.rs
+++ b/swap-p2p/src/protocols/rendezvous.rs
@@ -79,7 +79,7 @@ mod tests {
         registrar.listen_on_random_memory_address().await;
         let registrar_id = *registrar.local_peer_id();
 
-        // Create peer that discovers the 
+        // Create peer that discovers the
         let mut discoverer = new_swarm(|identity| {
             discovery::Behaviour::new(
                 identity,

--- a/swap/src/cli/command.rs
+++ b/swap/src/cli/command.rs
@@ -1,6 +1,6 @@
 use crate::cli::api::request::{
-    BalanceArgs, CancelAndRefundArgs, ExportBitcoinWalletArgs, GetConfigArgs,
-    GetHistoryArgs, MoneroRecoveryArgs, Request, ResumeSwapArgs, WithdrawBtcArgs,
+    BalanceArgs, CancelAndRefundArgs, ExportBitcoinWalletArgs, GetConfigArgs, GetHistoryArgs,
+    MoneroRecoveryArgs, Request, ResumeSwapArgs, WithdrawBtcArgs,
 };
 use crate::cli::api::Context;
 use crate::monero::{self, MoneroAddressPool};

--- a/swap/tests/harness/mod.rs
+++ b/swap/tests/harness/mod.rs
@@ -103,6 +103,7 @@ pub async fn setup_test<T, F, C>(
         .await
         .main_address()
         .await
+        .unwrap()
         .into();
 
     let developer_tip_monero_wallet_subaddress = developer_tip_monero_wallet
@@ -384,7 +385,7 @@ async fn init_test_wallets(
 
     let xmr_wallet = wallets.main_wallet().await;
     tracing::info!(
-        address = %xmr_wallet.main_address().await,
+        address = %xmr_wallet.main_address().await.unwrap(),
         "Initialized monero wallet"
     );
 
@@ -534,7 +535,12 @@ impl BobParams {
     pub async fn get_change_receive_addresses(&self) -> (bitcoin::Address, monero::Address) {
         (
             self.bitcoin_wallet.new_address().await.unwrap(),
-            self.monero_wallet.main_wallet().await.main_address().await,
+            self.monero_wallet
+                .main_wallet()
+                .await
+                .main_address()
+                .await
+                .unwrap(),
         )
     }
 
@@ -563,6 +569,7 @@ impl BobParams {
                 .await
                 .main_address()
                 .await
+                .unwrap()
                 .into(),
         )
         .await
@@ -603,6 +610,7 @@ impl BobParams {
                 .await
                 .main_address()
                 .await
+                .unwrap()
                 .into(),
             self.bitcoin_wallet.new_address().await?,
             btc_amount,
@@ -628,7 +636,7 @@ impl BobParams {
         let mut swarm = swarm::cli(identity.clone(), None, behaviour).await?;
         swarm.add_peer_address(self.alice_peer_id, self.alice_address.clone());
 
-        cli::EventLoop::new(swarm, db.clone())
+        cli::EventLoop::new(swarm, db.clone(), None)
     }
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adjust test harness to unwrap Monero wallet addresses and use updated `cli::EventLoop::new` signature; minor import/formatting cleanups elsewhere.
> 
> - **Tests (harness)**:
>   - Add `.unwrap()` to Monero `main_address()` calls in multiple paths to handle `Result`.
>   - Switch `cli::EventLoop::new` invocations to new signature with an extra `None` parameter.
> - **P2P/Env/CLI**:
>   - Minor import/order cleanups in `swap-env/src/prompt.rs`, `swap-p2p/src/protocols/*`, and `swap/src/cli/command.rs`.
> - **Build**:
>   - Tidy `sqlx` features line in `monero-sys/Cargo.toml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 674313f6d5e4c3e7a6de1c28c64bf551ff8f2263. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->