### PR TITLE
docs: update Flatpak GNOME runtime install step

### DIFF
--- a/docs/content/getting_started/install_instructions.mdx
+++ b/docs/content/getting_started/install_instructions.mdx
@@ -81,7 +81,7 @@ Choose your platform and follow the instructions.
     # Add eigenwallet repo
     flatpak remote-add --if-not-exists eigenwallet https://eigenwallet.github.io/core/eigenwallet.flatpakrepo
     # Add dependencies
-    flatpak install flathub org.gnome.Platform//47
+    flatpak install flathub org.gnome.Platform//48
     # Install eigenwallet
     flatpak install eigenwallet org.eigenwallet.app
     ```
@@ -178,4 +178,3 @@ Each release includes `.asc` signature files alongside the binaries.
   <Cards.Card arrow title="Guide: Building from Source" href="/contributing/building_from_source">
   </Cards.Card>
 </Cards>
-

--- a/docs/content/getting_started/install_instructions.mdx
+++ b/docs/content/getting_started/install_instructions.mdx
@@ -178,3 +178,4 @@ Each release includes `.asc` signature files alongside the binaries.
   <Cards.Card arrow title="Guide: Building from Source" href="/contributing/building_from_source">
   </Cards.Card>
 </Cards>
+


### PR DESCRIPTION
## Summary
- update Flatpak install instructions from `org.gnome.Platform//47` to `org.gnome.Platform//48`
- keep docs aligned with `flatpak/org.eigenwallet.app.json`

Fixes #840

## Verification
- checked docs command now matches manifest runtime-version `48`