### PR TITLE
feat(asb-rpc): include btc_redeem_fee in get-swaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- ASB+CONTROLLER: `get-swaps` now includes the `btc_redeem_fee` per swap: the fee Alice paid (or will pay) for the Bitcoin redeem transaction.
+
 ## [4.4.1] - 2026-04-15
 
 - ASB+CONTROLLER: New `get-current-quote` command returns the quote the ASB is currently serving to peers (price per XMR, min and max quantity). Reuses the in-flight quote cache so repeated calls don't trigger extra work.

--- a/swap-controller-api/src/lib.rs
+++ b/swap-controller-api/src/lib.rs
@@ -79,6 +79,9 @@ pub struct Swap {
     /// Exchange rate: BTC per XMR (amount of BTC needed to buy 1 XMR)
     #[serde(with = "bitcoin::amount::serde::as_sat")]
     pub exchange_rate: bitcoin::Amount,
+    /// Fee paid by Alice for the Bitcoin redeem transaction, in satoshis.
+    #[serde(with = "bitcoin::amount::serde::as_sat")]
+    pub btc_redeem_fee: bitcoin::Amount,
     pub peer_id: String,
     pub completed: bool,
 }

--- a/swap-controller/src/main.rs
+++ b/swap-controller/src/main.rs
@@ -88,6 +88,7 @@ async fn dispatch(cmd: Cmd, client: impl AsbApiClient) -> anyhow::Result<()> {
                 "BTC",
                 "XMR",
                 "Rate (BTC/XMR)",
+                "BTC Redeem Fee",
                 "Peer ID",
                 "Completed",
             ]);
@@ -106,6 +107,7 @@ async fn dispatch(cmd: Cmd, client: impl AsbApiClient) -> anyhow::Result<()> {
                         // Floating point may introduce very small inaccuracies here
                         &format!("{:.12} XMR", xmr.as_xmr()),
                         &swap.exchange_rate.to_string(),
+                        &swap.btc_redeem_fee.to_string(),
                         &swap.peer_id,
                         &swap.completed.to_string(),
                     ]);

--- a/swap-machine/src/alice/mod.rs
+++ b/swap-machine/src/alice/mod.rs
@@ -731,7 +731,7 @@ pub struct State3 {
     /// in case of a refund. Otherwise Bob will only be partially refunded.
     #[serde(default)]
     tx_reclaim_sig_bob: Option<swap_core::bitcoin::Signature>,
-    tx_redeem_fee: bitcoin::Amount,
+    pub tx_redeem_fee: bitcoin::Amount,
     pub tx_punish_fee: bitcoin::Amount,
     pub tx_refund_fee: bitcoin::Amount,
     #[serde(default)]

--- a/swap/src/asb/rpc/server.rs
+++ b/swap/src/asb/rpc/server.rs
@@ -218,6 +218,7 @@ impl AsbApiServer for RpcImpl {
                 btc_amount: state3.btc,
                 xmr_amount: state3.xmr.as_pico(),
                 exchange_rate,
+                btc_redeem_fee: state3.tx_redeem_fee,
                 peer_id: peer_id.to_string(),
                 completed: is_complete(&current_alice),
             });


### PR DESCRIPTION
Adds btc_redeem_fee to each swap returned by the get-swaps JSON-RPC and surfaces it as a new column in the controller's get-swaps table. The value comes straight from the Alice State3's tx_redeem_fee, so it's the fee Alice paid (or will pay) to publish TxRedeem.

Also made State3::tx_redeem_fee pub to match its sibling fields (tx_punish_fee, tx_refund_fee, etc.), and dropped a one-line Unreleased entry in the CHANGELOG.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Extends the `get-swaps` JSON-RPC response schema and controller output, which can break downstream consumers expecting the old swap shape. The change is otherwise a straightforward additional field plumbed from persisted swap state with low behavioral impact.
> 
> **Overview**
> Adds `btc_redeem_fee` (satoshis) to each swap returned by the ASB `get_swaps` JSON-RPC, sourced from Alice `State3.tx_redeem_fee` (made `pub` to expose it).
> 
> Surfaces the new value in `swap-controller` by adding a **BTC Redeem Fee** column to the `get-swaps` table output, and documents the addition in the Unreleased `CHANGELOG`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 119ec6059704cfd67afad5cd98cafe9016feee76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->