### PR TITLE
feat(swap-env): allow ticker url to be left out from config

### DIFF
--- a/swap-env/src/config.rs
+++ b/swap-env/src/config.rs
@@ -1,4 +1,7 @@
-use crate::defaults::GetDefaults;
+use crate::defaults::{
+    GetDefaults, BITFINEX_PRICE_TICKER_WS_URL, KRAKEN_PRICE_TICKER_WS_URL,
+    KUCOIN_PRICE_TICKER_REST_URL,
+};
 use crate::env::{Mainnet, Testnet};
 use crate::prompt;
 use anyhow::{bail, Context, Result};
@@ -98,8 +101,11 @@ pub struct Maker {
     #[serde(with = "::bitcoin::amount::serde::as_btc")]
     pub max_buy_btc: bitcoin::Amount,
     pub ask_spread: Decimal,
+    #[serde(default = "default_price_ticker_ws_url_kraken")]
     pub price_ticker_ws_url_kraken: Url,
+    #[serde(default = "default_price_ticker_ws_url_bitfinex")]
     pub price_ticker_ws_url_bitfinex: Url,
+    #[serde(default = "default_price_ticker_rest_url_kucoin")]
     pub price_ticker_rest_url_kucoin: Url,
     #[serde(default, with = "swap_serde::bitcoin::address_serde::option")]
     pub external_bitcoin_redeem_address: Option<bitcoin::Address>,
@@ -112,6 +118,18 @@ pub struct Maker {
 fn default_developer_tip() -> Decimal {
     // By default, we do not tip
     Decimal::ZERO
+}
+
+fn default_price_ticker_ws_url_kraken() -> Url {
+    Url::parse(KRAKEN_PRICE_TICKER_WS_URL).expect("default kraken ws url to be valid")
+}
+
+fn default_price_ticker_ws_url_bitfinex() -> Url {
+    Url::parse(BITFINEX_PRICE_TICKER_WS_URL).expect("default bitfinex ws url to be valid")
+}
+
+fn default_price_ticker_rest_url_kucoin() -> Url {
+    Url::parse(KUCOIN_PRICE_TICKER_REST_URL).expect("default kucoin rest url to be valid")
 }
 
 impl Config {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Provide defaults for Kraken/Bitfinex WS and KuCoin REST ticker URLs so these fields can be omitted in config.
> 
> - **Config**:
>   - **Maker**: Add serde defaults for `price_ticker_ws_url_kraken`, `price_ticker_ws_url_bitfinex`, and `price_ticker_rest_url_kucoin`, backed by new default helpers using `KRAKEN_PRICE_TICKER_WS_URL`, `BITFINEX_PRICE_TICKER_WS_URL`, and `KUCOIN_PRICE_TICKER_REST_URL`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 72ed29335133cc5c96b4fb1a4fabd5e2b7facb85. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->