### PR TITLE
fix(monero-sys): keep log callback installed while any WalletManager exists

### DIFF
--- a/monero-sys/src/lib.rs
+++ b/monero-sys/src/lib.rs
@@ -86,6 +86,47 @@ type AnyBox = Box<dyn Any + Send>;
 struct WalletManager {
     /// A wrapper around the raw C++ wallet manager pointer.
     inner: RawWalletManager,
+    _log_guard: LogCallbackGuard,
+}
+
+/// Refcounted guard for the process-wide C++ log callback.
+///
+/// `WalletManagerFactory` and the easylogging++ callback registry are global,
+/// so the callback must stay installed while any [`WalletManager`] exists and
+/// be uninstalled once the last one drops. If a new [`WalletManager`] is later
+/// constructed, the callback is re-installed; install/uninstall stay balanced.
+struct LogCallbackGuard;
+
+static LOG_CALLBACK_USERS: Mutex<usize> = Mutex::new(0);
+
+impl LogCallbackGuard {
+    fn acquire(span_name: &str) -> anyhow::Result<Self> {
+        let mut count = LOG_CALLBACK_USERS
+            .lock()
+            .expect("log callback mutex not poisoned");
+        if *count == 0 {
+            let_cxx_string!(span_name = span_name);
+            bridge::log::install_log_callback(&span_name)
+                .context("Failed to install log callback: FFI call failed with exception")?;
+        }
+        *count += 1;
+
+        Ok(Self)
+    }
+}
+
+impl Drop for LogCallbackGuard {
+    fn drop(&mut self) {
+        let mut count = LOG_CALLBACK_USERS
+            .lock()
+            .expect("log callback mutex not poisoned");
+        *count -= 1;
+        if *count == 0 {
+            if let Err(e) = bridge::log::uninstall_log_callback() {
+                tracing::error!(error=%e, "Failed to uninstall C++ log callback");
+            }
+        }
+    }
 }
 
 /// This is our own wrapper around a raw C++ wallet manager pointer.
@@ -1197,16 +1238,6 @@ impl Wallet {
         }
         // TODO: dispose of the manager
 
-        // Uninstall the log callback.
-        // We need to do this because easylogging++ may send logs after we end this thread, leading
-        // to a tracing panic.
-
-        if let Err(e) =
-            bridge::log::uninstall_log_callback().context("Error uninstalling log callback")
-        {
-            tracing::error!(error=%e, "Failed to uninstall C++ tracing log callback, continuing anyway");
-        }
-
         Ok(())
     }
 }
@@ -1219,16 +1250,14 @@ impl WalletManager {
     /// You can optionally pass a daemon with which the wallet manager and
     /// all wallets opened by the manager will connect.
     pub fn new(daemon: Daemon, span_name: &str) -> anyhow::Result<Self> {
-        // Install the log callback to route c++ logs to tracing.
-        let_cxx_string!(span_name = span_name);
-        bridge::log::install_log_callback(&span_name)
-            .context("Failed to install log callback: FFI call failed with exception")?;
+        let log_guard = LogCallbackGuard::acquire(span_name)?;
 
         let manager = ffi::getWalletManager()
             .context("Couldn't get wallet manager: FFi call failed with exception")?;
 
         let mut manager = Self {
             inner: RawWalletManager::new(manager),
+            _log_guard: log_guard,
         };
 
         manager


### PR DESCRIPTION
The easylogging++ callback registry that we install RustDispatch into is process-global. Install was already made idempotent in C++ but uninstall was tied to the lifetime of one wallet thread, so closing any wallet would tear down the callback that other still-open wallets depend on, silently dropping their C++ logs from tracing for the rest of those wallets' lives.

This moves the install/uninstall lifetime to a Rust-side reference-counted LogCallbackGuard held by every WalletManager. The first acquire installs the callback, the last drop uninstalls it, with a Mutex<usize> serializing concurrent acquires and drops from different wallet threads (multiple wallets, plus password-verify threads, can construct WalletManagers concurrently). The C++ side is unchanged — its idempotent install bool is still load-bearing for the dispatch handler's early-return when nothing is installed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches process-global FFI logging callback lifecycle and adds cross-thread refcounting; mistakes could disable logging globally or cause callback uninstall/install imbalance under concurrency.
> 
> **Overview**
> Ensures C++ easylogging++ logs continue to flow into Rust `tracing` when multiple wallets/managers exist concurrently by tying callback install/uninstall to `WalletManager` lifetime rather than individual wallet-thread shutdown.
> 
> Adds a Rust-side `LogCallbackGuard` with a `Mutex<usize>` refcount: the first `WalletManager::new` installs the callback and the last guard drop uninstalls it (logging an error if uninstall fails), and removes the previous unconditional uninstall that ran when a wallet thread exited.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8752cedf64fd510fb792759c1bb3df4f5ec6a46f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->