### PR TITLE
feat(wormhole): gate old swaps

### DIFF
--- a/.sqlx/query-32cafb8a1dc70149d335cd8603e3907f5bdf8b433036c4cca93772a1e3bfa3e2.json
+++ b/.sqlx/query-32cafb8a1dc70149d335cd8603e3907f5bdf8b433036c4cca93772a1e3bfa3e2.json
@@ -1,0 +1,28 @@
+{
+  "db_name": "SQLite",
+  "query": "\n            SELECT s.swap_id, s.state, p.peer_id\n            FROM (\n                SELECT max(id) as id, swap_id, state, entered_at\n                FROM swap_states\n                GROUP BY swap_id\n            ) s\n            INNER JOIN peers p ON s.swap_id = p.swap_id\n            WHERE CAST(strftime('%s', substr(s.entered_at, 1, 19)) AS INTEGER)\n                  >= CAST(strftime('%s', 'now') AS INTEGER) - ?\n            ",
+  "describe": {
+    "columns": [
+      {
+        "name": "swap_id",
+        "ordinal": 0,
+        "type_info": "Text"
+      },
+      {
+        "name": "state",
+        "ordinal": 1,
+        "type_info": "Text"
+      },
+      {
+        "name": "peer_id",
+        "ordinal": 2,
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": [false, false, false]
+  },
+  "hash": "32cafb8a1dc70149d335cd8603e3907f5bdf8b433036c4cca93772a1e3bfa3e2"
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- ASB: Wormhole eligibility now only considers swaps whose most recent state update falls within a configurable freshness window. This is controlled by the new `tor.wormhole_swap_freshness_hours` config option (default: `168`, i.e. 7 days). Inactive peers no longer keep their wormhole indefinitely.
+
 ## [4.3.1] - 2026-04-11
 
 ## [4.3.0] - 2026-04-09

--- a/dev-docs/asb/README.md
+++ b/dev-docs/asb/README.md
@@ -161,7 +161,7 @@ The ASB provider has to monitor Monero funds to make sure the ASB still has liqu
 
 If `tor.register_hidden_service` is set to `true` that asb will automatically start listening on an onion service.
 
-If `tor.wormhole_enabled` is set to `true` (default), the ASB will spawn dedicated per-peer onion services (wormholes) for peers that have committed funds to a swap. `tor.wormhole_max_concurrent_rend_requests` controls the maximum concurrent rendezvous requests per wormhole (default: 3). `tor.wormhole_num_intro_points` controls the number of introduction points per wormhole (default: 3).
+If `tor.wormhole_enabled` is set to `true` (default), the ASB will spawn dedicated per-peer onion services (wormholes) for peers that have committed funds to a swap. `tor.wormhole_max_concurrent_rend_requests` controls the maximum concurrent rendezvous requests per wormhole (default: 3). `tor.wormhole_num_intro_points` controls the number of introduction points per wormhole (default: 3). `tor.wormhole_swap_freshness_hours` bounds how far back swaps are considered when deciding wormhole eligibility; peers whose most recent swap state update is older than this window are ignored (default: 168, i.e. 7 days).
 
 ### Exporting the Bitcoin wallet descriptor
 

--- a/docs/content/becoming_a_maker/overview.mdx
+++ b/docs/content/becoming_a_maker/overview.mdx
@@ -217,6 +217,7 @@ wormhole_num_intro_points = 3
 | `wormhole_enabled` | Whether the asb should spawn dedicated per-peer onion services (wormholes) for peers that have committed funds to a swap. Default: `true`. |
 | `wormhole_max_concurrent_rend_requests` | Maximum concurrent rendezvous requests per wormhole. Default: `3`. |
 | `wormhole_num_intro_points` | Number of introduction points per wormhole onion service. Default: `3`. |
+| `wormhole_swap_freshness_hours` | Only peers whose most recent swap state update falls within this window (in hours) are eligible for a wormhole. Older swaps are ignored, so inactive peers do not accumulate onion services indefinitely. Default: `168` (7 days). |
 
 
 ### Network Section

--- a/swap-asb/src/main.rs
+++ b/swap-asb/src/main.rs
@@ -244,6 +244,7 @@ pub async fn main() -> Result<()> {
                 config.tor.wormhole_enabled,
                 config.tor.wormhole_max_concurrent_rend_requests,
                 config.tor.wormhole_num_intro_points,
+                config.tor.wormhole_swap_freshness_hours,
                 db.clone(),
             )?;
 

--- a/swap-env/src/config.rs
+++ b/swap-env/src/config.rs
@@ -96,6 +96,11 @@ pub struct TorConf {
     /// Number of introduction points per wormhole onion service.
     #[serde(default = "default_wormhole_num_intro_points")]
     pub wormhole_num_intro_points: u8,
+    /// Only swaps whose latest state update occurred within this many hours
+    /// are considered when deciding which peers receive a wormhole. Stale
+    /// swaps beyond this window are ignored.
+    #[serde(default = "default_wormhole_swap_freshness_hours")]
+    pub wormhole_swap_freshness_hours: u64,
 }
 
 fn default_max_concurrent_rend_requests() -> usize {
@@ -114,6 +119,10 @@ fn default_wormhole_num_intro_points() -> u8 {
     3
 }
 
+fn default_wormhole_swap_freshness_hours() -> u64 {
+    7 * 24
+}
+
 impl Default for TorConf {
     fn default() -> Self {
         Self {
@@ -123,6 +132,7 @@ impl Default for TorConf {
             wormhole_enabled: default_wormhole_enabled(),
             wormhole_max_concurrent_rend_requests: default_wormhole_max_concurrent_rend_requests(),
             wormhole_num_intro_points: default_wormhole_num_intro_points(),
+            wormhole_swap_freshness_hours: default_wormhole_swap_freshness_hours(),
         }
     }
 }

--- a/swap-orchestrator/src/images.rs
+++ b/swap-orchestrator/src/images.rs
@@ -33,8 +33,7 @@ pub static ASB_TRACING_LOGGER_IMAGE: &str =
     "alpine@sha256:4bcff63911fcb4448bd4fdacec207030997caf25e9bea4045fa6c8c44de311d1";
 
 /// cloudflared 2026.3.0 (https://hub.docker.com/r/cloudflare/cloudflared)
-pub static CLOUDFLARED_IMAGE: &str =
-    "cloudflare/cloudflared@sha256:6b599ca3e974349ead3286d178da61d291961182ec3fe9c505e1dd02c8ac31b0";
+pub static CLOUDFLARED_IMAGE: &str = "cloudflare/cloudflared@sha256:6b599ca3e974349ead3286d178da61d291961182ec3fe9c505e1dd02c8ac31b0";
 
 /// These are built from source
 pub static ASB_IMAGE_FROM_SOURCE: DockerBuildInput = DockerBuildInput {

--- a/swap-orchestrator/src/main.rs
+++ b/swap-orchestrator/src/main.rs
@@ -309,21 +309,16 @@ fn main() {
 /// the public wss external address required by the Cloudflare Tunnel, and
 /// writes it back. Idempotent — running this repeatedly does not duplicate
 /// entries.
-fn ensure_cloudflared_addresses_in_config(
-    recipe: &OrchestratorInput,
-    cf: &CloudflaredConfig,
-) {
+fn ensure_cloudflared_addresses_in_config(recipe: &OrchestratorInput, cf: &CloudflaredConfig) {
     let config_path = recipe.directories.asb_config_path_on_host_as_path_buf();
 
     let mut config = swap_env::config::read_config(config_path.clone())
         .expect("Failed to read asb config for cloudflared patching")
         .expect("asb config must exist by this point");
 
-    let ws_listen: Multiaddr = Multiaddr::from_str(&format!(
-        "/ip4/0.0.0.0/tcp/{}/ws",
-        cf.internal_port
-    ))
-    .expect("ws listen multiaddr to be valid");
+    let ws_listen: Multiaddr =
+        Multiaddr::from_str(&format!("/ip4/0.0.0.0/tcp/{}/ws", cf.internal_port))
+            .expect("ws listen multiaddr to be valid");
 
     let wss_external: Multiaddr = Multiaddr::from_str(&format!(
         "/dns4/{}/tcp/{}/wss",
@@ -387,7 +382,9 @@ fn print_cloudflared_instructions(cf: &CloudflaredConfig) {
         "  4. Peers will reach this ASB at /dns4/{}/tcp/{}/wss",
         cf.external_host, cf.external_port
     );
-    println!("  5. Do NOT put a Cloudflare Access policy in front of this hostname — libp2p clients cannot authenticate with it.");
+    println!(
+        "  5. Do NOT put a Cloudflare Access policy in front of this hostname — libp2p clients cannot authenticate with it."
+    );
 }
 
 fn unix_epoch_secs() -> u64 {

--- a/swap/src/asb/network.rs
+++ b/swap/src/asb/network.rs
@@ -211,9 +211,7 @@ pub mod behaviour {
                     channels.service_tx,
                     channels.handle_rx,
                     wormhole::alice::Config {
-                        swap_freshness: Duration::from_secs(
-                            wormhole_swap_freshness_hours.saturating_mul(3600),
-                        ),
+                        swap_freshness_hours: wormhole_swap_freshness_hours,
                         ..wormhole::alice::Config::default()
                     },
                 )

--- a/swap/src/asb/network.rs
+++ b/swap/src/asb/network.rs
@@ -193,6 +193,7 @@ pub mod behaviour {
             connection_limits: connection_limits::ConnectionLimits,
             trust_provider: Arc<dyn PeerTrust + Send + Sync>,
             wormhole_channels: Option<WormholeChannels>,
+            wormhole_swap_freshness_hours: u64,
         ) -> Self {
             let (identity, namespace) = identify_params;
             let agent_version = format!("asb/{} ({})", env!("CARGO_PKG_VERSION"), namespace);
@@ -209,7 +210,12 @@ pub mod behaviour {
                     trust_provider,
                     channels.service_tx,
                     channels.handle_rx,
-                    wormhole::alice::Config::default(),
+                    wormhole::alice::Config {
+                        swap_freshness: Duration::from_secs(
+                            wormhole_swap_freshness_hours.saturating_mul(3600),
+                        ),
+                        ..wormhole::alice::Config::default()
+                    },
                 )
             });
 

--- a/swap/src/database/sqlite.rs
+++ b/swap/src/database/sqlite.rs
@@ -507,10 +507,7 @@ impl SqliteDatabase {
     /// accept the offset trailer, so we `substr` down to the first 19
     /// characters before parsing with `strftime('%s', ...)`. All writes use
     /// `OffsetDateTime::now_utc()`, so dropping the offset is safe.
-    pub async fn all_fresh(
-        &self,
-        freshness_hours: u64,
-    ) -> Result<Vec<(PeerId, Uuid, State)>> {
+    pub async fn all_fresh(&self, freshness_hours: u64) -> Result<Vec<(PeerId, Uuid, State)>> {
         let freshness_seconds = (freshness_hours as i64).saturating_mul(3600);
 
         let rows = sqlx::query!(

--- a/swap/src/database/sqlite.rs
+++ b/swap/src/database/sqlite.rs
@@ -498,12 +498,80 @@ impl Database for SqliteDatabase {
     }
 }
 
+impl SqliteDatabase {
+    /// Like [`Database::all`] but only returns swaps whose latest state
+    /// update happened within `freshness`.
+    ///
+    /// `entered_at` is stored as a Rust-formatted string
+    /// (`YYYY-MM-DD HH:MM:SS.fff +00:00:00`). SQLite's date functions don't
+    /// accept the offset trailer, so we `substr` down to the first 19
+    /// characters before parsing with `strftime('%s', ...)`. All writes use
+    /// `OffsetDateTime::now_utc()`, so dropping the offset is safe.
+    pub async fn all_fresh(
+        &self,
+        freshness: std::time::Duration,
+    ) -> Result<Vec<(PeerId, Uuid, State)>> {
+        let freshness_seconds = freshness.as_secs() as i64;
+
+        let rows = sqlx::query!(
+            r#"
+            SELECT s.swap_id, s.state, p.peer_id
+            FROM (
+                SELECT max(id) as id, swap_id, state, entered_at
+                FROM swap_states
+                GROUP BY swap_id
+            ) s
+            INNER JOIN peers p ON s.swap_id = p.swap_id
+            WHERE CAST(strftime('%s', substr(s.entered_at, 1, 19)) AS INTEGER)
+                  >= CAST(strftime('%s', 'now') AS INTEGER) - ?
+            "#,
+            freshness_seconds,
+        )
+        .fetch_all(&self.pool)
+        .await?;
+
+        let result = rows
+            .iter()
+            .filter_map(|row| {
+                let swap_id = match Uuid::from_str(&row.swap_id) {
+                    Ok(id) => id,
+                    Err(e) => {
+                        tracing::error!(swap_id = %row.swap_id, error = ?e, "Failed to parse UUID");
+                        return None;
+                    }
+                };
+                let peer_id = match PeerId::from_str(&row.peer_id) {
+                    Ok(id) => id,
+                    Err(e) => {
+                        tracing::error!(%swap_id, error = ?e, "Failed to parse PeerId");
+                        return None;
+                    }
+                };
+                let state = match serde_json::from_str::<Swap>(&row.state) {
+                    Ok(a) => State::from(a),
+                    Err(e) => {
+                        tracing::error!(%swap_id, error = ?e, "Failed to deserialize state");
+                        return None;
+                    }
+                };
+
+                Some((peer_id, swap_id, state))
+            })
+            .collect();
+
+        Ok(result)
+    }
+}
+
 #[async_trait]
 impl crate::network::wormhole::PeerTrust for SqliteDatabase {
-    async fn peers_with_financially_relevant_swap(&self) -> Result<Vec<PeerId>> {
+    async fn peers_with_financially_relevant_swap(
+        &self,
+        freshness: std::time::Duration,
+    ) -> Result<Vec<PeerId>> {
         use std::collections::HashSet;
 
-        let swaps = self.all().await?;
+        let swaps = self.all_fresh(freshness).await?;
         let peers = swaps
             .into_iter()
             .filter_map(|(peer_id, _, state)| {

--- a/swap/src/database/sqlite.rs
+++ b/swap/src/database/sqlite.rs
@@ -500,7 +500,7 @@ impl Database for SqliteDatabase {
 
 impl SqliteDatabase {
     /// Like [`Database::all`] but only returns swaps whose latest state
-    /// update happened within `freshness`.
+    /// update happened within the last `freshness_hours`.
     ///
     /// `entered_at` is stored as a Rust-formatted string
     /// (`YYYY-MM-DD HH:MM:SS.fff +00:00:00`). SQLite's date functions don't
@@ -509,9 +509,9 @@ impl SqliteDatabase {
     /// `OffsetDateTime::now_utc()`, so dropping the offset is safe.
     pub async fn all_fresh(
         &self,
-        freshness: std::time::Duration,
+        freshness_hours: u64,
     ) -> Result<Vec<(PeerId, Uuid, State)>> {
-        let freshness_seconds = freshness.as_secs() as i64;
+        let freshness_seconds = (freshness_hours as i64).saturating_mul(3600);
 
         let rows = sqlx::query!(
             r#"
@@ -567,11 +567,11 @@ impl SqliteDatabase {
 impl crate::network::wormhole::PeerTrust for SqliteDatabase {
     async fn peers_with_financially_relevant_swap(
         &self,
-        freshness: std::time::Duration,
+        freshness_hours: u64,
     ) -> Result<Vec<PeerId>> {
         use std::collections::HashSet;
 
-        let swaps = self.all_fresh(freshness).await?;
+        let swaps = self.all_fresh(freshness_hours).await?;
         let peers = swaps
             .into_iter()
             .filter_map(|(peer_id, _, state)| {

--- a/swap/src/network/swarm.rs
+++ b/swap/src/network/swarm.rs
@@ -37,6 +37,7 @@ pub fn asb<LR>(
     wormhole_enabled: bool,
     wormhole_max_concurrent_rend_requests: usize,
     wormhole_num_intro_points: u8,
+    wormhole_swap_freshness_hours: u64,
     trust_provider: Arc<dyn super::wormhole::PeerTrust + Send + Sync>,
 ) -> Result<(
     Swarm<asb::Behaviour<LR>>,
@@ -91,6 +92,7 @@ where
         } else {
             None
         },
+        wormhole_swap_freshness_hours,
     );
 
     let mut swarm = SwarmBuilder::with_existing_identity(identity)

--- a/swap/src/network/wormhole/alice/mod.rs
+++ b/swap/src/network/wormhole/alice/mod.rs
@@ -395,7 +395,10 @@ impl NetworkBehaviour for Behaviour {
             let trust_provider = Arc::clone(&self.trust_provider);
             let freshness = self.swap_freshness;
             let fut: Fuse<BoxFuture<'static, Vec<PeerId>>> = async move {
-                match trust_provider.peers_with_financially_relevant_swap(freshness).await {
+                match trust_provider
+                    .peers_with_financially_relevant_swap(freshness)
+                    .await
+                {
                     Ok(peers) => peers,
                     Err(e) => {
                         tracing::warn!(error = ?e, "Failed to query peers");

--- a/swap/src/network/wormhole/alice/mod.rs
+++ b/swap/src/network/wormhole/alice/mod.rs
@@ -35,16 +35,16 @@ const BACKOFF_MULTIPLIER: f64 = 1.5;
 pub struct Config {
     /// How often to poll the trust provider for new peers.
     pub poll_interval: Duration,
-    /// Only swaps whose latest state update occurred within this window
+    /// Only swaps whose latest state update occurred within this many hours
     /// count as financially relevant.
-    pub swap_freshness: Duration,
+    pub swap_freshness_hours: u64,
 }
 
 impl Default for Config {
     fn default() -> Self {
         Self {
             poll_interval: Duration::from_secs(60),
-            swap_freshness: Duration::from_secs(7 * 24 * 3600),
+            swap_freshness_hours: 168,
         }
     }
 }
@@ -79,9 +79,9 @@ pub struct Behaviour {
 
     /// Timer for periodic polling of the trust provider.
     poll_interval: tokio::time::Interval,
-    /// Only swaps whose latest state update occurred within this window
+    /// Only swaps whose latest state update occurred within this many hours
     /// count as financially relevant.
-    swap_freshness: Duration,
+    swap_freshness_hours: u64,
 
     /// Channel to send service spawn requests to the wrapper transport.
     service_tx: mpsc::UnboundedSender<ServiceRequest>,
@@ -139,7 +139,7 @@ impl Behaviour {
             last_sent: HashMap::new(),
             backoff: BackoffTracker::new(BACKOFF_INITIAL, BACKOFF_MAX, BACKOFF_MULTIPLIER),
             poll_interval,
-            swap_freshness: config.swap_freshness,
+            swap_freshness_hours: config.swap_freshness_hours,
             pending_query: OptionFuture::from(None),
         }
     }
@@ -393,10 +393,10 @@ impl NetworkBehaviour for Behaviour {
         // Check if it's time to poll the trust provider
         if self.pending_query.is_terminated() && self.poll_interval.poll_tick(cx).is_ready() {
             let trust_provider = Arc::clone(&self.trust_provider);
-            let freshness = self.swap_freshness;
+            let freshness_hours = self.swap_freshness_hours;
             let fut: Fuse<BoxFuture<'static, Vec<PeerId>>> = async move {
                 match trust_provider
-                    .peers_with_financially_relevant_swap(freshness)
+                    .peers_with_financially_relevant_swap(freshness_hours)
                     .await
                 {
                     Ok(peers) => peers,

--- a/swap/src/network/wormhole/alice/mod.rs
+++ b/swap/src/network/wormhole/alice/mod.rs
@@ -35,12 +35,16 @@ const BACKOFF_MULTIPLIER: f64 = 1.5;
 pub struct Config {
     /// How often to poll the trust provider for new peers.
     pub poll_interval: Duration,
+    /// Only swaps whose latest state update occurred within this window
+    /// count as financially relevant.
+    pub swap_freshness: Duration,
 }
 
 impl Default for Config {
     fn default() -> Self {
         Self {
             poll_interval: Duration::from_secs(60),
+            swap_freshness: Duration::from_secs(7 * 24 * 3600),
         }
     }
 }
@@ -75,6 +79,9 @@ pub struct Behaviour {
 
     /// Timer for periodic polling of the trust provider.
     poll_interval: tokio::time::Interval,
+    /// Only swaps whose latest state update occurred within this window
+    /// count as financially relevant.
+    swap_freshness: Duration,
 
     /// Channel to send service spawn requests to the wrapper transport.
     service_tx: mpsc::UnboundedSender<ServiceRequest>,
@@ -132,6 +139,7 @@ impl Behaviour {
             last_sent: HashMap::new(),
             backoff: BackoffTracker::new(BACKOFF_INITIAL, BACKOFF_MAX, BACKOFF_MULTIPLIER),
             poll_interval,
+            swap_freshness: config.swap_freshness,
             pending_query: OptionFuture::from(None),
         }
     }
@@ -385,8 +393,9 @@ impl NetworkBehaviour for Behaviour {
         // Check if it's time to poll the trust provider
         if self.pending_query.is_terminated() && self.poll_interval.poll_tick(cx).is_ready() {
             let trust_provider = Arc::clone(&self.trust_provider);
+            let freshness = self.swap_freshness;
             let fut: Fuse<BoxFuture<'static, Vec<PeerId>>> = async move {
-                match trust_provider.peers_with_financially_relevant_swap().await {
+                match trust_provider.peers_with_financially_relevant_swap(freshness).await {
                     Ok(peers) => peers,
                     Err(e) => {
                         tracing::warn!(error = ?e, "Failed to query peers");

--- a/swap/src/network/wormhole/mod.rs
+++ b/swap/src/network/wormhole/mod.rs
@@ -2,6 +2,7 @@ pub mod alice;
 pub mod bob;
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use anyhow::Result;
 use libp2p::{Multiaddr, PeerId};
@@ -29,8 +30,12 @@ pub struct ServiceHandle {
 /// Provides trust information about peers (Alice side).
 #[async_trait::async_trait]
 pub trait PeerTrust {
-    /// Returns peers that have committed real funds to a swap.
-    async fn peers_with_financially_relevant_swap(&self) -> Result<Vec<PeerId>>;
+    /// Returns peers that have committed real funds to a swap whose latest
+    /// state update occurred within `freshness`. Older swaps are ignored.
+    async fn peers_with_financially_relevant_swap(
+        &self,
+        freshness: Duration,
+    ) -> Result<Vec<PeerId>>;
 }
 
 /// Stores wormhole addresses received from peers (Bob side).

--- a/swap/src/network/wormhole/mod.rs
+++ b/swap/src/network/wormhole/mod.rs
@@ -2,7 +2,6 @@ pub mod alice;
 pub mod bob;
 
 use std::sync::Arc;
-use std::time::Duration;
 
 use anyhow::Result;
 use libp2p::{Multiaddr, PeerId};
@@ -31,10 +30,11 @@ pub struct ServiceHandle {
 #[async_trait::async_trait]
 pub trait PeerTrust {
     /// Returns peers that have committed real funds to a swap whose latest
-    /// state update occurred within `freshness`. Older swaps are ignored.
+    /// state update occurred within the last `freshness_hours`. Older swaps
+    /// are ignored.
     async fn peers_with_financially_relevant_swap(
         &self,
-        freshness: Duration,
+        freshness_hours: u64,
     ) -> Result<Vec<PeerId>>;
 }
 


### PR DESCRIPTION
- **feat(wormhole): gate peer trust on swap freshness**
- **fix**

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes wormhole peer-eligibility and adds a new time-based filter on swap-state queries; misconfiguration or query edge cases could cause peers to lose wormhole access unexpectedly or increase DB load.
> 
> **Overview**
> Wormhole eligibility is now bounded by a configurable freshness window via new `tor.wormhole_swap_freshness_hours` (default 168h), preventing inactive peers with old swaps from keeping wormholes indefinitely.
> 
> This threads the new config through ASB startup/swarm/behaviour, extends `wormhole::alice::Config` and `PeerTrust` to accept `freshness_hours`, and updates the SQLite trust provider to query only swaps whose **latest** `swap_states.entered_at` falls within the window (new `SqliteDatabase::all_fresh` + sqlx query artifact). Docs/changelog are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b83f7c84b90e2fd3d4595f4147f61ca75fc9fcff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->