### PR TITLE
Fix broken link in intro slideshow

### DIFF
--- a/src-gui/src/renderer/components/modal/introduction/slides/Slide05_KeepAnEyeOnYourSwaps.tsx
+++ b/src-gui/src/renderer/components/modal/introduction/slides/Slide05_KeepAnEyeOnYourSwaps.tsx
@@ -17,7 +17,7 @@ export default function Slide05_KeepAnEyeOnYourSwaps(props: IntroSlideProps) {
         point during the refund period.
       </Typography>
       <Typography>
-        <ExternalLink href="https://docs.unstoppableswap.net/usage/first_swap">
+        <ExternalLink href="https://docs.eigenwallet.org/getting_started/first_swap">
           Learn more about atomic swaps
         </ExternalLink>
       </Typography>


### PR DESCRIPTION
Hi, I noticed that on the second slide for step 3 of the introduction slides, the linked url (discussing atomic swaps) is broken; pretty easy to fix. 

Also, tangentially related (sorry for digressing but b4 opening an issue I thought asking here may be wise bc maybe it's really petty idk): maybe it would be good to have an option to clear the local cache? Not the wallets themselves, but the folder w/ the settings.bin file (needed to delete this file to see the intro slides again after the first viewing), on linux it's ~/.local/share/net.unstoppableswap.gui, which took a bit to discern as I was preoccupied with the red herring of ~/.ls/eigenwallet (not to mention ~/ls/xmr-btc-swap! =); if not an option for clearing the cache, at least mentioning these paths somewhere in the docs (although the docs are also kinda broke lol) would be handy.