### PR TITLE
Revert "refactor(swap-fs): replace directories-next (=> dirs-sys-next, redox_users) with dirs which is already in our dependency tree"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2831,6 +2831,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "directories-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "339ee130d97a610ea5a5872d2bbb130fdf68884ff09d3028b81bec8a1ac23bbc"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
 name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2847,8 +2857,19 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users",
+ "redox_users 0.5.2",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users 0.4.6",
+ "winapi",
 ]
 
 [[package]]
@@ -8683,6 +8704,17 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.16",
+ "libredox",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
@@ -10828,7 +10860,7 @@ name = "swap-fs"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "dirs",
+ "directories-next",
  "tracing",
 ]
 

--- a/swap-fs/Cargo.toml
+++ b/swap-fs/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 
 [dependencies]
 anyhow = { workspace = true }
-dirs = "6.0"
+directories-next = "2"
 tracing = { workspace = true }
 
 [lints]

--- a/swap-fs/src/lib.rs
+++ b/swap-fs/src/lib.rs
@@ -1,12 +1,13 @@
 use anyhow::{Context, Result};
+use directories_next::ProjectDirs;
 use std::path::{Path, PathBuf};
 
 /// This is the default location for the overall config-dir specific by system
 // Linux: /home/<user>/.config/xmr-btc-swap/
 // OSX: /Users/<user>/Library/Application Support/xmr-btc-swap/
 pub fn system_config_dir() -> Result<PathBuf> {
-    dirs::config_dir()
-        .map(|cd| cd.join("xmr-btc-swap"))
+    ProjectDirs::from("", "", "xmr-btc-swap")
+        .map(|proj_dirs| proj_dirs.config_dir().to_path_buf())
         .context("Could not generate default system configuration dir path")
 }
 
@@ -14,8 +15,8 @@ pub fn system_config_dir() -> Result<PathBuf> {
 // Linux: /home/<user>/.local/share/xmr-btc-swap/
 // OSX: /Users/<user>/Library/Application Support/xmr-btc-swap/
 pub fn system_data_dir() -> Result<PathBuf> {
-    dirs::data_dir()
-        .map(|cd| cd.join("xmr-btc-swap"))
+    ProjectDirs::from("", "", "xmr-btc-swap")
+        .map(|proj_dirs| proj_dirs.data_dir().to_path_buf())
         .context("Could not generate default system data-dir dir path")
 }
 
@@ -25,8 +26,8 @@ pub fn system_data_dir_eigenwallet(testnet: bool) -> Result<PathBuf> {
         false => "eigenwallet",
     };
 
-    dirs::data_dir()
-        .map(|cd| cd.join(application_directory))
+    ProjectDirs::from("", "", application_directory)
+        .map(|proj_dirs| proj_dirs.data_dir().to_path_buf())
         .context("Could not generate default system data-dir dir path")
 }
 


### PR DESCRIPTION
This reverts commit 9c72c2b6612fec43a2c408b1ac2970f4d888ff06.

Ref: https://github.com/eigenwallet/core/pull/815#issuecomment-3686219544