### PR TITLE
chore: remove dead default Electrum servers

### DIFF
--- a/src-gui/src/store/defaults.ts
+++ b/src-gui/src/store/defaults.ts
@@ -17,6 +17,7 @@ export const NEGATIVE_NODES_MAINNET = [
   "tcp://electrum.coinucopia.io:50001",
   "tcp://se-mma-crypto-payments-001.mullvad.net:50001",
   "tcp://electrum2.bluewallet.io:50777",
+  "tcp://electrum.eigenwallet.org:22293",
 ];
 
 export const NEGATIVE_NODES_TESTNET = [
@@ -26,6 +27,8 @@ export const NEGATIVE_NODES_TESTNET = [
   "ssl://testnet.qtornado.com:50002",
   "ssl://testnet.qtornado.com:51002",
   "tcp://testnet.qtornado.com:51001",
+  "ssl://bitcoin.devmole.eu:5010",
+  "tcp://bitcoin.devmole.eu:5000",
 ];
 
 export const DEFAULT_NODES: Record<Network, Record<Blockchain, string[]>> = {
@@ -38,14 +41,11 @@ export const DEFAULT_NODES: Record<Network, Record<Blockchain, string[]>> = {
       "ssl://blockstream.info:993",
       "tcp://testnet.aranguren.org:51001",
       "ssl://testnet.aranguren.org:51002",
-      "ssl://bitcoin.devmole.eu:5010",
-      "tcp://bitcoin.devmole.eu:5000",
     ],
     [Blockchain.Monero]: [],
   },
   [Network.Mainnet]: {
     [Blockchain.Bitcoin]: [
-      "tcp://electrum.eigenwallet.org:22293",
       "ssl://electrum.blockstream.info:50002",
       "ssl://bitcoin.stackwallet.com:50002",
       "ssl://b.1209k.com:50002",

--- a/swap-env/src/defaults.rs
+++ b/swap-env/src/defaults.rs
@@ -58,8 +58,6 @@ pub fn default_rendezvous_points() -> Vec<Multiaddr> {
 
 pub fn default_electrum_servers_mainnet() -> Vec<Url> {
     vec![
-        Url::parse("tcp://electrum.eigenwallet.org:22293")
-            .expect("default electrum server url to be valid"),
         Url::parse("ssl://electrum.blockstream.info:50002")
             .expect("default electrum server url to be valid"),
         Url::parse("ssl://bitcoin.stackwallet.com:50002")
@@ -97,10 +95,6 @@ pub fn default_electrum_servers_testnet() -> Vec<Url> {
         Url::parse("tcp://testnet.aranguren.org:51001")
             .expect("default electrum server url to be valid"),
         Url::parse("ssl://testnet.aranguren.org:51002")
-            .expect("default electrum server url to be valid"),
-        Url::parse("ssl://bitcoin.devmole.eu:5010")
-            .expect("default electrum server url to be valid"),
-        Url::parse("tcp://bitcoin.devmole.eu:5000")
             .expect("default electrum server url to be valid"),
     ]
 }


### PR DESCRIPTION
## Summary

Removes three Electrum servers from the default lists that no longer respond, and adds them to `NEGATIVE_NODES_*` so existing GUI user configs are migrated automatically.

| Server | Network | Failure |
|---|---|---|
| `tcp://electrum.eigenwallet.org:22293` | mainnet | connection refused |
| `ssl://bitcoin.devmole.eu:5010` | testnet | no response |
| `tcp://bitcoin.devmole.eu:5000` | testnet | no response |

## How it was verified

- Ran `dev-scripts/health_check_default_electrum_servers.py` against the current defaults — all 3 fail; the remaining 9 mainnet + 7 testnet defaults are healthy and report the expected block height.
- Cross-checked the survivors against [1209k.com/bitcoin-eye](https://1209k.com/bitcoin-eye/ele.php) (mainnet + `?chain=tbtc`) — heights and statuses agree on every server they track.

## Files

- `swap-env/src/defaults.rs` — drop the three servers from `default_electrum_servers_mainnet` / `default_electrum_servers_testnet`
- `src-gui/src/store/defaults.ts` — drop from `DEFAULT_NODES`, append to `NEGATIVE_NODES_MAINNET` / `NEGATIVE_NODES_TESTNET` (consumed by `settingsSlice.ts` to strip them from existing user configs)

## Test plan

- [ ] `cargo c --all-features` passes locally
- [ ] GUI startup with a pre-existing config containing one of the dead servers strips it on launch

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates static default Electrum server lists and negative/migration lists; no protocol, wallet, or security logic changes.
> 
> **Overview**
> Removes three unresponsive Electrum servers from the **default** Bitcoin server lists (mainnet + testnet) in both the GUI (`DEFAULT_NODES`) and Rust env (`default_electrum_servers_*`).
> 
> Adds those endpoints to `NEGATIVE_NODES_MAINNET`/`NEGATIVE_NODES_TESTNET` so existing GUI configs that still reference them can be automatically stripped during defaults application/migration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a11cf6e031fb6cf2f8a392ff9dd562e8458a12f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->