### PR TITLE
security(swap-core): redact SecretKey in Debug output

### DIFF
--- a/swap-core/src/bitcoin.rs
+++ b/swap-core/src/bitcoin.rs
@@ -39,10 +39,23 @@ use serde::{Deserialize, Serialize};
 use sha2::Sha256;
 use std::str::FromStr;
 
-#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
+/// SECURITY: This type contains secret key material.
+/// - Implements Serialize/Deserialize for state persistence (encrypted at rest recommended)
+/// - Debug output is REDACTED to prevent accidental logging of secrets
+/// - Clone creates untracked copies - use sparingly
+#[derive(Clone, Deserialize, Serialize, PartialEq)]
 pub struct SecretKey {
     inner: Scalar,
     public: Point,
+}
+
+impl std::fmt::Debug for SecretKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("SecretKey")
+            .field("inner", &"[REDACTED]")
+            .field("public", &self.public)
+            .finish()
+    }
 }
 
 impl SecretKey {


### PR DESCRIPTION
## Summary

**Security Issue:** The `SecretKey` struct was deriving `Debug`, which would expose the raw secret scalar bytes if logged or printed.

**Fix:** Implemented a custom `Debug` trait that shows `[REDACTED]` instead of the actual secret key material, while still displaying the public key for debugging purposes.

```rust
impl std::fmt::Debug for SecretKey {
    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
        f.debug_struct("SecretKey")
            .field("inner", &"[REDACTED]")
            .field("public", &self.public)
            .finish()
    }
}
```

## Security Impact

- Prevents accidental exposure of secret key material in logs
- Maintains debugging utility by showing the corresponding public key
- Follows secure coding best practices for cryptographic types

## Testing

- Library compiles successfully
- All dependent packages build correctly
- No changes to public API

## Checklist
- [x] Code formatted
- [x] Builds successfully
- [x] No API changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)