### PR TITLE
ci: add dev test release workflow

### DIFF
--- a/.github/workflows/build-gui-release-binaries.yml
+++ b/.github/workflows/build-gui-release-binaries.yml
@@ -12,8 +12,8 @@ concurrency:
 
 jobs:
   draft-cb-release:
-    # don't do it for PR's
-    if: ${{ github.event_name != 'pull_request' && !contains(github.ref_name, 'preview') }}
+    # don't do it for PR's, preview releases, or developer testing releases
+    if: ${{ github.event_name != 'pull_request' && !contains(github.ref_name, 'preview') && !startsWith(github.ref_name, 'test-') }}
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
@@ -159,14 +159,14 @@ jobs:
           done
 
       - name: Clean up Rust build cache before building Flatpak
-        if: ${{ github.event_name != 'pull_request' && !contains(github.ref_name, 'preview') && matrix.target == 'x86_64-unknown-linux-gnu' }}
+        if: ${{ github.event_name != 'pull_request' && !contains(github.ref_name, 'preview') && !startsWith(github.ref_name, 'test-') && matrix.target == 'x86_64-unknown-linux-gnu' }}
         shell: bash
         run: |
           rm -rf target/*/release/{deps,build,incremental}
           df -h .
 
       - name: Upload flatpak release
-        if: ${{ github.event_name != 'pull_request' && !contains(github.ref_name, 'preview') && matrix.target == 'x86_64-unknown-linux-gnu' }}
+        if: ${{ github.event_name != 'pull_request' && !contains(github.ref_name, 'preview') && !startsWith(github.ref_name, 'test-') && matrix.target == 'x86_64-unknown-linux-gnu' }}
         shell: bash
         run: |
           set -euxo pipefail
@@ -204,8 +204,8 @@ jobs:
           git fetch -f "$outdir" HEAD:gh-pages
           git push -f origin gh-pages
 
-      - name: Upload to crabnebula release (not for previews)
-        if: ${{ github.event_name != 'pull_request' && !contains(github.ref_name, 'preview') }}
+      - name: Upload to crabnebula release (not for previews or test releases)
+        if: ${{ github.event_name != 'pull_request' && !contains(github.ref_name, 'preview') && !startsWith(github.ref_name, 'test-') }}
         uses: crabnebula-dev/cloud-release@v0
         with:
           command: release upload ${{ env.CN_APPLICATION }} --framework tauri
@@ -213,6 +213,8 @@ jobs:
           args: --target ${{ matrix.target }}
 
   generate-homebrew-formula:
+    # don't do it for developer testing releases
+    if: ${{ !startsWith(github.ref_name, 'test-') }}
     needs: [build_gui]
     runs-on: ubuntu-24.04
     steps:
@@ -264,8 +266,8 @@ jobs:
             --clobber
 
   publish:
-    # don't publish previews to crabnebula
-    if: ${{ github.event_name != 'pull_request' && !contains(github.ref_name, 'preview') }}
+    # don't publish previews or developer testing releases to crabnebula
+    if: ${{ github.event_name != 'pull_request' && !contains(github.ref_name, 'preview') && !startsWith(github.ref_name, 'test-') }}
     needs: [draft-cb-release, build_gui]
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/build-release-binaries.yml
+++ b/.github/workflows/build-release-binaries.yml
@@ -214,7 +214,8 @@ jobs:
 
   build_and_push_docker:
     name: Build and Push Docker Image
-    if: github.event_name == 'release'
+    # Skip Docker publishing for developer testing releases (tag prefix `test-`).
+    if: github.event_name == 'release' && !startsWith(github.event.release.tag_name, 'test-')
     runs-on: ubuntu-22.04
     needs: build_binaries
     permissions:

--- a/.github/workflows/dev-test-release.yml
+++ b/.github/workflows/dev-test-release.yml
@@ -1,0 +1,76 @@
+name: "Create dev test release"
+
+# Allows a developer to build a release from a specific commit hash for testing
+# purposes. The resulting release is a GitHub pre-release tagged
+# `test-<short-sha>-<timestamp>` and is wired up so that the existing build
+# workflows (build-release-binaries.yml, build-gui-release-binaries.yml) build
+# binaries and attach them to the release, but DO NOT:
+#   - push Docker images to ghcr
+#   - upload to crabnebula
+#   - update the Homebrew formula
+#   - update the Flatpak repo on gh-pages
+# Those publishing steps are gated on the tag prefix `test-` in the consuming
+# workflows.
+
+on:
+  workflow_dispatch:
+    inputs:
+      commit:
+        description: "Commit SHA (or ref) to build the testing release from"
+        required: true
+      description:
+        description: "Short description shown after 'TESTING RELEASE:' in the release body"
+        required: false
+        default: ""
+
+concurrency:
+  group: dev-test-release-${{ github.event.inputs.commit }}
+  cancel-in-progress: false
+
+jobs:
+  create_testing_release:
+    name: Create testing release from commit
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4.1.7
+        with:
+          ref: ${{ github.event.inputs.commit }}
+          fetch-depth: 0
+
+      - name: Resolve commit SHA
+        id: commit
+        shell: bash
+        run: |
+          set -euo pipefail
+          SHA="$(git rev-parse "${{ github.event.inputs.commit }}^{commit}")"
+          SHORT_SHA="$(git rev-parse --short "$SHA")"
+          echo "sha=$SHA" >> "$GITHUB_OUTPUT"
+          echo "short_sha=$SHORT_SHA" >> "$GITHUB_OUTPUT"
+
+      - name: Compute tag name
+        id: tag
+        shell: bash
+        run: |
+          set -euo pipefail
+          TAG="test-${{ steps.commit.outputs.short_sha }}-$(date -u +%Y%m%d%H%M%S)"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Create testing release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.BOTTY_GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.tag.outputs.tag }}
+          release_name: ${{ steps.tag.outputs.tag }}
+          draft: false
+          prerelease: true
+          commitish: ${{ steps.commit.outputs.sha }}
+          body: |
+            TESTING RELEASE: ${{ github.event.inputs.description }}
+
+            Built from commit `${{ steps.commit.outputs.sha }}` by @${{ github.actor }}.
+
+            This is a developer test build. Docker images were NOT pushed to
+            ghcr, binaries were NOT uploaded to crabnebula, the Homebrew
+            formula was NOT updated, and the Flatpak repo was NOT republished.
+            Do not distribute this build to end users.


### PR DESCRIPTION
Adds a `workflow_dispatch` trigger that builds a release from an arbitrary commit hash. The release is a GitHub pre-release tagged `test-<short-sha>-<timestamp>` with body prefixed `TESTING RELEASE: ...`.

Binaries are still built and attached. Docker push, crabnebula upload, Homebrew formula, and Flatpak/gh-pages updates are gated off for `test-` tags.