### PR TITLE
feat(asb): buffer quote construction

### DIFF
--- a/swap/src/asb/event_loop.rs
+++ b/swap/src/asb/event_loop.rs
@@ -303,10 +303,13 @@ where
                         SwarmEvent::Behaviour(OutEvent::QuoteRequested { channel, peer }) => {
                             self.pending_quote_channels.push((channel, peer));
 
-                            // Only start a computation if one isn't already in-flight
-                            // If the length is 1, only the keep-alive future is in the queue
-                            // meaning we are not already computing a quote
-                            if self.pending_quote_channels.len() == 1 {
+                            // If no computation is in flight, we start one
+                            // (If the length is one, only the keep-alive future is in the queue)
+                            if self.inflight_quote_computation.len() == 1 {
+                                // This should be the first request,
+                                // so the pending queue should also have exactly one request
+                                debug_assert!(self.pending_quote_channels.len() == 1);
+
                                 self.inflight_quote_computation.push(
                                     self.make_quote_or_use_cached(
                                         self.min_buy,
@@ -501,6 +504,9 @@ where
                         // We don't log it here to avoid spamming on each request
                         Err(_) => BidQuote::ZERO,
                     };
+
+                    tracing::trace!(?quote, num_requests = self.pending_quote_channels.len(), "Responding with quote to requests");
+
                     for (channel, peer) in self.pending_quote_channels.drain(..) {
                         if self.swarm.behaviour_mut().quote.send_response(channel, quote.clone()).is_err() {
                             tracing::debug!(%peer, "Failed to respond with quote");


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the quote request/response flow in the ASB event loop by batching concurrent quote requests behind a single in-flight computation, which could affect responsiveness and failure behavior under load if the queue grows or the computation stalls.
> 
> **Overview**
> **Buffers and coalesces quote responses**: `OutEvent::QuoteRequested` no longer computes/sends a quote per request; it now queues response channels and triggers **at most one** in-flight quote computation, replying to all pending requests when it resolves (falling back to `BidQuote::ZERO` on error).
> 
> Refactors `make_quote_or_use_cached` to return a `'static` boxed future (cloning needed dependencies) so quote computation can be stored/polled asynchronously in the `tokio::select!` loop without blocking other event processing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3e2b8394cdc82c6f26c59a002e099ecef866a00e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->