### PR TITLE
Update GNOME runtime from 47 (EOL) to 48

### DIFF
--- a/flatpak/org.eigenwallet.app.json
+++ b/flatpak/org.eigenwallet.app.json
@@ -1,8 +1,8 @@
 {
   "id": "org.eigenwallet.app",
   "runtime": "org.gnome.Platform",
-  "runtime-version": "47",
-  "sdk": "org.gnome.Sdk",
+  "runtime-version": "48",
+  "sdk": "org.gnome.Sdk//48",
   "command": "unstoppableswap-gui-rs.flatpak.sh",
   "finish-args": [
     "--socket=wayland",


### PR DESCRIPTION
## Summary

- Updates Flatpak runtime-version from 47 to 48
- Updates SDK from `org.gnome.Sdk` to `org.gnome.Sdk//48`

GNOME runtime 47 has reached end-of-life. This PR updates to runtime 48.

Related to #840, #841

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates Flatpak manifest to GNOME 48.
> 
> - Bumps `runtime-version` from `47` to `48` in `flatpak/org.eigenwallet.app.json`
> - Pins `sdk` to `org.gnome.Sdk//48`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e26095999680cc4a17f92be51ded90298e5d0966. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->