### PR TITLE
feat(asb): validate btc_redeem_fee_multiplier at startup

### DIFF
--- a/swap-env/src/config.rs
+++ b/swap-env/src/config.rs
@@ -308,6 +308,15 @@ pub fn read_config(config_path: PathBuf) -> Result<Result<Config, ConfigNotIniti
 /// and likely indicate a misconfiguration (e.g. deposit exceeding fees).
 pub const MAX_ANTI_SPAM_DEPOSIT_RATIO: Decimal = Decimal::from_parts(2, 0, 0, false, 1); // 0.2
 
+/// Minimum allowed BTC redeem fee multiplier. Values below this would scale
+/// the estimated fee down so far that the redeem transaction is unlikely to
+/// confirm, and likely indicate a misconfiguration.
+pub const MIN_BTC_REDEEM_FEE_MULTIPLIER: Decimal = Decimal::from_parts(1, 0, 0, false, 1); // 0.1
+
+/// Maximum allowed BTC redeem fee multiplier. Values above this are implausible
+/// (10x the estimated fee) and likely indicate a misconfiguration.
+pub const MAX_BTC_REDEEM_FEE_MULTIPLIER: Decimal = Decimal::from_parts(10, 0, 0, false, 0); // 10
+
 pub fn validate_config(config: &Config, env_config: crate::env::Config) -> Result<()> {
     if config.monero.network != env_config.monero_network {
         bail!(
@@ -332,6 +341,23 @@ pub fn validate_config(config: &Config, env_config: crate::env::Config) -> Resul
         bail!(
             "anti_spam_deposit_ratio of {ratio} exceeds maximum of {MAX_ANTI_SPAM_DEPOSIT_RATIO}. \
              Such a high deposit ratio is implausible and likely a misconfiguration."
+        );
+    }
+
+    let multiplier = config.maker.btc_redeem_fee_multiplier;
+    if multiplier < MIN_BTC_REDEEM_FEE_MULTIPLIER {
+        bail!(
+            "btc_redeem_fee_multiplier of {multiplier} is below minimum of \
+             {MIN_BTC_REDEEM_FEE_MULTIPLIER}. A multiplier this low scales the \
+             redeem fee down so far that the transaction is unlikely to confirm \
+             (a non-positive multiplier would also fail at runtime in scale_fee)."
+        );
+    }
+    if multiplier > MAX_BTC_REDEEM_FEE_MULTIPLIER {
+        bail!(
+            "btc_redeem_fee_multiplier of {multiplier} exceeds maximum of \
+             {MAX_BTC_REDEEM_FEE_MULTIPLIER}. Such a high multiplier is implausible \
+             and likely a misconfiguration."
         );
     }
 


### PR DESCRIPTION
## Summary
- Reject `btc_redeem_fee_multiplier` values `< 0.1` or `> 10` in `validate_config`, mirroring the existing `anti_spam_deposit_ratio` pattern.
- Without this, a zero or negative multiplier silently produces a zero-fee redeem tx that never confirms; a negative value later panics in `scale_fee`'s `try_into::<u64>` mid-swap. Both are hard to diagnose in production.

## Test plan
- [ ] `cargo c -p swap-env --tests --all-features`
- [ ] Manual: ASB refuses to start with `btc_redeem_fee_multiplier = 0`, `-1`, `0.05`, `100`.