### PR TITLE
test: Integration tests for monero wallet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,6 +190,14 @@ jobs:
             test_name: transfers
           - package: monero-tests
             test_name: transfers_wrong_key
+          - package: monero-wallet
+            test_name: advanced_wallet_tests
+          - package: monero-wallet
+            test_name: tauri_wallet_listener_tests
+          - package: monero-wallet
+            test_name: transaction_tests
+          - package: monero-wallet
+            test_name: wallet_operations
 
     runs-on: ubuntu-22.04
     if: github.event_name == 'push' || !github.event.pull_request.draft

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6620,21 +6620,32 @@ dependencies = [
  "anyhow",
  "backoff",
  "curve25519-dalek",
+ "data-encoding",
  "hex",
+ "mockito",
  "monero",
  "monero-daemon-rpc",
+ "monero-harness",
  "monero-simple-request-rpc",
  "monero-sys",
  "monero-wallet 0.1.0 (git+https://github.com/kayabaNerve/monero-oxide.git?branch=rpc-rewrite)",
  "monero-wallet-ng",
+ "proptest",
+ "rustls 0.23.35",
+ "serial_test",
  "swap-core",
+ "swap-p2p",
+ "tempfile",
+ "testcontainers",
  "throttle",
  "time",
  "tokio",
  "tracing",
  "tracing-appender",
+ "tracing-ext",
  "tracing-subscriber",
  "uuid",
+ "vergen-git2",
  "zeroize",
 ]
 
@@ -9333,6 +9344,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9429,6 +9449,12 @@ dependencies = [
  "ring 0.17.14",
  "untrusted 0.9.0",
 ]
+
+[[package]]
+name = "sdd"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "seahash"
@@ -9851,6 +9877,31 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
+]
+
+[[package]]
+name = "serial_test"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b258109f244e1d6891bf1053a55d63a5cd4f8f4c30cf9a1280989f80e7a1fa9"
+dependencies = [
+ "futures",
+ "log",
+ "once_cell",
+ "parking_lot 0.12.5",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d69265a08751de7844521fd15003ae0a888e035773ba05695c5c759a6f89eef"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6631,6 +6631,7 @@ dependencies = [
  "monero-wallet 0.1.0 (git+https://github.com/kayabaNerve/monero-oxide.git?branch=rpc-rewrite)",
  "monero-wallet-ng",
  "proptest",
+ "rand 0.8.5",
  "rustls 0.23.35",
  "serial_test",
  "swap-core",

--- a/monero-wallet/Cargo.toml
+++ b/monero-wallet/Cargo.toml
@@ -34,3 +34,20 @@ monero-wallet-ng = { path = "../monero-wallet-ng" }
 curve25519-dalek = { workspace = true }
 hex = { workspace = true }
 zeroize = { workspace = true }
+
+
+[dev-dependencies]
+data-encoding = { workspace = true }
+mockito = "1.4"
+monero-harness = { path = "../monero-harness" }
+proptest = "1"
+swap-p2p = { path = "../swap-p2p", features = ["test-support"] }
+tempfile = "3"
+testcontainers = "0.15"
+serial_test = "3"
+tracing-ext = { path = "../tracing-ext" }
+rustls = { version = "0.23", features = ["ring"] }
+
+[build-dependencies]
+anyhow = { workspace = true }
+vergen-git2 = { workspace = true }

--- a/monero-wallet/Cargo.toml
+++ b/monero-wallet/Cargo.toml
@@ -47,6 +47,8 @@ testcontainers = "0.15"
 serial_test = "3"
 tracing-ext = { path = "../tracing-ext" }
 rustls = { version = "0.23", features = ["ring"] }
+rand = "0.8"
+
 
 [build-dependencies]
 anyhow = { workspace = true }

--- a/monero-wallet/src/listener.rs
+++ b/monero-wallet/src/listener.rs
@@ -16,7 +16,7 @@ pub trait MoneroTauriHandle: Send + Sync {
     fn sync_progress(&self, current_block: u64, target_block: u64, progress_percentage: f32);
 }
 
-pub(crate) struct TauriWalletListener {
+pub struct TauriWalletListener {
     balance_throttle: Throttle<()>,
     history_throttle: Throttle<()>,
     sync_throttle: Throttle<()>,

--- a/monero-wallet/tests/advanced_wallet_tests.rs
+++ b/monero-wallet/tests/advanced_wallet_tests.rs
@@ -1,0 +1,89 @@
+mod harness;
+
+use anyhow::Result;
+use harness::{setup_test, TestContext, WALLET_NAME};
+use monero::Network;
+use monero_sys::TransactionInfo;
+use monero_wallet::{MoneroTauriHandle, Wallets};
+use serial_test::serial;
+use std::str::FromStr;
+use std::sync::{Arc, Mutex};
+use swap_core::monero::Amount;
+use uuid::Uuid;
+
+/// Mock Tauri handle for testing.
+/// Tauri handle requires the application to be running
+/// which is not possible in tests
+/// so we mock it.
+/// Thread-safe implementation.
+struct MockTauriHandle {
+    balance_updates: Arc<Mutex<Vec<(Amount, Amount)>>>,
+    history_updates: Arc<Mutex<Vec<Vec<TransactionInfo>>>>,
+    sync_updates: Arc<Mutex<Vec<(u64, u64, f32)>>>,
+}
+
+impl MockTauriHandle {
+    fn new() -> Self {
+        Self {
+            balance_updates: Arc::new(Mutex::new(Vec::new())),
+            history_updates: Arc::new(Mutex::new(Vec::new())),
+            sync_updates: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+}
+
+/// Mock Tauri handle implementation for testing.
+impl MoneroTauriHandle for MockTauriHandle {
+    fn balance_change(&self, total_balance: Amount, unlocked_balance: Amount) {
+        self.balance_updates
+            .lock()
+            .unwrap()
+            .push((total_balance, unlocked_balance));
+    }
+
+    fn history_update(&self, transactions: Vec<TransactionInfo>) {
+        self.history_updates.lock().unwrap().push(transactions);
+    }
+
+    fn sync_progress(&self, current_block: u64, target_block: u64, progress_percentage: f32) {
+        self.sync_updates
+            .lock()
+            .unwrap()
+            .push((current_block, target_block, progress_percentage));
+    }
+}
+
+#[tokio::test]
+#[serial]
+async fn test_tauri_listener() -> Result<()> {
+    setup_test(|context| async move {
+        let handle = Arc::new(MockTauriHandle::new());
+        let tauri_handle = Some(handle.clone() as Arc<dyn MoneroTauriHandle>);
+
+        // Create wallets with tauri handle
+        let _wallets = Wallets::new(
+            context.wallet_dir.path().to_path_buf(),
+            WALLET_NAME.to_string(),
+            context.daemon.clone(),
+            Network::Mainnet,
+            true,
+            tauri_handle,
+            None,
+        )
+        .await?;
+
+        // Create an action
+        context.monero.generate_block().await?;
+
+        tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+
+        let updates = handle.sync_updates.lock().unwrap();
+        assert!(!updates.is_empty());
+
+        assert_eq!(updates.len(), 1);
+
+        Ok(())
+    })
+    .await;
+    Ok(())
+}

--- a/monero-wallet/tests/harness/mod.rs
+++ b/monero-wallet/tests/harness/mod.rs
@@ -1,0 +1,83 @@
+use anyhow::{Context, Result};
+use monero_harness::{image, Monero};
+use monero_sys::Daemon;
+use monero_wallet::Wallets;
+use std::path::PathBuf;
+use std::sync::Arc;
+use tempfile::TempDir;
+use testcontainers::clients::Cli;
+use testcontainers::{Container, RunnableImage};
+
+pub const WALLET_NAME: &str = "test_wallet";
+
+pub struct TestContext {
+    pub monero: Monero,
+    pub wallet_dir: TempDir,
+    pub daemon: Daemon,
+}
+
+impl TestContext {
+    pub async fn new<'a>(cli: &'a Cli) -> Result<(Self, Container<'a, image::Monerod>)> {
+        // start monero daemon
+        let (monero, monerod_container, _) = Monero::new(cli, vec![WALLET_NAME]).await?;
+
+        let monerod_port = monerod_container
+            .ports()
+            .map_to_host_port_ipv4(image::RPC_PORT)
+            .context("rpc port should be mapped to some external port")?;
+
+        let daemon = Daemon {
+            hostname: "127.0.0.1".to_string(),
+            port: monerod_port,
+            ssl: false,
+        };
+
+        // create wallet dir
+        let wallet_dir = TempDir::new()?;
+
+        Ok((
+            Self {
+                monero,
+                wallet_dir,
+                daemon,
+            },
+            monerod_container,
+        ))
+    }
+
+    pub async fn create_wallets(&self) -> Result<Wallets> {
+        // create wallets
+        Wallets::new(
+            self.wallet_dir.path().to_path_buf(),
+            WALLET_NAME.to_string(),
+            self.daemon.clone(),
+            monero::Network::Mainnet,
+            true,
+            None,
+            None,
+        )
+        .await
+    }
+}
+
+/// setup test environment for monero wallet
+pub async fn setup_test<F, Fut>(test: F)
+where
+    F: FnOnce(TestContext) -> Fut,
+    Fut: std::future::Future<Output = Result<()>>,
+{
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter("info,monero_wallet=debug,monero_sys=debug")
+        .with_test_writer()
+        .try_init();
+
+    let _ = rustls::crypto::ring::default_provider().install_default();
+
+    let cli = Cli::default();
+    let (context, _container) = TestContext::new(&cli).await.unwrap();
+
+    context.monero.init_miner().await.unwrap();
+    context.monero.start_miner().await.unwrap();
+
+    test(context).await.unwrap();
+}

--- a/monero-wallet/tests/tauri_wallet_listener_tests.rs
+++ b/monero-wallet/tests/tauri_wallet_listener_tests.rs
@@ -1,0 +1,139 @@
+mod harness;
+
+use anyhow::Result;
+use harness::{setup_test, TestContext, WALLET_NAME};
+use monero_sys::{TransactionInfo, WalletEventListener};
+use monero_wallet::{MoneroTauriHandle, TauriWalletListener, Wallets};
+use serial_test::serial;
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+use swap_core::monero::Amount;
+
+/// Mock Tauri handle for testing.
+struct MockTauriHandle {
+    balance_updates: Arc<Mutex<Vec<(Amount, Amount)>>>,
+    history_updates: Arc<Mutex<Vec<Vec<TransactionInfo>>>>,
+    sync_updates: Arc<Mutex<Vec<(u64, u64, f32)>>>,
+}
+
+impl MockTauriHandle {
+    fn new() -> Self {
+        Self {
+            balance_updates: Arc::new(Mutex::new(Vec::new())),
+            history_updates: Arc::new(Mutex::new(Vec::new())),
+            sync_updates: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+}
+
+impl MoneroTauriHandle for MockTauriHandle {
+    fn balance_change(&self, total_balance: Amount, unlocked_balance: Amount) {
+        self.balance_updates
+            .lock()
+            .unwrap()
+            .push((total_balance, unlocked_balance));
+    }
+
+    fn history_update(&self, transactions: Vec<TransactionInfo>) {
+        self.history_updates.lock().unwrap().push(transactions);
+    }
+
+    fn sync_progress(&self, current_block: u64, target_block: u64, progress_percentage: f32) {
+        self.sync_updates
+            .lock()
+            .unwrap()
+            .push((current_block, target_block, progress_percentage));
+    }
+}
+
+#[tokio::test]
+#[serial]
+async fn test_on_money_received_triggers_updates() -> Result<()> {
+    setup_test(|context| async move {
+        let handle = Arc::new(MockTauriHandle::new());
+        let tauri_handle = handle.clone() as Arc<dyn MoneroTauriHandle>;
+
+        let wallets = context.create_wallets().await?;
+        let wallet = wallets.main_wallet().await;
+
+        let listener = TauriWalletListener::new(tauri_handle, wallet).await;
+
+        // Trigger money received event
+        listener.on_money_received("txid", 1000000);
+
+        // Wait for throttle
+        tokio::time::sleep(Duration::from_secs(3)).await;
+
+        let balances = handle.balance_updates.lock().unwrap();
+        // Assert that balance updates are not empty
+        assert!(!balances.is_empty());
+
+        let history = handle.history_updates.lock().unwrap();
+        // Assert that history updates are not empty
+        assert!(!history.is_empty());
+
+        Ok(())
+    })
+    .await;
+    Ok(())
+}
+
+#[tokio::test]
+#[serial]
+async fn test_on_money_spent_triggers_updates() -> Result<()> {
+    setup_test(|context| async move {
+        let handle = Arc::new(MockTauriHandle::new());
+        let tauri_handle = handle.clone() as Arc<dyn MoneroTauriHandle>;
+
+        let wallets = context.create_wallets().await?;
+        let wallet = wallets.main_wallet().await;
+
+        let listener = TauriWalletListener::new(tauri_handle, wallet).await;
+
+        // Trigger money spent event
+        listener.on_money_spent("txid", 500000);
+
+        // Wait for throttle
+        tokio::time::sleep(Duration::from_secs(3)).await;
+
+        let balances = handle.balance_updates.lock().unwrap();
+        // Assert that balance updates are not empty
+        assert!(!balances.is_empty());
+
+        let history = handle.history_updates.lock().unwrap();
+        // Assert that history updates are not empty
+        assert!(!history.is_empty());
+
+        Ok(())
+    })
+    .await;
+    Ok(())
+}
+
+#[tokio::test]
+#[serial]
+async fn test_on_new_block_triggers_sync_progress() -> Result<()> {
+    setup_test(|context| async move {
+        let handle = Arc::new(MockTauriHandle::new());
+        let tauri_handle = handle.clone() as Arc<dyn MoneroTauriHandle>;
+
+        let wallets = context.create_wallets().await?;
+        let wallet = wallets.main_wallet().await;
+
+        let listener = TauriWalletListener::new(tauri_handle, wallet).await;
+
+        // Trigger new block event
+        listener.on_new_block(100);
+
+        // Wait for throttle
+        tokio::time::sleep(Duration::from_secs(3)).await;
+
+        let sync = handle.sync_updates.lock().unwrap();
+        // Assert that sync updates are not empty
+        assert!(!sync.is_empty());
+
+        Ok(())
+    })
+    .await;
+    Ok(())
+}

--- a/monero-wallet/tests/transaction_tests.rs
+++ b/monero-wallet/tests/transaction_tests.rs
@@ -42,6 +42,7 @@ async fn test_receive_funds() -> Result<()> {
         Ok(())
     })
     .await;
+    Ok(())
 }
 
 #[tokio::test]
@@ -61,8 +62,8 @@ async fn test_transfer_funds() -> Result<()> {
         miner_wallet.transfer(&alice_address, amount).await?;
 
         // Generate blocks to confirm the transaction
-        // We need enough blocks for the transaction to be unlocked (10 blocks)
-        // and ideally enough outputs on chain for ring signatures (though coinbase outputs help)
+        // We need enough blocks for the transaction to be unlocked
+        // and ideally enough outputs on chain for ring signatures
         for _ in 0..20 {
             context.monero.generate_block().await?;
         }

--- a/monero-wallet/tests/transaction_tests.rs
+++ b/monero-wallet/tests/transaction_tests.rs
@@ -1,0 +1,155 @@
+mod harness;
+
+use anyhow::Result;
+use harness::{setup_test, TestContext, WALLET_NAME};
+use monero::Network;
+use monero_sys::WalletHandle;
+use monero_wallet::Wallets;
+use serial_test::serial;
+use std::time::Duration;
+
+#[tokio::test]
+#[serial]
+async fn test_transfer_funds() -> Result<()> {
+    setup_test(|context| async move {
+        // Create Alice wallet
+        let wallets_alice = context.create_wallets().await?;
+        let alice_wallet = wallets_alice.main_wallet().await;
+        let alice_address = alice_wallet.main_address().await?;
+
+        // Fund Alice from Miner
+        let miner_wallet = context.monero.wallet("miner")?;
+        let amount = 1_000_000_000_000; // 1 XMR
+
+        // Sending 1 XMR to Alice
+        miner_wallet.transfer(&alice_address, amount).await?;
+
+        // Generate blocks to confirm the transaction
+        // We need enough blocks for the transaction to be unlocked (10 blocks)
+        // and ideally enough outputs on chain for ring signatures (though coinbase outputs help)
+        for _ in 0..20 {
+            context.monero.generate_block().await?;
+        }
+
+        // Wait for sync loop
+        let mut initial_balance = monero::Amount::from_pico(0);
+        for _ in 0..20 {
+            alice_wallet
+                .wait_until_synced(monero_sys::no_listener())
+                .await?;
+            let b = alice_wallet.unlocked_balance().await?;
+            if b.as_pico() > 0 {
+                initial_balance = b;
+                break;
+            }
+            // Pause execution for a while before checking again
+            tokio::time::sleep(Duration::from_millis(500)).await;
+        }
+
+        let total_balance = alice_wallet.total_balance().await?;
+
+        // Total balance should be equal to amount
+        assert_eq!(total_balance.as_pico(), amount);
+        // Unlocked balance should be equal to amount
+        assert_eq!(initial_balance.as_pico(), amount);
+
+        // Create bob's wallet
+        let bob_dir = tempfile::TempDir::new()?;
+        let bob_name = "bob_wallet";
+
+        let bob_wallet = WalletHandle::open_or_create(
+            bob_dir.path().join(bob_name).display().to_string(),
+            context.daemon.clone(),
+            Network::Mainnet,
+            true,
+        )
+        .await?;
+
+        let bob_address = bob_wallet.main_address().await?;
+
+        // Alice sends to Bob
+        let send_amount = 100_000_000_000; // 0.1 XMR
+
+        alice_wallet
+            .transfer_single_destination(&bob_address, monero::Amount::from_pico(send_amount))
+            .await?;
+
+        // Generate blocks to confirm the transaction
+        context.monero.generate_block().await?;
+        context.monero.generate_block().await?;
+
+        // Verify Bob received
+        let mut bob_received = false;
+        for _ in 0..20 {
+            bob_wallet
+                .wait_until_synced(monero_sys::no_listener())
+                .await?;
+            let b = bob_wallet.unlocked_balance().await?;
+            if b.as_pico() == send_amount {
+                bob_received = true;
+                break;
+            }
+            // Pause execution for a while before checking again
+            tokio::time::sleep(Duration::from_millis(500)).await;
+        }
+
+        let bob_total = bob_wallet.total_balance().await?;
+
+        assert!(bob_received);
+        assert_eq!(bob_total.as_pico(), send_amount);
+
+        Ok(())
+    })
+    .await;
+    Ok(())
+}
+
+#[tokio::test]
+#[serial]
+async fn test_transaction_history() -> Result<()> {
+    setup_test(|context| async move {
+        let wallets = context.create_wallets().await?;
+        let main_wallet = wallets.main_wallet().await;
+        let address = main_wallet.main_address().await?;
+
+        // Receive funds
+        let miner_wallet = context.monero.wallet("miner")?;
+        let amount = 1_000_000_000_000; // 1 XMR
+        miner_wallet.transfer(&address, amount).await?;
+
+        context.monero.generate_block().await?;
+        context.monero.generate_block().await?;
+
+        // Polling loop for history
+        let mut history_found = false;
+        let mut transactions = Vec::new();
+        for _ in 0..20 {
+            main_wallet
+                .wait_until_synced(monero_sys::no_listener())
+                .await?;
+            let h = main_wallet.history().await?;
+            if !h.is_empty() {
+                history_found = true;
+                transactions = h;
+                break;
+            }
+            // Pause execution for a while before checking again
+            tokio::time::sleep(Duration::from_millis(500)).await;
+        }
+
+        // Assert that the history is not empty
+        assert!(history_found);
+
+        let tx = &transactions[0];
+
+        // Assert that the transaction is an incoming transaction
+        assert_eq!(tx.direction, monero_sys::TransactionDirection::In);
+
+        // Assert that the transaction amount is correct
+        assert_eq!(tx.amount.as_pico(), amount);
+
+        Ok(())
+    })
+    .await;
+    Ok(())
+}

--- a/monero-wallet/tests/wallet_operations.rs
+++ b/monero-wallet/tests/wallet_operations.rs
@@ -1,0 +1,98 @@
+mod harness;
+
+use anyhow::Result;
+use harness::{setup_test, TestContext};
+use monero::Network;
+use monero_wallet::Wallets;
+use serial_test::serial;
+
+#[tokio::test]
+#[serial]
+async fn test_create_wallet() -> Result<()> {
+    setup_test(|context| async move {
+        let wallets = context.create_wallets().await?;
+        let main_wallet = wallets.main_wallet().await;
+
+        let address = main_wallet.main_address().await?;
+
+        // Check if the address is valid
+        assert_eq!(address.network, Network::Mainnet);
+        // Mainnet standard addresses start with '4'.
+        assert!(address.to_string().starts_with('4'));
+
+        Ok(())
+    })
+    .await;
+    Ok(())
+}
+
+#[tokio::test]
+#[serial]
+async fn test_open_existing_wallet() -> Result<()> {
+    setup_test(|context| async move {
+        let _wallets = context.create_wallets().await?;
+        // Dropping wallets, but the files persist in context.wallet_dir
+        let initial_address = _wallets.main_wallet().await.main_address().await?;
+        drop(_wallets);
+
+        // Re-open
+        let wallets = Wallets::new(
+            context.wallet_dir.path().to_path_buf(),
+            harness::WALLET_NAME.to_string(),
+            context.daemon.clone(),
+            Network::Mainnet,
+            true,
+            None,
+            None,
+        )
+        .await?;
+
+        let main_wallet = wallets.main_wallet().await;
+        let address = main_wallet.main_address().await?;
+
+        assert_eq!(address.network, Network::Mainnet);
+        // address should be the same as the initial address
+        assert_eq!(address.to_string(), initial_address.to_string());
+
+        Ok(())
+    })
+    .await;
+    Ok(())
+}
+
+#[tokio::test]
+#[serial]
+async fn test_restore_wallet_from_seed() -> Result<()> {
+    setup_test(|context| async move {
+        // Create initial wallet and get seed
+        let wallets = context.create_wallets().await?;
+        let main_wallet = wallets.main_wallet().await;
+        let seed = main_wallet.seed().await?;
+        let address = main_wallet.main_address().await?;
+
+        // Create a new wallet dir for restoration
+        let restore_dir = tempfile::TempDir::new()?;
+        let restore_name = "restored_wallet";
+
+        use monero_sys::WalletHandle;
+
+        let restored_wallet = WalletHandle::open_or_create_from_seed(
+            restore_dir.path().join(restore_name).display().to_string(),
+            seed.clone(),
+            Network::Mainnet,
+            0,    // restore height
+            true, // background_sync
+            context.daemon.clone(),
+        )
+        .await?;
+
+        restored_wallet.unsafe_prepare_for_regtest().await;
+
+        let restored_address = restored_wallet.main_address().await?;
+        assert_eq!(address, restored_address);
+
+        Ok(())
+    })
+    .await;
+    Ok(())
+}


### PR DESCRIPTION
## Overview
Adds Integration tests for monero wallet
### Sections Covered:
* Opening existing wallets
* Creating wallets
* Restoring wallets
* Transferring funds
* Receiving funds
* Transaction history
* Changing the Monero node at runtime
* Retrieving recently opened wallets
* Tauri handle calls
* TauriWalletListener
* Swap wallet

## Related Issues
Closes #800

## Screenshot
<img width="904" height="409" alt="Monero wallet tests" src="https://github.com/user-attachments/assets/0165c60f-34de-4339-9375-176fe5229c66" />

