### PR TITLE
Fix broken swap-core unit tests

### DIFF
--- a/bitcoin-wallet/src/wallet.rs
+++ b/bitcoin-wallet/src/wallet.rs
@@ -2921,7 +2921,7 @@ impl TestWalletBuilder {
     }
 }
 
-/// Implement BitcoinWallet trait for a stub wallet and panic when the function is not implemented
+/// Implement the wallet trait for the in-memory static-fee wallet used by tests.
 #[async_trait::async_trait]
 #[allow(unused)]
 impl BitcoinWallet for Wallet<Connection, StaticFeeRate> {
@@ -2934,15 +2934,15 @@ impl BitcoinWallet for Wallet<Connection, StaticFeeRate> {
     }
 
     async fn balance(&self) -> Result<Amount> {
-        unimplemented!("stub method called erroneously")
+        Wallet::balance(self).await
     }
 
     async fn balance_info(&self) -> Result<Balance> {
-        unimplemented!("stub method called erroneously")
+        Wallet::balance_info(self).await
     }
 
     async fn new_address(&self) -> Result<Address> {
-        unimplemented!("stub method called erroneously")
+        Wallet::new_address(self).await
     }
 
     async fn send_to_address(
@@ -2952,7 +2952,7 @@ impl BitcoinWallet for Wallet<Connection, StaticFeeRate> {
         spending_fee: Amount,
         change_override: Option<Address>,
     ) -> Result<Psbt> {
-        unimplemented!("stub method called erroneously")
+        Wallet::send_to_address(self, address, amount, spending_fee, change_override).await
     }
 
     async fn send_to_address_dynamic_fee(
@@ -2961,15 +2961,15 @@ impl BitcoinWallet for Wallet<Connection, StaticFeeRate> {
         amount: Amount,
         change_override: Option<Address>,
     ) -> Result<Psbt> {
-        unimplemented!("stub method called erroneously")
+        Wallet::send_to_address_dynamic_fee(self, address, amount, change_override).await
     }
 
     async fn sweep_balance_to_address_dynamic_fee(&self, address: Address) -> Result<Psbt> {
-        unimplemented!("stub method called erroneously")
+        Wallet::sweep_balance_to_address_dynamic_fee(self, address).await
     }
 
     async fn sign_and_finalize(&self, psbt: Psbt) -> Result<bitcoin::Transaction> {
-        unimplemented!("stub method called erroneously")
+        Wallet::sign_and_finalize(self, psbt).await
     }
 
     async fn sync(&self) -> Result<()> {
@@ -2992,7 +2992,7 @@ impl BitcoinWallet for Wallet<Connection, StaticFeeRate> {
     }
 
     async fn max_giveable(&self, locking_script_size: usize) -> Result<(Amount, Amount)> {
-        unimplemented!("stub method called erroneously")
+        Wallet::max_giveable(self, locking_script_size).await
     }
 
     async fn estimate_fee(
@@ -3000,15 +3000,15 @@ impl BitcoinWallet for Wallet<Connection, StaticFeeRate> {
         weight: Weight,
         transfer_amount: Option<Amount>,
     ) -> Result<Amount> {
-        unimplemented!("stub method called erroneously")
+        Wallet::estimate_fee(self, weight, transfer_amount).await
     }
 
     fn network(&self) -> Network {
-        unimplemented!("stub method called erroneously")
+        Wallet::network(self)
     }
 
     fn finality_confirmations(&self) -> u32 {
-        unimplemented!("stub method called erroneously")
+        Wallet::finality_confirmations(self)
     }
 
     async fn wallet_export(&self, role: &str) -> Result<FullyNodedExport> {

--- a/swap-core/src/monero/primitives.rs
+++ b/swap-core/src/monero/primitives.rs
@@ -506,10 +506,7 @@ mod tests {
     fn parse_monero_overflows() {
         let overflow_pics = "18446744.073709551616";
         let error = Amount::parse_monero(overflow_pics).unwrap_err();
-        assert_eq!(
-            error.downcast_ref::<OverflowError>().unwrap(),
-            &OverflowError(overflow_pics.to_owned())
-        );
+        assert_eq!(error.to_string(), format!("{overflow_pics} too big"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Forward the test-only static-fee wallet trait methods to the real wallet implementation instead of panicking in swap-core tests.
- Update the Monero overflow assertion to match the current `Amount::parse_monero` error shape.

## Reproduction
On current `master`, `cargo test -p swap-core -p swap-feed -p swap-orchestrator` reached `swap-core` and failed seven tests: the TxLock/funding tests hit the static-fee wallet stub, and `parse_monero_overflows` tried to downcast the current parser error into an old local `OverflowError` type.

## Tests
- `cargo fmt --all`
- `git diff --check`
- `cargo test -p swap-core --lib`
- `cargo test -p swap-core -p swap-feed -p swap-orchestrator`
- `cargo test -p bitcoin-wallet`

I also attempted `cargo test -p swap -p swap-asb`; after initializing submodules and installing missing local `cmake`, it continued into the native Monero/Boost depends build and was stopped before Rust test execution because that path was no longer the shortest proof for this patch.

## Bounty
Refs #724 / bounty: 0.25 XMR.

## AI assistance
AI assistance was used for investigation and patch drafting; the changes above were inspected and verified with the listed local commands.