### PR TITLE
fix(monero-harness): add missing ? operator in address_at

### DIFF
--- a/monero-harness/src/lib.rs
+++ b/monero-harness/src/lib.rs
@@ -467,7 +467,7 @@ impl MoneroWallet {
 
     /// Get address at a given account and subaddress index.
     pub async fn address_at(&self, account_index: u32, address_index: u32) -> Result<Address> {
-        Ok(self.wallet.address(account_index, address_index).await)
+        Ok(self.wallet.address(account_index, address_index).await?)
     }
 
     pub async fn balance(&self) -> Result<u64> {


### PR DESCRIPTION
## Summary

The `address` method in `Wallet::address_at` was missing the `?` operator for error propagation, causing a type mismatch.

**Before:**
```rust
Ok(self.wallet.address(account_index, address_index).await)
```

**After:**
```rust
Ok(self.wallet.address(account_index, address_index).await?)
```

## Testing

- Code compiles successfully
- monero-harness package builds without errors
- Integration tests require Docker containers (not run locally)

## Checklist
- [x] Code formatted with dprint
- [x] Clippy passes (for this package)
- [x] Builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)