### PR TITLE
fix(gui): keep form fields editable in WKWebView

### DIFF
--- a/src-gui/index.html
+++ b/src-gui/index.html
@@ -22,6 +22,15 @@
         -webkit-app-region: no-drag;
       }
 
+      /* Older WKWebView builds can treat global user-select:none as non-editable form controls. */
+      input,
+      textarea,
+      [contenteditable]:not([contenteditable="false"]) {
+        -webkit-user-select: text;
+        -webkit-user-drag: auto;
+        user-select: text;
+      }
+
       html,
       body {
         height: 100%;


### PR DESCRIPTION
Fixes #659.

The app currently applies `-webkit-user-select: none` to every element. On older macOS WKWebView builds this can make native editable controls behave as non-editable. This keeps the global non-selectable UI chrome behavior, but restores text selection for `input`, `textarea`, and editable content.

Validation:
- `yarn install --immutable`
- `yarn run gen-bindings`
- `yarn run tsc`
- `yarn run build`
- `git diff --check`

I also attempted `cargo check -p unstoppableswap-gui-rs`. After installing missing local build tools (`cmake`, `autoconf`, `automake`, `libtool`), the check still stops inside `monero-sys` while compiling the native Monero `wallet_api` target on this macOS 26 / Xcode 26 machine:

```
monero/src/common/command_line.h:187:8: error: definition with same mangled name ... as another definition
monero/src/common/command_line.h:211:15: note: previous definition is here
```

That failure is in the native Monero build, before this HTML/CSS-only patch is relevant.

AI assistance disclosure: Codex helped investigate and prepare this small patch; I kept the diff scoped and ran the checks above.
