### PR TITLE
security: remove sensitive xprv logging in export-bitcoin-wallet

### DIFF
--- a/swap/src/cli/api/request.rs
+++ b/swap/src/cli/api/request.rs
@@ -1472,7 +1472,7 @@ pub async fn export_bitcoin_wallet(context: Arc<Context>) -> Result<serde_json::
     let bitcoin_wallet = context.try_get_bitcoin_wallet().await?;
 
     let wallet_export = bitcoin_wallet.wallet_export("cli").await?;
-    tracing::info!(descriptor=%wallet_export.to_string(), "Exported bitcoin wallet");
+    tracing::info!("Exported bitcoin wallet");
     Ok(json!({
         "descriptor": wallet_export.to_string(),
     }))


### PR DESCRIPTION
Fixes #866

This PR removes the insecure logging of the Bitcoin xprv master private key in the export_bitcoin_wallet function. The key was being logged in plaintext to swap-all.log, which is a permanent log file.

Changes:
- Replaced tracing::info! that included the full descriptor with a generic action log.