### PR TITLE
feat(asb-rpc): include btc_redeem_txid in get-swaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- ASB+CONTROLLER: `get-swaps` now includes the `btc_redeem_txid` per swap: the Bitcoin redeem transaction id. This is deterministic from the swap's locked state, so it is set even before the redeem transaction is published.
+
 ## [4.5.1] - 2026-05-05
 
 - ASB+CONTROLLER: `get-swaps` now accepts optional `limit` and `offset` parameters which can be used for pagination.

--- a/swap-controller-api/src/lib.rs
+++ b/swap-controller-api/src/lib.rs
@@ -82,6 +82,9 @@ pub struct Swap {
     /// Fee paid by Alice for the Bitcoin redeem transaction, in satoshis.
     #[serde(with = "bitcoin::amount::serde::as_sat")]
     pub btc_redeem_fee: bitcoin::Amount,
+    /// Bitcoin redeem transaction id. Deterministic from the swap's locked state,
+    /// so this is set even before the redeem transaction is published.
+    pub btc_redeem_txid: String,
     pub peer_id: String,
     pub completed: bool,
 }

--- a/swap-controller/src/main.rs
+++ b/swap-controller/src/main.rs
@@ -89,6 +89,7 @@ async fn dispatch(cmd: Cmd, client: impl AsbApiClient) -> anyhow::Result<()> {
                 "XMR",
                 "Rate (BTC/XMR)",
                 "BTC Redeem Fee",
+                "BTC Redeem TxID",
                 "Peer ID",
                 "Completed",
             ]);
@@ -108,6 +109,7 @@ async fn dispatch(cmd: Cmd, client: impl AsbApiClient) -> anyhow::Result<()> {
                         &format!("{:.12} XMR", xmr.as_xmr()),
                         &swap.exchange_rate.to_string(),
                         &swap.btc_redeem_fee.to_string(),
+                        &swap.btc_redeem_txid,
                         &swap.peer_id,
                         &swap.completed.to_string(),
                     ]);

--- a/swap/src/asb/rpc/server.rs
+++ b/swap/src/asb/rpc/server.rs
@@ -217,6 +217,7 @@ impl AsbApiServer for RpcImpl {
                 xmr_amount: state3.xmr.as_pico(),
                 exchange_rate,
                 btc_redeem_fee: state3.tx_redeem_fee,
+                btc_redeem_txid: state3.tx_redeem().txid().to_string(),
                 peer_id: peer_id.to_string(),
                 completed: is_complete(&current_alice),
             });


### PR DESCRIPTION
Adds `btc_redeem_txid` to each swap returned by the `get-swaps` JSON-RPC and surfaces it as a new column in the controller's `get-swaps` table. The txid is computed from `state3.tx_redeem()`, which is deterministic from the locked state, so it is set even before the redeem transaction is published.

Also drops a one-line Unreleased entry in the CHANGELOG.