### PR TITLE
feat(gui): improve donation tip setting dialog

### DIFF
--- a/src-gui/src/renderer/background.ts
+++ b/src-gui/src/renderer/background.ts
@@ -32,7 +32,10 @@ import {
   setHistory,
   setSyncProgress,
 } from "store/features/walletSlice";
-import { applyDefaultNodes } from "store/features/settingsSlice";
+import {
+  applyDefaultNodes,
+  validateDonateToDevelopmentTip,
+} from "store/features/settingsSlice";
 import {
   DEFAULT_NODES,
   NEGATIVE_NODES_MAINNET,
@@ -76,6 +79,9 @@ export async function setupBackgroundTasks(): Promise<void> {
       negativeNodesTestnet: NEGATIVE_NODES_TESTNET,
     }),
   );
+
+  // Validate donation tip setting
+  store.dispatch(validateDonateToDevelopmentTip());
 
   // Setup periodic fetch tasks
   setIntervalImmediate(updateAllNodeStatuses, STATUS_UPDATE_INTERVAL);

--- a/src-gui/src/renderer/components/App.tsx
+++ b/src-gui/src/renderer/components/App.tsx
@@ -25,6 +25,7 @@ import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
 import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
 import PasswordEntryDialog from "./modal/password-entry/PasswordEntryDialog";
 import ContextErrorDialog from "./modal/context-error/ContextErrorDialog";
+import { GlobalDonationTipDialog } from "./modal/donation-tip/DonationTipDialog";
 import ErrorBoundary from "./other/ErrorBoundary";
 
 declare module "@mui/material/styles" {
@@ -54,6 +55,7 @@ export default function App() {
             <CssBaseline />
             <GlobalSnackbarProvider>
               <IntroductionModal />
+              <GlobalDonationTipDialog />
               <SeedSelectionDialog />
               <PasswordEntryDialog />
               <ContextErrorDialog />

--- a/src-gui/src/renderer/components/modal/donation-tip/DonationTipDialog.tsx
+++ b/src-gui/src/renderer/components/modal/donation-tip/DonationTipDialog.tsx
@@ -1,0 +1,256 @@
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  Typography,
+  ToggleButton,
+  ToggleButtonGroup,
+  Box,
+  Link,
+  Button,
+  Tooltip,
+} from "@mui/material";
+import {
+  DonateToDevelopmentTip,
+  DONATE_TO_DEVELOPMENT_OPTIONS,
+  setDonateToDevelopment,
+} from "store/features/settingsSlice";
+import {
+  useAppDispatch,
+  useSettings,
+  useIsExperiencedUser,
+  useIsIdle,
+} from "store/hooks";
+import ExternalLink from "renderer/components/other/ExternalLink";
+import GitHubIcon from "@mui/icons-material/GitHub";
+import { useState, useEffect } from "react";
+
+const GITHUB_BOUNTIES_URL = "https://eigenwallet.org/bounties";
+
+// How long the user must be idle before showing the donation dialog
+const DONATION_DIALOG_IDLE_DELAY_MS = 10 * 1000;
+
+/** Formats a donation tip value as a percentage string (e.g., "0.5%", "1.2%", "0%") */
+export function formatDonationTipLabel(tip: DonateToDevelopmentTip): string {
+  if (tip === false || tip === 0) return "0%";
+  return `${(tip * 100).toFixed(1)}%`;
+}
+
+// Helper functions for tip button styling (defined outside component to avoid recreation)
+function getTipButtonColor(
+  tip: Exclude<DonateToDevelopmentTip, false>,
+): string {
+  if (tip !== 0) {
+    return "#198754"; // Green for any tip > 0
+  }
+  return "#6c757d"; // Gray for no tip
+}
+
+function getTipButtonHoverColor(
+  tip: Exclude<DonateToDevelopmentTip, false>,
+): string {
+  if (tip === 0) return "#5c636a"; // Darker gray
+  return "#146c43"; // Darker green
+}
+
+interface DonationTipDialogProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+/**
+ * Dialog for selecting a donation tip amount.
+ */
+export default function DonationTipDialog({
+  open,
+  onClose,
+}: DonationTipDialogProps) {
+  const dispatch = useAppDispatch();
+  const [selectedTip, setSelectedTip] = useState<Exclude<
+    DonateToDevelopmentTip,
+    false
+  > | null>(null);
+
+  const handleConfirm = () => {
+    if (selectedTip !== null) {
+      dispatch(setDonateToDevelopment(selectedTip));
+      onClose();
+    }
+  };
+
+  return (
+    <Dialog open={open} maxWidth="sm" fullWidth>
+      <DialogTitle>Support the project?</DialogTitle>
+      <DialogContent>
+        <Box sx={{ display: "flex", flexDirection: "column", gap: 2 }}>
+          <Typography variant="subtitle2">
+            Eigenwallet is an open source, community-driven project. It is
+            funded entirely by the community.
+          </Typography>
+          <Typography variant="subtitle2">
+            We use{" "}
+            <ExternalLink href={GITHUB_BOUNTIES_URL}>
+              <GitHubIcon
+                sx={{ fontSize: "1em", verticalAlign: "middle", mr: 0.5 }}
+              />
+              <strong>Github bounties</strong>
+            </ExternalLink>{" "}
+            to fuel development efforts. Anyone can contribute to the project,
+            fix an existing issue and claim the bounty.
+          </Typography>
+          <Typography variant="subtitle2">
+            Bounties are funded with:
+            <ol style={{ margin: 0, padding: 0, paddingLeft: "1.5rem" }}>
+              <li>Funds left over from a previous Monero CCS</li>
+              <li>
+                Personal financial contributions by the core developer team
+              </li>
+              <li>Tips donated by users like you</li>
+            </ol>
+          </Typography>
+          <Typography variant="subtitle2">
+            If you enable the auto tip feature:
+            <ul style={{ margin: 0, padding: 0, paddingLeft: "1.5rem" }}>
+              <li>
+                A <strong>small tip</strong> will be donated for each successful
+                swap
+              </li>
+              <li>
+                Tips will go <strong>directly</strong> to open source
+                contributors
+              </li>
+              <li>Monero is used for the tips, giving you full privacy</li>
+              <li>You can disable this at any time in the settings</li>
+            </ul>
+          </Typography>
+          <ToggleButtonGroup
+            value={selectedTip}
+            exclusive
+            onChange={(_, newValue) => {
+              if (newValue !== null) {
+                setSelectedTip(newValue);
+              }
+            }}
+            aria-label="Development tip amount"
+            size="small"
+            sx={{
+              width: "100%",
+              gap: 1,
+              "& .MuiToggleButton-root": {
+                flex: 1,
+                borderRadius: "8px",
+                fontWeight: "600",
+                textTransform: "none",
+                border: "2px solid",
+                "&:not(:first-of-type)": {
+                  marginLeft: "8px",
+                  borderLeft: "2px solid",
+                },
+              },
+            }}
+          >
+            {DONATE_TO_DEVELOPMENT_OPTIONS.map((tipAmount) => (
+              <ToggleButton
+                key={String(tipAmount)}
+                value={tipAmount}
+                sx={{
+                  borderColor: `${getTipButtonColor(tipAmount)} !important`,
+                  color:
+                    selectedTip === tipAmount
+                      ? "white"
+                      : getTipButtonColor(tipAmount),
+                  backgroundColor:
+                    selectedTip === tipAmount
+                      ? getTipButtonColor(tipAmount)
+                      : "transparent",
+                  "&:hover": {
+                    backgroundColor: `${getTipButtonHoverColor(tipAmount)} !important`,
+                    color: "white !important",
+                  },
+                  "&.Mui-selected": {
+                    backgroundColor: `${getTipButtonColor(tipAmount)} !important`,
+                    color: "white !important",
+                  },
+                }}
+              >
+                {formatDonationTipLabel(tipAmount)}
+              </ToggleButton>
+            ))}
+          </ToggleButtonGroup>
+          <Box
+            sx={{
+              display: "flex",
+              justifyContent: "flex-end",
+              alignItems: "center",
+              gap: 2,
+            }}
+          >
+            <Link
+              component="button"
+              variant="body2"
+              onClick={onClose}
+              sx={{
+                color: "text.secondary",
+                opacity: selectedTip !== null ? 0.5 : 1,
+              }}
+            >
+              Remind me later
+            </Link>
+            <Tooltip
+              title={selectedTip === null ? "Select an option first" : ""}
+              arrow
+            >
+              <span>
+                <Button
+                  variant="contained"
+                  onClick={handleConfirm}
+                  disabled={selectedTip === null}
+                >
+                  Done
+                </Button>
+              </span>
+            </Tooltip>
+          </Box>
+        </Box>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+/**
+ * Wrapper that shows DonationTipDialog automatically based on global state.
+ * Shows when user hasn't selected a tip yet, is an experienced user, and has been idle.
+ */
+export function GlobalDonationTipDialog() {
+  // Has the user selected the tip any option yet?
+  const hasntSelectedTipYet = useSettings(
+    (s) => s.donateToDevelopment === false,
+  );
+
+  // Has the user used the app at least a little bit?
+  const isExperiencedUser = useIsExperiencedUser();
+
+  // Has the user been idle?
+  const isIdle = useIsIdle(DONATION_DIALOG_IDLE_DELAY_MS);
+
+  // Track if user dismissed the dialog this session (don't show again until next app launch)
+  const [dismissed, setDismissed] = useState(false);
+
+  // "Latch" pattern: once conditions are met, we remember that the dialog should be shown.
+  // This prevents the dialog from closing when the user moves their mouse (which would
+  // break the idle condition). Once triggered, it stays triggered.
+  const [hasTriggered, setHasTriggered] = useState(false);
+
+  const shouldOpen = hasntSelectedTipYet && isExperiencedUser && isIdle;
+
+  useEffect(() => {
+    if (shouldOpen && !hasTriggered) {
+      setHasTriggered(true);
+    }
+  }, [shouldOpen, hasTriggered]);
+
+  // Show dialog if we've triggered and user hasn't dismissed
+  const open = hasTriggered && !dismissed;
+
+  return <DonationTipDialog open={open} onClose={() => setDismissed(true)} />;
+}

--- a/src-gui/src/renderer/components/pages/help/SettingsBox.tsx
+++ b/src-gui/src/renderer/components/pages/help/SettingsBox.tsx
@@ -26,7 +26,6 @@ import {
 import {
   addNode,
   addRendezvousPoint,
-  DonateToDevelopmentTip,
   FiatCurrency,
   moveUpNode,
   removeNode,
@@ -38,7 +37,6 @@ import {
   setTorEnabled,
   setEnableMoneroTor,
   setUseMoneroRpcPool,
-  setDonateToDevelopment,
   setMoneroRedeemPolicy,
   setMoneroRedeemAddress,
   setBitcoinRefundAddress,
@@ -69,6 +67,9 @@ import { getNodeStatus } from "renderer/rpc";
 import { setStatus } from "store/features/nodesSlice";
 import MoneroAddressTextField from "renderer/components/inputs/MoneroAddressTextField";
 import BitcoinAddressTextField from "renderer/components/inputs/BitcoinAddressTextField";
+import DonationTipDialog, {
+  formatDonationTipLabel,
+} from "renderer/components/modal/donation-tip/DonationTipDialog";
 
 const PLACEHOLDER_ELECTRUM_RPC_URL = "ssl://blockstream.info:700";
 const PLACEHOLDER_MONERO_NODE_URL = "http://xmr-node.cakewallet.com:18081";
@@ -887,120 +888,39 @@ function RendezvousPointsSetting() {
  */
 function DonationTipSetting() {
   const donateToDevelopment = useSettings((s) => s.donateToDevelopment);
-  const dispatch = useAppDispatch();
-
-  const handleTipSelect = (tipAmount: DonateToDevelopmentTip) => {
-    dispatch(setDonateToDevelopment(tipAmount));
-  };
-
-  const formatTipLabel = (tip: DonateToDevelopmentTip) => {
-    if (tip === false) return "0%";
-    return `${(tip * 100).toFixed(2)}%`;
-  };
-
-  const getTipButtonColor = (
-    tip: DonateToDevelopmentTip,
-    isSelected: boolean,
-  ) => {
-    // Only show colored if selected and > 0
-    if (isSelected && tip !== false) {
-      return "#198754"; // Green for any tip > 0
-    }
-    return "#6c757d"; // Gray for all unselected or no tip
-  };
-
-  const getTipButtonSelectedColor = (tip: DonateToDevelopmentTip) => {
-    if (tip === false) return "#5c636a"; // Darker gray
-    return "#146c43"; // Darker green for any tip > 0
-  };
+  const [dialogOpen, setDialogOpen] = useState(false);
 
   return (
     <TableRow>
       <TableCell>
         <SettingLabel
           label="Tip to the developers"
-          tooltip="Support the development of eigenwallet by donating a small percentage of your swaps. Donations go directly to paying for infrastructure costs and developers"
+          tooltip="Donates a small percentage of your swaps to fund development efforts"
         />
       </TableCell>
       <TableCell>
-        <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
-          <ToggleButtonGroup
-            value={donateToDevelopment}
-            exclusive
-            onChange={(event, newValue) => {
-              if (newValue !== null) {
-                handleTipSelect(newValue);
-              }
-            }}
-            aria-label="Development tip amount"
-            size="small"
-            sx={{
-              width: "100%",
-              gap: 1,
-              "& .MuiToggleButton-root": {
-                flex: 1,
-                borderRadius: "8px",
-                fontWeight: "600",
-                textTransform: "none",
-                border: "2px solid",
-                "&:not(:first-of-type)": {
-                  marginLeft: "8px",
-                  borderLeft: "2px solid",
-                },
-              },
-            }}
-          >
-            {([false, 0.0005, 0.0075] as const).map((tipAmount) => (
-              <ToggleButton
-                key={String(tipAmount)}
-                value={tipAmount}
-                sx={{
-                  borderColor: `${getTipButtonColor(tipAmount, donateToDevelopment === tipAmount)} !important`,
-                  color:
-                    donateToDevelopment === tipAmount
-                      ? "white"
-                      : getTipButtonColor(
-                          tipAmount,
-                          donateToDevelopment === tipAmount,
-                        ),
-                  backgroundColor:
-                    donateToDevelopment === tipAmount
-                      ? getTipButtonColor(
-                          tipAmount,
-                          donateToDevelopment === tipAmount,
-                        )
-                      : "transparent",
-                  "&:hover": {
-                    backgroundColor: `${getTipButtonSelectedColor(tipAmount)} !important`,
-                    color: "white !important",
-                  },
-                  "&.Mui-selected": {
-                    backgroundColor: `${getTipButtonColor(tipAmount, true)} !important`,
-                    color: "white !important",
-                    "&:hover": {
-                      backgroundColor: `${getTipButtonSelectedColor(tipAmount)} !important`,
-                    },
-                  },
-                }}
-              >
-                {formatTipLabel(tipAmount)}
-              </ToggleButton>
-            ))}
-          </ToggleButtonGroup>
-          <Typography variant="subtitle2">
-            <ul style={{ margin: 0, padding: "0 1.5rem" }}>
-              <li>
-                Tips go <strong>directly</strong> towards paying for
-                infrastructure costs and developers
-              </li>
-              <li>
-                Only ever sent for <strong>successful</strong> swaps
-              </li>{" "}
-              (refunds are not counted)
-              <li>Monero is used for the tips, giving you full anonymity</li>
-            </ul>
+        <Box
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+          }}
+        >
+          <Typography variant="body1" sx={{ fontWeight: "bold" }}>
+            {formatDonationTipLabel(donateToDevelopment)}
           </Typography>
+          <Button
+            variant="outlined"
+            size="small"
+            onClick={() => setDialogOpen(true)}
+          >
+            Change
+          </Button>
         </Box>
+        <DonationTipDialog
+          open={dialogOpen}
+          onClose={() => setDialogOpen(false)}
+        />
       </TableCell>
     </TableRow>
   );


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Introduces a global donation tip dialog with auto-show logic, updates tip options and settings UI, and validates the tip setting on startup.
> 
> - **UI/UX**:
>   - **Global Donation Tip Dialog**: New `renderer/components/modal/donation-tip/DonationTipDialog.tsx` with `GlobalDonationTipDialog` auto-shown for experienced/idle users; wired into `App.tsx`.
>   - **Settings**: `DonationTipSetting` now shows current tip (`formatDonationTipLabel`) and a "Change" button that opens the dialog, replacing inline toggle buttons.
> - **State/Logic**:
>   - **Tip Options & Validation**: `settingsSlice` expands `DonateToDevelopmentTip` to `0 | 0.005 | 0.012 | 0.02` (plus `false`) and adds `DONATE_TO_DEVELOPMENT_OPTIONS` and `validateDonateToDevelopmentTip`.
>   - **Startup**: `background.ts` dispatches `validateDonateToDevelopmentTip()` during setup.
>   - **Hooks**: Adds `useIsExperiencedUser` and `useIsIdle` (with throttled activity tracking) in `store/hooks.ts` used by the global dialog.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 95adb03a48c7dae021d93b96a865061a5c8b18a5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->