### PR TITLE
Optimize alert and pool health selectors

### DIFF
--- a/src-gui/src/renderer/components/pages/help/MoneroPoolHealthBox.tsx
+++ b/src-gui/src/renderer/components/pages/help/MoneroPoolHealthBox.tsx
@@ -17,10 +17,8 @@ import NetworkWifiIcon from "@mui/icons-material/NetworkWifi";
 import { useAppSelector } from "store/hooks";
 
 export default function MoneroPoolHealthBox() {
-  const { poolStatus, isLoading } = useAppSelector((state) => ({
-    poolStatus: state.pool.status,
-    isLoading: state.pool.isLoading,
-  }));
+  const poolStatus = useAppSelector((state) => state.pool.status);
+  const isLoading = useAppSelector((state) => state.pool.isLoading);
   const theme = useTheme();
 
   const formatLatency = (latencyMs?: number) => {

--- a/src-gui/src/store/hooks.ts
+++ b/src-gui/src/store/hooks.ts
@@ -32,12 +32,12 @@ import {
   TauriBitcoinSyncProgress,
 } from "models/tauriModel";
 import { Alert } from "models/apiModel";
-import { fnv1a } from "utils/hash";
 import {
   selectAllSwapInfos,
   selectPendingApprovals,
   selectSwapInfoWithTimelock,
   selectSwapInfosRaw,
+  selectUnacknowledgedAlerts,
 } from "./selectors";
 
 export const useAppDispatch = () => useDispatch<AppDispatch>();
@@ -339,16 +339,7 @@ export function useTotalUnreadMessagesCount(): number {
 
 /// Returns all the alerts that have not been acknowledged
 export function useAlerts(): Alert[] {
-  return useAppSelector((state) =>
-    state.alerts.alerts.filter(
-      (alert) =>
-        // Check if there is an acknowledgement with
-        // the same id and the same title hash
-        !state.alerts.acknowledgedAlerts.some(
-          (ack) => ack.id === alert.id && ack.titleHash === fnv1a(alert.title),
-        ),
-    ),
-  );
+  return useAppSelector(selectUnacknowledgedAlerts);
 }
 
 /// Returns true if the we heuristically determine that the user has used the app at least a little bit

--- a/src-gui/src/store/selectors.ts
+++ b/src-gui/src/store/selectors.ts
@@ -6,9 +6,13 @@ import {
   ExpiredTimelocks,
   QuoteStatus,
 } from "models/tauriModel";
+import { fnv1a } from "utils/hash";
 
 const selectRpcState = (state: RootState) => state.rpc.state;
 const selectP2pState = (state: RootState) => state.p2p;
+const selectAlerts = (state: RootState) => state.alerts.alerts;
+const selectAcknowledgedAlerts = (state: RootState) =>
+  state.alerts.acknowledgedAlerts;
 
 export const selectSwapInfosRaw = createSelector(
   [selectRpcState],
@@ -57,6 +61,17 @@ export const selectPendingApprovals = createSelector(
   (rpcState) =>
     Object.values(rpcState.approvalRequests).filter(
       (c) => c.request_status.state === "Pending",
+    ),
+);
+
+export const selectUnacknowledgedAlerts = createSelector(
+  [selectAlerts, selectAcknowledgedAlerts],
+  (alerts, acknowledgedAlerts) =>
+    alerts.filter(
+      (alert) =>
+        !acknowledgedAlerts.some(
+          (ack) => ack.id === alert.id && ack.titleHash === fnv1a(alert.title),
+        ),
     ),
 );
 


### PR DESCRIPTION
## Summary

- Memoize the unacknowledged-alert list with `createSelector` so `useAlerts()` returns the same array while alert state is unchanged.
- Split `MoneroPoolHealthBox` into primitive selectors instead of returning a new wrapper object from `useAppSelector`.

## Why

This targets the UI performance bounty in #727.

The previous `useAlerts()` selector filtered inside `useAppSelector`, allocating a new array on every Redux store update. `MoneroPoolHealthBox` also returned a fresh object from its selector on every update. Both patterns can make React-Redux treat unrelated store changes as changed selector output and re-render subscribers unnecessarily.

## Testing

- `eslint src/store/hooks.ts src/store/selectors.ts src/renderer/components/pages/help/MoneroPoolHealthBox.tsx`
- `git diff --check`

Notes:
- `yarn tsc` is blocked in this local clone because `src/models/tauriModel.ts` is generated and gitignored. The repo README says to generate it with `typeshare` + `dprint`; this machine does not currently have `cargo`, `typeshare`, or `dprint` installed.
