### PR TITLE
feat(asb): add btc_redeem_fee_multiplier config option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- ASB: New `maker.btc_redeem_fee_multiplier` config option (default `1.0`) that scales the estimated BTC redeem fee. Setting it higher (e.g. `2.0`) acts as a safety margin so the redeem still confirms when fee estimation undershoots actual mempool conditions.
+
 ## [4.5.1] - 2026-05-05
 
 - ASB+CONTROLLER: `get-swaps` now accepts optional `limit` and `offset` parameters which can be used for pagination.

--- a/dev-docs/asb/README.md
+++ b/dev-docs/asb/README.md
@@ -125,6 +125,8 @@ If the option is not set, a new address from the internal wallet is used for eve
 
 `developer_tip` allows configuring your maker to donate a small part of swaps to funding further development of the project. This is disabled by default. You can manually enable it if you choose to do so. Set it to a number between 0 and 1. Setting it to 0.02 will donate 2% of each swap to the donation address of the project. The tip is sent by adding an additional output to the Monero lock transaction of a swap. This means this will not impact the availability of your UTXOs (unlocked funds) as it does not require an additonal transaction.
 
+`btc_redeem_fee_multiplier` scales the estimated BTC redeem fee. Defaults to `1.0`. Set higher (e.g. `2.0`) as a safety margin so the redeem still confirms when fee estimation undershoots actual mempool conditions. The fee is deducted from the BTC Alice receives, so a higher value reduces her net redeem amount.
+
 In order to be able to trade, the ASB must define a price to be able to agree on the amounts to be swapped with a CLI.
 The `XMR<>BTC` price is currently determined by the price from the central exchange Kraken.
 Upon startup the ASB connects to the Kraken price websocket and listens on the stream for price updates.

--- a/docs/content/becoming_a_maker/overview.mdx
+++ b/docs/content/becoming_a_maker/overview.mdx
@@ -145,6 +145,7 @@ Below an explanation of what each option does:
 | `price_ticker_rest_url_kucoin` | The URL of a REST API that provides the market price. The default is the KuCoin API, but you can build your own REST + websocket servers which mimics the KuCoin API. |
 | `external_bitcoin_address` | Bitcoin address used by the asb when redeeming or punishing swaps. If omitted, a new internal address is generated for each swap. |
 | `developer_tip` | Optional donation as a fraction between 0 and 1 (e.g. `0.02` = 2%). Disabled by default. Sent in Monero by adding an extra output to the Monero lock transaction, so no extra transaction and no impact on unlocked UTXOs; privacy preserved. |
+| `btc_redeem_fee_multiplier` | Multiplier applied to the estimated BTC redeem fee. Defaults to `1.0`. Set higher (e.g. `2.0` for 2x) as a safety margin so the redeem still confirms when fee estimation undershoots actual mempool conditions; the fee comes out of the BTC Alice receives, so a higher value reduces her net redeem amount. |
 
 ### Bitcoin Section
 

--- a/swap-asb/src/main.rs
+++ b/swap-asb/src/main.rs
@@ -360,6 +360,7 @@ pub async fn main() -> Result<()> {
                 config.maker.min_buy_btc,
                 config.maker.max_buy_btc,
                 config.maker.external_bitcoin_redeem_address,
+                config.maker.btc_redeem_fee_multiplier,
                 tip_config,
                 config.maker.refund_policy,
                 onion_service_handle,

--- a/swap-env/src/config.rs
+++ b/swap-env/src/config.rs
@@ -181,6 +181,11 @@ pub struct Maker {
     /// If specified, Bitcoin received from successful swaps will be sent to this address.
     #[serde(default, with = "swap_serde::bitcoin::address_serde::option")]
     pub external_bitcoin_redeem_address: Option<bitcoin::Address>,
+    /// Multiplier applied to the estimated BTC redeem fee. Defaults to 1.0;
+    /// set higher (e.g. 2.0) to overpay for faster confirmation as a safety
+    /// margin against fee estimation undershooting actual mempool conditions.
+    #[serde(default = "default_btc_redeem_fee_multiplier")]
+    pub btc_redeem_fee_multiplier: Decimal,
     /// Percentage (between 0.0 and 1.0) of the swap amount
     /// that will be donated to the devepment fund as part of the Monero lock transaction.
     #[serde(default = "default_developer_tip")]
@@ -241,6 +246,10 @@ pub fn default_price_ticker_validity_duration_secs() -> u64 {
 
 fn default_developer_tip() -> Decimal {
     Decimal::ZERO
+}
+
+pub fn default_btc_redeem_fee_multiplier() -> Decimal {
+    Decimal::ONE
 }
 
 fn default_anti_spam_deposit_ratio() -> Decimal {
@@ -405,6 +414,7 @@ pub fn query_user_for_initial_config_with_network(
             price_ticker_source_bitfinex_enabled: default_price_ticker_source_enabled(),
             price_ticker_source_kucoin_enabled: default_price_ticker_source_enabled(),
             external_bitcoin_redeem_address: None,
+            btc_redeem_fee_multiplier: default_btc_redeem_fee_multiplier(),
             developer_tip,
             refund_policy: defaults.refund_policy,
         },

--- a/swap-orchestrator/src/main.rs
+++ b/swap-orchestrator/src/main.rs
@@ -271,6 +271,7 @@ fn main() {
                 price_ticker_source_bitfinex_enabled: default_price_ticker_source_enabled(),
                 price_ticker_source_kucoin_enabled: default_price_ticker_source_enabled(),
                 external_bitcoin_redeem_address: None,
+                btc_redeem_fee_multiplier: swap_env::config::default_btc_redeem_fee_multiplier(),
                 refund_policy: defaults.refund_policy,
                 developer_tip,
             },

--- a/swap/src/asb/event_loop.rs
+++ b/swap/src/asb/event_loop.rs
@@ -54,6 +54,7 @@ where
     min_buy: bitcoin::Amount,
     max_buy: bitcoin::Amount,
     external_redeem_address: Option<bitcoin::Address>,
+    btc_redeem_fee_multiplier: Decimal,
     developer_tip: TipConfig,
     refund_policy: RefundPolicy,
 
@@ -183,6 +184,7 @@ where
         min_buy: bitcoin::Amount,
         max_buy: bitcoin::Amount,
         external_redeem_address: Option<bitcoin::Address>,
+        btc_redeem_fee_multiplier: Decimal,
         developer_tip: TipConfig,
         refund_policy: RefundPolicy,
         onion_service_handle: Option<Arc<RunningOnionService>>,
@@ -205,6 +207,7 @@ where
             min_buy,
             max_buy,
             external_redeem_address,
+            btc_redeem_fee_multiplier,
             developer_tip,
             refund_policy,
             quote_cache,
@@ -289,13 +292,14 @@ where
                             let bitcoin_wallet = self.bitcoin_wallet.clone();
                             let monero_wallet = self.monero_wallet.clone();
                             let external_redeem_address = self.external_redeem_address.clone();
+                            let btc_redeem_fee_multiplier = self.btc_redeem_fee_multiplier;
 
                             self.inflight_wallet_snapshots.push(async move {
                                 // Wait for the swap setup handler to request the wallet snapshot
                                 let (btc, responder) = send_wallet_snapshot.recv().await?;
 
                                 // Compute the wallet snapshot
-                                let wallet_snapshot = capture_wallet_snapshot(bitcoin_wallet, &monero_wallet, &external_redeem_address, btc).await?;
+                                let wallet_snapshot = capture_wallet_snapshot(bitcoin_wallet, &monero_wallet, &external_redeem_address, btc_redeem_fee_multiplier, btc).await?;
 
                                 // This is used further down to then actually respond to the swap setup handler
                                 Ok((btc, responder, wallet_snapshot))
@@ -1161,10 +1165,22 @@ fn apply_anti_spam_policy(
     ))
 }
 
+/// Multiply a fee amount by `multiplier`, rounding to the nearest satoshi.
+fn scale_fee(fee: bitcoin::Amount, multiplier: Decimal) -> Result<bitcoin::Amount> {
+    let sats: u64 = Decimal::from(fee.to_sat())
+        .checked_mul(multiplier)
+        .context("Decimal overflow when scaling fee")?
+        .round()
+        .try_into()
+        .context("Scaled fee does not fit in u64")?;
+    Ok(bitcoin::Amount::from_sat(sats))
+}
+
 async fn capture_wallet_snapshot(
     bitcoin_wallet: Arc<dyn BitcoinWallet>,
     monero_wallet: &monero::Wallets,
     external_redeem_address: &Option<bitcoin::Address>,
+    btc_redeem_fee_multiplier: Decimal,
     transfer_amount: bitcoin::Amount,
 ) -> Result<WalletSnapshot> {
     let start_time = Instant::now();
@@ -1184,6 +1200,8 @@ async fn capture_wallet_snapshot(
     let redeem_fee = bitcoin_wallet
         .estimate_fee(bitcoin::TxRedeem::weight(), Some(transfer_amount))
         .await?;
+    let redeem_fee = scale_fee(redeem_fee, btc_redeem_fee_multiplier)
+        .context("Failed to apply btc_redeem_fee_multiplier")?;
     let punish_fee = bitcoin_wallet
         .estimate_fee(bitcoin::TxPunish::weight(), Some(transfer_amount))
         .await?;

--- a/swap/tests/harness/mod.rs
+++ b/swap/tests/harness/mod.rs
@@ -394,6 +394,7 @@ async fn start_alice(
         min_buy,
         max_buy,
         None,
+        swap_env::config::default_btc_redeem_fee_multiplier(),
         developer_tip,
         refund_policy,
         None,


### PR DESCRIPTION
Adds a `maker.btc_redeem_fee_multiplier` config option (default `1.0`). When set higher (e.g. `2.0`), the estimated BTC redeem fee is scaled by that factor before being baked into the redeem transaction.

Useful as a safety margin against fee-estimation undershoot.

```toml
[maker]
btc_redeem_fee_multiplier = 2.0
```