### PR TITLE
feat(gui): sortable maker offers on swap page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- GUI: Allow sorting of maker offers on the swap page by largest max amount (default), smallest min amount, or cheapest price, via a subtle sort button above the offer list.
+
 ## [4.3.1] - 2026-04-11
 
 ## [4.3.0] - 2026-04-09

--- a/src-gui/src/renderer/components/pages/swap/swap/init/deposit_and_choose_offer/DepositAndChooseOfferPage.tsx
+++ b/src-gui/src/renderer/components/pages/swap/swap/init/deposit_and_choose_offer/DepositAndChooseOfferPage.tsx
@@ -136,14 +136,19 @@ export default function DepositAndChooseOfferPage({
                   display: "flex",
                   justifyContent: "flex-end",
                   alignItems: "center",
+                  gap: 0.5,
                   mb: 0.5,
+                  opacity: 0.6,
+                  "&:hover": { opacity: 1 },
                 }}
               >
+                <Typography variant="caption" color="text.secondary">
+                  Sorting
+                </Typography>
                 <Tooltip title={`Sort: ${currentSortLabel}`}>
                   <IconButton
                     size="small"
                     onClick={(e) => setSortAnchorEl(e.currentTarget)}
-                    sx={{ opacity: 0.6, "&:hover": { opacity: 1 } }}
                   >
                     <SortIcon fontSize="small" />
                   </IconButton>

--- a/src-gui/src/renderer/components/pages/swap/swap/init/deposit_and_choose_offer/DepositAndChooseOfferPage.tsx
+++ b/src-gui/src/renderer/components/pages/swap/swap/init/deposit_and_choose_offer/DepositAndChooseOfferPage.tsx
@@ -1,4 +1,18 @@
-import { Typography, Box, Paper, Divider, Pagination } from "@mui/material";
+import {
+  Typography,
+  Box,
+  Paper,
+  Divider,
+  Pagination,
+  IconButton,
+  Menu,
+  MenuItem,
+  ListItemIcon,
+  ListItemText,
+  Tooltip,
+} from "@mui/material";
+import SortIcon from "@mui/icons-material/Sort";
+import CheckIcon from "@mui/icons-material/Check";
 import ActionableMonospaceTextBox from "renderer/components/other/ActionableMonospaceTextBox";
 import MakerOfferItem from "./MakerOfferItem";
 import { usePendingSelectMakerApproval } from "store/hooks";
@@ -6,7 +20,16 @@ import MakerDiscoveryStatus from "./MakerDiscoveryStatus";
 import { TauriSwapProgressEventContent } from "models/tauriModelExt";
 import { SatsAmount } from "renderer/components/other/Units";
 import { useState } from "react";
-import { sortApprovalsAndKnownQuotes } from "utils/sortUtils";
+import {
+  sortApprovalsAndKnownQuotes,
+  OfferSortMode,
+} from "utils/sortUtils";
+
+const SORT_OPTIONS: { value: OfferSortMode; label: string }[] = [
+  { value: "large", label: "Large swaps" },
+  { value: "small", label: "Small swaps" },
+  { value: "cheapest", label: "Cheapest" },
+];
 
 export default function DepositAndChooseOfferPage({
   deposit_address,
@@ -15,12 +38,18 @@ export default function DepositAndChooseOfferPage({
 }: TauriSwapProgressEventContent<"WaitingForBtcDeposit">) {
   const pendingSelectMakerApprovals = usePendingSelectMakerApproval();
   const [currentPage, setCurrentPage] = useState(1);
+  const [sortMode, setSortMode] = useState<OfferSortMode>("large");
+  const [sortAnchorEl, setSortAnchorEl] = useState<null | HTMLElement>(null);
   const offersPerPage = 3;
 
   const makerOffers = sortApprovalsAndKnownQuotes(
     pendingSelectMakerApprovals,
     known_quotes,
+    sortMode,
   );
+
+  const currentSortLabel =
+    SORT_OPTIONS.find((o) => o.value === sortMode)?.label ?? "";
 
   // Pagination calculations
   const totalPages = Math.ceil(makerOffers.length / offersPerPage);
@@ -102,6 +131,51 @@ export default function DepositAndChooseOfferPage({
         <Box>
           {makerOffers.length > 0 && (
             <>
+              <Box
+                sx={{
+                  display: "flex",
+                  justifyContent: "flex-end",
+                  alignItems: "center",
+                  mb: 0.5,
+                }}
+              >
+                <Tooltip title={`Sort: ${currentSortLabel}`}>
+                  <IconButton
+                    size="small"
+                    onClick={(e) => setSortAnchorEl(e.currentTarget)}
+                    sx={{ opacity: 0.6, "&:hover": { opacity: 1 } }}
+                  >
+                    <SortIcon fontSize="small" />
+                  </IconButton>
+                </Tooltip>
+                <Menu
+                  anchorEl={sortAnchorEl}
+                  open={Boolean(sortAnchorEl)}
+                  onClose={() => setSortAnchorEl(null)}
+                  anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
+                  transformOrigin={{ vertical: "top", horizontal: "right" }}
+                >
+                  {SORT_OPTIONS.map((option) => (
+                    <MenuItem
+                      key={option.value}
+                      selected={option.value === sortMode}
+                      onClick={() => {
+                        setSortMode(option.value);
+                        setCurrentPage(1);
+                        setSortAnchorEl(null);
+                      }}
+                      dense
+                    >
+                      <ListItemIcon sx={{ minWidth: 28 }}>
+                        {option.value === sortMode && (
+                          <CheckIcon fontSize="small" />
+                        )}
+                      </ListItemIcon>
+                      <ListItemText>{option.label}</ListItemText>
+                    </MenuItem>
+                  ))}
+                </Menu>
+              </Box>
               <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
                 {paginatedOffers.map((quote, index) => {
                   return (

--- a/src-gui/src/renderer/components/pages/swap/swap/init/deposit_and_choose_offer/DepositAndChooseOfferPage.tsx
+++ b/src-gui/src/renderer/components/pages/swap/swap/init/deposit_and_choose_offer/DepositAndChooseOfferPage.tsx
@@ -4,7 +4,6 @@ import {
   Paper,
   Divider,
   Pagination,
-  IconButton,
   Menu,
   MenuItem,
   ListItemIcon,
@@ -136,22 +135,39 @@ export default function DepositAndChooseOfferPage({
                   display: "flex",
                   justifyContent: "flex-end",
                   alignItems: "center",
-                  gap: 0.5,
                   mb: 0.5,
-                  opacity: 0.6,
-                  "&:hover": { opacity: 1 },
                 }}
               >
-                <Typography variant="caption" color="text.secondary">
-                  Sorting
-                </Typography>
                 <Tooltip title={`Sort: ${currentSortLabel}`}>
-                  <IconButton
-                    size="small"
-                    onClick={(e) => setSortAnchorEl(e.currentTarget)}
+                  <Box
+                    component="button"
+                    type="button"
+                    onClick={(e) =>
+                      setSortAnchorEl(e.currentTarget as HTMLElement)
+                    }
+                    sx={{
+                      display: "flex",
+                      alignItems: "center",
+                      gap: 0.5,
+                      px: 0.75,
+                      py: 0.25,
+                      border: "none",
+                      background: "transparent",
+                      color: "inherit",
+                      cursor: "pointer",
+                      borderRadius: 1,
+                      opacity: 0.6,
+                      "&:hover": {
+                        opacity: 1,
+                        bgcolor: "action.hover",
+                      },
+                    }}
                   >
+                    <Typography variant="caption" color="text.secondary">
+                      Sorting
+                    </Typography>
                     <SortIcon fontSize="small" />
-                  </IconButton>
+                  </Box>
                 </Tooltip>
                 <Menu
                   anchorEl={sortAnchorEl}

--- a/src-gui/src/renderer/components/pages/swap/swap/init/deposit_and_choose_offer/DepositAndChooseOfferPage.tsx
+++ b/src-gui/src/renderer/components/pages/swap/swap/init/deposit_and_choose_offer/DepositAndChooseOfferPage.tsx
@@ -18,7 +18,7 @@ import { usePendingSelectMakerApproval } from "store/hooks";
 import MakerDiscoveryStatus from "./MakerDiscoveryStatus";
 import { TauriSwapProgressEventContent } from "models/tauriModelExt";
 import { SatsAmount } from "renderer/components/other/Units";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import {
   sortApprovalsAndKnownQuotes,
   OfferSortMode,
@@ -51,8 +51,16 @@ export default function DepositAndChooseOfferPage({
     SORT_OPTIONS.find((o) => o.value === sortMode)?.label ?? "";
 
   // Pagination calculations
-  const totalPages = Math.ceil(makerOffers.length / offersPerPage);
-  const startIndex = (currentPage - 1) * offersPerPage;
+  const totalPages = Math.max(1, Math.ceil(makerOffers.length / offersPerPage));
+
+  useEffect(() => {
+    if (currentPage > totalPages) {
+      setCurrentPage(totalPages);
+    }
+  }, [currentPage, totalPages]);
+
+  const clampedPage = Math.min(currentPage, totalPages);
+  const startIndex = (clampedPage - 1) * offersPerPage;
   const endIndex = startIndex + offersPerPage;
   const paginatedOffers = makerOffers.slice(startIndex, endIndex);
 
@@ -198,10 +206,10 @@ export default function DepositAndChooseOfferPage({
                 </Menu>
               </Box>
               <Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
-                {paginatedOffers.map((quote, index) => {
+                {paginatedOffers.map((quote) => {
                   return (
                     <MakerOfferItem
-                      key={startIndex + index}
+                      key={quote.quote_with_address.peer_id}
                       quoteWithAddress={quote.quote_with_address}
                       requestId={quote.approval?.request_id}
                     />
@@ -213,7 +221,7 @@ export default function DepositAndChooseOfferPage({
                 <Box sx={{ display: "flex", justifyContent: "center", mt: 2 }}>
                   <Pagination
                     count={totalPages}
-                    page={currentPage}
+                    page={clampedPage}
                     onChange={handlePageChange}
                     color="primary"
                   />

--- a/src-gui/src/utils/sortUtils.ts
+++ b/src-gui/src/utils/sortUtils.ts
@@ -6,9 +6,12 @@ import { QuoteWithAddress } from "models/tauriModel";
 import { isMakerVersionOld, isMakerVersionTooOld } from "./multiAddrUtils";
 import _ from "lodash";
 
+export type OfferSortMode = "large" | "small" | "cheapest";
+
 export function sortApprovalsAndKnownQuotes(
   pendingSelectMakerApprovals: PendingSelectMakerApprovalRequest[],
   known_quotes: QuoteWithAddress[],
+  sortMode: OfferSortMode = "large",
 ) {
   const sortableQuotes: SortableQuoteWithAddress[] =
     pendingSelectMakerApprovals.map((approval) => {
@@ -31,6 +34,18 @@ export function sortApprovalsAndKnownQuotes(
     })),
   );
 
+  const primaryIteratee = (m: SortableQuoteWithAddress) => {
+    const q = m.quote_with_address.quote;
+    switch (sortMode) {
+      case "large":
+        return -(q.max_quantity ?? 0);
+      case "small":
+        return q.min_quantity ?? 0;
+      case "cheapest":
+        return q.price;
+    }
+  };
+
   return (
     _(sortableQuotes)
       .orderBy(
@@ -38,6 +53,8 @@ export function sortApprovalsAndKnownQuotes(
           // Prefer makers that have a 'version' attribute
           // If we don't have a version, we cannot clarify if it's outdated or not
           (m) => (m.quote_with_address.version ? 0 : 1),
+          // Prefer makers with a max quantity > 0 (have liquidity)
+          (m) => ((m.quote_with_address.quote.max_quantity ?? 0) > 0 ? 0 : 1),
           // Prefer makers with a minimum quantity > 0
           (m) => ((m.quote_with_address.quote.min_quantity ?? 0) > 0 ? 0 : 1),
           // Prefer makers that are not incompatible
@@ -49,10 +66,10 @@ export function sortApprovalsAndKnownQuotes(
                 : 0,
           // Prefer approvals over actual quotes
           (m) => (m.approval ? 0 : 1),
-          // Prefer makers with a lower price
-          (m) => m.quote_with_address.quote.price,
+          // User-selected sort criterion
+          primaryIteratee,
         ],
-        ["asc", "asc", "asc", "asc", "asc"],
+        ["asc", "asc", "asc", "asc", "asc", "asc"],
       )
       // Remove duplicate makers
       .uniqBy((m) => m.quote_with_address.peer_id)

--- a/src-gui/src/utils/sortUtils.ts
+++ b/src-gui/src/utils/sortUtils.ts
@@ -38,9 +38,9 @@ export function sortApprovalsAndKnownQuotes(
     const q = m.quote_with_address.quote;
     switch (sortMode) {
       case "large":
-        return -(q.max_quantity ?? 0);
+        return -q.max_quantity;
       case "small":
-        return q.min_quantity ?? 0;
+        return q.min_quantity;
       case "cheapest":
         return q.price;
     }
@@ -54,9 +54,9 @@ export function sortApprovalsAndKnownQuotes(
           // If we don't have a version, we cannot clarify if it's outdated or not
           (m) => (m.quote_with_address.version ? 0 : 1),
           // Prefer makers with a max quantity > 0 (have liquidity)
-          (m) => ((m.quote_with_address.quote.max_quantity ?? 0) > 0 ? 0 : 1),
+          (m) => (m.quote_with_address.quote.max_quantity > 0 ? 0 : 1),
           // Prefer makers with a minimum quantity > 0
-          (m) => ((m.quote_with_address.quote.min_quantity ?? 0) > 0 ? 0 : 1),
+          (m) => (m.quote_with_address.quote.min_quantity > 0 ? 0 : 1),
           // Prefer makers that are not incompatible
           (m) =>
             isMakerVersionTooOld(m.quote_with_address.version)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk UI/UX change that tweaks client-side sorting/pagination and list keys; primary risk is offer ordering/regression in pagination edge cases.
> 
> **Overview**
> Adds a *sorting control* above the maker offer list on the swap deposit/offer-selection page, letting users switch between **Large swaps (default)**, **Small swaps**, and **Cheapest**; changing sort resets pagination.
> 
> Updates `sortApprovalsAndKnownQuotes` to accept an `OfferSortMode` and apply the selected primary sort after existing preference rules (version/liquidity/compatibility/approval), and hardens pagination/rendering by clamping page counts and using a stable `peer_id` key for offer rows. Also records the change in `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8ec0e7405f1b8562e355b48b98a8f67638fee9f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->