### PR TITLE
swap-feed: request fixed rate from Exolix

### DIFF
--- a/swap-feed/src/exolix.rs
+++ b/swap-feed/src/exolix.rs
@@ -165,13 +165,13 @@ pub mod wire {
     #[derive(Debug, Serialize)]
     #[serde(rename_all = "lowercase")]
     pub enum RateType {
-        Float,
         #[allow(dead_code)]
+        Float,
         Fixed,
     }
 
     impl RateRequest {
-        /// Request the XMR -> BTC floating rate for a 1 XMR send amount.
+        /// Request the XMR -> BTC fixed rate for a 1 XMR send amount.
         pub fn xmr_to_btc() -> Self {
             Self {
                 coin_from: "XMR".to_string(),
@@ -179,7 +179,7 @@ pub mod wire {
                 coin_to: "BTC".to_string(),
                 network_to: "BTC".to_string(),
                 amount: Decimal::ONE,
-                rate_type: RateType::Float,
+                rate_type: RateType::Fixed,
             }
         }
     }


### PR DESCRIPTION
## Summary

Switch the Exolix rate request in `swap-feed/src/exolix.rs` from `RateType::Float` to `RateType::Fixed`. The wire enum already had both variants; only the variant chosen by `RateRequest::xmr_to_btc()` and the `#[allow(dead_code)]` marker move.

## Test plan

- [ ] `cargo c --all-features` (not run locally per request)
- [ ] Confirm Exolix `/api/v2/rate` responses with `rateType=fixed` still parse via the existing `RateResponse` / `PriceUpdate` path

https://claude.ai/code/session_012Rvh2VZtXZEPdWe1y7yYWJ

---
_Generated by [Claude Code](https://claude.ai/code/session_012Rvh2VZtXZEPdWe1y7yYWJ)_