### PR TITLE
refactor(bitcoin-wallet): concurrent bitcoin wallet client

### DIFF
--- a/bitcoin-wallet/src/wallet.rs
+++ b/bitcoin-wallet/src/wallet.rs
@@ -101,10 +101,6 @@ pub struct Wallet<Persister = Connection, C = Client> {
     /// The database connection used to persist the wallet.
     persister: Arc<TokioMutex<Persister>>,
     /// The electrum client.
-    ///
-    /// `Arc<C>` (no outer mutex): `C` is responsible for its own internal
-    /// synchronization. This lets `sync()` (a long-running call) and
-    /// `status_of_script()` proceed concurrently against the same client.
     electrum_client: Arc<C>,
     /// The cached fee estimator for the electrum client.
     cached_electrum_fee_estimator: Arc<CachedFeeEstimator<C>>,
@@ -125,11 +121,6 @@ pub struct Wallet<Persister = Connection, C = Client> {
 }
 
 /// This is our wrapper around a bdk electrum client.
-///
-/// All mutable state is held behind interior locks so methods can take `&self`
-/// and run concurrently. Network calls go through `inner` (the balancer) which
-/// is itself concurrency-safe; per-method short critical sections only protect
-/// the in-memory caches.
 #[derive(Clone)]
 pub struct Client {
     /// The underlying electrum balancer for load balancing across multiple servers.
@@ -1644,16 +1635,17 @@ impl Client {
     pub async fn update_state(&self, force: bool) -> Result<()> {
         let now = Instant::now();
 
-        {
-            let mut last_sync = self.last_sync.lock().expect("last_sync mutex poisoned");
-            if !force && now.duration_since(*last_sync) < self.sync_interval {
+        if !force {
+            let last_sync = *self.last_sync.lock().expect("last_sync mutex poisoned");
+            if now.duration_since(last_sync) < self.sync_interval {
                 return Ok(());
             }
-            *last_sync = now;
         }
 
         self.update_script_histories().await?;
         self.update_block_height().await?;
+
+        *self.last_sync.lock().expect("last_sync mutex poisoned") = Instant::now();
 
         Ok(())
     }

--- a/bitcoin-wallet/src/wallet.rs
+++ b/bitcoin-wallet/src/wallet.rs
@@ -32,6 +32,7 @@ use std::time::Duration;
 use std::time::Instant;
 use sync_ext::{CumulativeProgressHandle, InnerSyncCallback, SyncCallbackExt};
 use tokio::sync::Mutex as TokioMutex;
+use tokio::sync::RwLock as TokioRwLock;
 use tokio::sync::watch;
 use tracing::{Instrument, debug_span};
 
@@ -100,7 +101,11 @@ pub struct Wallet<Persister = Connection, C = Client> {
     /// The database connection used to persist the wallet.
     persister: Arc<TokioMutex<Persister>>,
     /// The electrum client.
-    electrum_client: Arc<TokioMutex<C>>,
+    ///
+    /// `Arc<C>` (no outer mutex): `C` is responsible for its own internal
+    /// synchronization. This lets `sync()` (a long-running call) and
+    /// `status_of_script()` proceed concurrently against the same client.
+    electrum_client: Arc<C>,
     /// The cached fee estimator for the electrum client.
     cached_electrum_fee_estimator: Arc<CachedFeeEstimator<C>>,
     /// The cached fee estimator for the mempool client.
@@ -120,20 +125,25 @@ pub struct Wallet<Persister = Connection, C = Client> {
 }
 
 /// This is our wrapper around a bdk electrum client.
+///
+/// All mutable state is held behind interior locks so methods can take `&self`
+/// and run concurrently. Network calls go through `inner` (the balancer) which
+/// is itself concurrency-safe; per-method short critical sections only protect
+/// the in-memory caches.
 #[derive(Clone)]
 pub struct Client {
     /// The underlying electrum balancer for load balancing across multiple servers.
     inner: Arc<ElectrumBalancer>,
     /// The history of transactions for each script.
-    script_history: BTreeMap<ScriptBuf, Vec<GetHistoryRes>>,
+    script_history: Arc<TokioRwLock<BTreeMap<ScriptBuf, Vec<GetHistoryRes>>>>,
     /// The subscriptions to the status of transactions.
-    subscriptions: HashMap<(Txid, ScriptBuf), Subscription>,
+    subscriptions: Arc<TokioMutex<HashMap<(Txid, ScriptBuf), Subscription>>>,
     /// The time of the last sync.
-    last_sync: Instant,
+    last_sync: Arc<SyncMutex<Instant>>,
     /// How often we sync with the server.
     sync_interval: Duration,
     /// The height of the latest block we know about.
-    latest_block_height: BlockHeight,
+    latest_block_height: Arc<SyncMutex<BlockHeight>>,
 }
 
 /// Holds the configuration parameters for creating a Bitcoin wallet.
@@ -604,7 +614,7 @@ impl Wallet {
 
         Ok(Wallet {
             wallet: wallet.into_arc_mutex_async(),
-            electrum_client: client.into_arc_mutex_async(),
+            electrum_client: Arc::new(client),
             cached_electrum_fee_estimator,
             cached_mempool_fee_estimator,
             persister: persister.into_arc_mutex_async(),
@@ -663,7 +673,7 @@ impl Wallet {
 
         let wallet = Wallet {
             wallet: wallet.into_arc_mutex_async(),
-            electrum_client: client.into_arc_mutex_async(),
+            electrum_client: Arc::new(client),
             cached_electrum_fee_estimator,
             cached_mempool_fee_estimator: Arc::new(cached_mempool_fee_estimator),
             persister: persister.into_arc_mutex_async(),
@@ -696,8 +706,8 @@ impl Wallet {
             )))
             .await;
 
-        let client = self.electrum_client.lock().await;
-        let broadcast_results = client
+        let broadcast_results = self
+            .electrum_client
             .transaction_broadcast_all(&transaction)
             .await
             .with_context(|| {
@@ -796,24 +806,14 @@ impl Wallet {
     }
 
     pub async fn status_of_script(&self, tx: &dyn Watchable) -> Result<ScriptStatus> {
-        self.electrum_client
-            .lock()
-            .await
-            .status_of_script(tx, true)
-            .await
+        self.electrum_client.status_of_script(tx, true).await
     }
 
     pub async fn subscribe_to(&self, tx: Box<dyn Watchable>) -> Subscription {
         let txid = tx.id();
         let script = tx.script();
 
-        let initial_status = match self
-            .electrum_client
-            .lock()
-            .await
-            .status_of_script(&tx, false)
-            .await
-        {
+        let initial_status = match self.electrum_client.status_of_script(&tx, false).await {
             Ok(status) => Some(status),
             Err(err) => {
                 tracing::debug!(%txid, %err, "Failed to get initial status for subscription. We won't notify the caller and will try again later.");
@@ -821,11 +821,9 @@ impl Wallet {
             }
         };
 
-        let sub = self
-            .electrum_client
-            .lock()
-            .await
-            .subscriptions
+        let mut subscriptions = self.electrum_client.subscriptions.lock().await;
+
+        let sub = subscriptions
             .entry((txid, script.clone()))
             .or_insert_with(|| {
                 let (sender, receiver) = watch::channel(ScriptStatus::Unseen);
@@ -835,8 +833,7 @@ impl Wallet {
                     let mut last_status = initial_status;
 
                     loop {
-                        let new_status = client.lock()
-                            .await
+                        let new_status = client
                             .status_of_script(&tx, false)
                             .await
                             .unwrap_or_else(|error| {
@@ -852,7 +849,7 @@ impl Wallet {
 
                             if all_receivers_gone {
                                 tracing::debug!(%txid, "All receivers gone, removing subscription");
-                                client.lock().await.subscriptions.remove(&(txid, script));
+                                client.subscriptions.lock().await.remove(&(txid, script));
                                 return;
                             }
                         }
@@ -886,8 +883,8 @@ impl Wallet {
 
     /// Get a transaction from the Electrum server or the cache.
     pub async fn get_tx(&self, txid: Txid) -> Result<Option<Arc<Transaction>>> {
-        let client = self.electrum_client.lock().await;
-        let tx = client
+        let tx = self
+            .electrum_client
             .get_tx(txid)
             .await
             .context("Failed to get transaction from cache or Electrum server")?;
@@ -1029,8 +1026,6 @@ impl Wallet {
 
         let sync_response = self
             .electrum_client
-            .lock()
-            .await
             .inner
             .call_async("sync_wallet", move |client| {
                 let sync_request_factory = sync_request_factory.clone();
@@ -1629,30 +1624,34 @@ impl Client {
     /// Create a new client with multiple electrum servers for load balancing.
     pub async fn new(electrum_rpc_urls: &[String], sync_interval: Duration) -> Result<Self> {
         let balancer = ElectrumBalancer::new(electrum_rpc_urls.to_vec()).await?;
+        let initial_last_sync = Instant::now()
+            .checked_sub(sync_interval)
+            .ok_or(anyhow!("failed to set last sync time"))?;
 
         Ok(Self {
             inner: Arc::new(balancer),
-            script_history: Default::default(),
-            last_sync: Instant::now()
-                .checked_sub(sync_interval)
-                .ok_or(anyhow!("failed to set last sync time"))?,
+            script_history: Arc::new(TokioRwLock::new(BTreeMap::new())),
+            last_sync: Arc::new(SyncMutex::new(initial_last_sync)),
             sync_interval,
-            latest_block_height: BlockHeight::from(0),
-            subscriptions: Default::default(),
+            latest_block_height: Arc::new(SyncMutex::new(BlockHeight::from(0))),
+            subscriptions: Arc::new(TokioMutex::new(HashMap::new())),
         })
     }
 
     /// Update the client state, if the refresh duration has passed.
     ///
     /// Optionally force an update even if the sync interval has not passed.
-    pub async fn update_state(&mut self, force: bool) -> Result<()> {
+    pub async fn update_state(&self, force: bool) -> Result<()> {
         let now = Instant::now();
 
-        if !force && now.duration_since(self.last_sync) < self.sync_interval {
-            return Ok(());
+        {
+            let mut last_sync = self.last_sync.lock().expect("last_sync mutex poisoned");
+            if !force && now.duration_since(*last_sync) < self.sync_interval {
+                return Ok(());
+            }
+            *last_sync = now;
         }
 
-        self.last_sync = now;
         self.update_script_histories().await?;
         self.update_block_height().await?;
 
@@ -1664,7 +1663,7 @@ impl Client {
     /// As opposed to [`update_state`] this function does not
     /// check the time since the last update before refreshing
     /// It therefore also does not take a [`force`] parameter
-    pub async fn update_state_single(&mut self, script: &dyn Watchable) -> Result<()> {
+    pub async fn update_state_single(&self, script: &dyn Watchable) -> Result<()> {
         self.update_script_history(script).await?;
         self.update_block_height().await?;
 
@@ -1672,7 +1671,7 @@ impl Client {
     }
 
     /// Update the block height.
-    async fn update_block_height(&mut self) -> Result<()> {
+    async fn update_block_height(&self) -> Result<()> {
         let latest_block = self
             .inner
             .call_async("block_headers_subscribe", |client| {
@@ -1682,20 +1681,24 @@ impl Client {
             .context("Failed to subscribe to header notifications")?;
         let latest_block_height = BlockHeight::try_from(latest_block)?;
 
-        if latest_block_height > self.latest_block_height {
+        let mut current = self
+            .latest_block_height
+            .lock()
+            .expect("latest_block_height mutex poisoned");
+        if latest_block_height > *current {
             tracing::trace!(
                 block_height = u32::from(latest_block_height),
                 "Got notification for new block"
             );
-            self.latest_block_height = latest_block_height;
+            *current = latest_block_height;
         }
 
         Ok(())
     }
 
     /// Update the script histories.
-    async fn update_script_histories(&mut self) -> Result<()> {
-        let scripts: Vec<_> = self.script_history.keys().cloned().collect();
+    async fn update_script_histories(&self) -> Result<()> {
+        let scripts: Vec<_> = self.script_history.read().await.keys().cloned().collect();
 
         // No need to do any network request if we have nothing to fetch
         if scripts.is_empty() {
@@ -1730,6 +1733,7 @@ impl Client {
 
         // Iterate through each script we fetched and find the highest
         // returned entry at any Electrum node
+        let mut script_history = self.script_history.write().await;
         for (script_index, script) in scripts.iter().enumerate() {
             let all_history_for_script: Vec<GetHistoryRes> = successful_results
                 .iter()
@@ -1751,14 +1755,14 @@ impl Client {
             }
 
             let final_history: Vec<GetHistoryRes> = best_history.into_values().collect();
-            self.script_history.insert(script.clone(), final_history);
+            script_history.insert(script.clone(), final_history);
         }
 
         Ok(())
     }
 
     /// Update the script history of a single script.
-    pub async fn update_script_history(&mut self, script: &dyn Watchable) -> Result<()> {
+    pub async fn update_script_history(&self, script: &dyn Watchable) -> Result<()> {
         let (script_buf, _) = script.script_and_txid();
         let script_clone = script_buf.clone();
 
@@ -1810,7 +1814,10 @@ impl Client {
 
         let final_history: Vec<GetHistoryRes> = best_history.into_values().collect();
 
-        self.script_history.insert(script_buf, final_history);
+        self.script_history
+            .write()
+            .await
+            .insert(script_buf, final_history);
 
         Ok(())
     }
@@ -1836,14 +1843,19 @@ impl Client {
 
     /// Get the status of a script.
     pub async fn status_of_script(
-        &mut self,
+        &self,
         script: &dyn Watchable,
         force: bool,
     ) -> Result<ScriptStatus> {
         let (script_buf, txid) = script.script_and_txid();
 
-        if !self.script_history.contains_key(&script_buf) {
-            self.script_history.insert(script_buf.clone(), vec![]);
+        let is_first_time = !self.script_history.read().await.contains_key(&script_buf);
+
+        if is_first_time {
+            self.script_history
+                .write()
+                .await
+                .insert(script_buf.clone(), vec![]);
 
             // Immediately refetch the status of the script
             // when we first subscribe to it.
@@ -1857,10 +1869,12 @@ impl Client {
             self.update_state(false).await?;
         }
 
-        let history = self.script_history.entry(script_buf).or_default();
+        let history_guard = self.script_history.read().await;
+        let history = history_guard.get(&script_buf);
 
         let history_of_tx: Vec<&GetHistoryRes> = history
-            .iter()
+            .into_iter()
+            .flatten()
             .filter(|entry| entry.tx_hash == txid)
             .collect();
 
@@ -1875,6 +1889,11 @@ impl Client {
             tracing::warn!(%txid, "Found multiple history entries for the same txid. Ignoring all but the last one.");
         }
 
+        let latest_block_height = *self
+            .latest_block_height
+            .lock()
+            .expect("latest_block_height mutex poisoned");
+
         match last.height {
             // If the height is 0 or less, the transaction is still in the mempool.
             ..=0 => Ok(ScriptStatus::InMempool),
@@ -1882,7 +1901,7 @@ impl Client {
             height => Ok(ScriptStatus::Confirmed(
                 Confirmed::from_inclusion_and_latest_block(
                     u32::try_from(height)?,
-                    u32::from(self.latest_block_height),
+                    u32::from(latest_block_height),
                 ),
             )),
         }
@@ -2866,7 +2885,7 @@ impl TestWalletBuilder {
 
         let wallet = Wallet {
             wallet: bdk_core_wallet.into_arc_mutex_async(),
-            electrum_client: client.into_arc_mutex_async(),
+            electrum_client: Arc::new(client),
             cached_electrum_fee_estimator,
             cached_mempool_fee_estimator: Arc::new(None), // We don't use mempool client in tests
             persister: persister.into_arc_mutex_async(),

--- a/bitcoin-wallet/src/wallet.rs
+++ b/bitcoin-wallet/src/wallet.rs
@@ -1841,14 +1841,17 @@ impl Client {
     ) -> Result<ScriptStatus> {
         let (script_buf, txid) = script.script_and_txid();
 
-        let is_first_time = !self.script_history.read().await.contains_key(&script_buf);
+        let is_first_time = {
+            let mut history = self.script_history.write().await;
+            if history.contains_key(&script_buf) {
+                false
+            } else {
+                history.insert(script_buf.clone(), vec![]);
+                true
+            }
+        };
 
         if is_first_time {
-            self.script_history
-                .write()
-                .await
-                .insert(script_buf.clone(), vec![]);
-
             // Immediately refetch the status of the script
             // when we first subscribe to it.
             self.update_state_single(script).await?;

--- a/swap/src/cli/api/request.rs
+++ b/swap/src/cli/api/request.rs
@@ -1783,7 +1783,7 @@ impl CheckElectrumNodeArgs {
 
         // Check if the node is available by performing a lightweight RPC call.
         // This forces a real connection and TLS handshake (for ssl:// URLs).
-        let mut client =
+        let client =
             match bitcoin_wallet::Client::new(&[url.as_str().to_string()], Duration::from_secs(60))
                 .await
             {


### PR DESCRIPTION
Replace the outer `TokioMutex<Client>` with per-field interior locks so `sync()` and `status_of_script()` can run in parallel.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Concurrency/locking changes in wallet sync and script-status tracking can introduce subtle race conditions or deadlocks, and affect correctness of cached state (history/last-sync/block height).
> 
> **Overview**
> Refactors `bitcoin-wallet` to make the Electrum `Client` concurrently usable by replacing the outer `TokioMutex<Client>` with interior locks (`RwLock`/`Mutex`) on `script_history`, `subscriptions`, `last_sync`, and `latest_block_height`, and updating `Client` APIs to take `&self`.
> 
> Updates `Wallet` to hold `Arc<C>` directly and removes call-site `.lock().await` around operations like `broadcast`, `get_tx`, `status_of_script`, and `sync_with_custom_callback`; subscription polling now locks only the shared subscription map when inserting/removing entries. The CLI electrum node check is adjusted accordingly (no longer needs `mut client`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 547af2f2d4d2144d1d23c743130be3e2749d2266. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->