### PR TITLE
Optimize maker reputation rendering

### DIFF
--- a/src-gui/src/renderer/components/pages/swap/swap/init/deposit_and_choose_offer/MakerOfferItem.tsx
+++ b/src-gui/src/renderer/components/pages/swap/swap/init/deposit_and_choose_offer/MakerOfferItem.tsx
@@ -16,7 +16,10 @@ import WarningIcon from "@mui/icons-material/Warning";
 import { isMakerVersionOld, isMakerVersionTooOld } from "utils/multiAddrUtils";
 import { RefundPolicy } from "store/features/settingsSlice";
 import { useAppSelector } from "store/hooks";
-import { BobStateName } from "models/tauriModelExt";
+import {
+  EMPTY_SWAP_REPUTATION,
+  selectSwapReputationByPeer,
+} from "store/selectors";
 
 const FULL_WARNING_ANTI_SPAM_DEPOSIT_RATIO = 0.1;
 
@@ -240,30 +243,10 @@ function AntiSpamDepositChip(quote: BidQuote) {
 }
 
 function ReputationChip(peer_id: string) {
-  const allSwaps = useAppSelector((state) => state.rpc.state.swapInfos);
-  if (!allSwaps) {
-    return <></>;
-  }
-  const swapsWithThisPeer = Object.values(allSwaps).filter(
-    (swap) => swap.seller.peer_id == peer_id,
+  const { successfulSwaps, refundedSwaps, failedSwaps } = useAppSelector(
+    (state) =>
+      selectSwapReputationByPeer(state)[peer_id] ?? EMPTY_SWAP_REPUTATION,
   );
-
-  const successfulSwaps = swapsWithThisPeer.filter(
-    (swap) => swap.state_name === BobStateName.XmrRedeemed,
-  ).length;
-  // TODO: don't hardcode this check (was swap refunded/punished?) here, put into tauriModelExt or other place
-  const refundedSwaps = swapsWithThisPeer.filter((swap) =>
-    [
-      BobStateName.BtcRefunded,
-      BobStateName.BtcEarlyRefunded,
-      BobStateName.BtcMercyConfirmed,
-    ].includes(swap.state_name),
-  ).length;
-  const failedSwaps = swapsWithThisPeer.filter((swap) =>
-    [BobStateName.BtcPunished, BobStateName.BtcWithheld].includes(
-      swap.state_name,
-    ),
-  ).length;
 
   return (
     <Chip

--- a/src-gui/src/store/selectors.ts
+++ b/src-gui/src/store/selectors.ts
@@ -1,6 +1,6 @@
 import { createSelector } from "@reduxjs/toolkit";
 import { RootState } from "renderer/store/storeRenderer";
-import { GetSwapInfoResponseExt } from "models/tauriModelExt";
+import { BobStateName, GetSwapInfoResponseExt } from "models/tauriModelExt";
 import {
   ConnectionStatus,
   ExpiredTimelocks,
@@ -58,6 +58,59 @@ export const selectPendingApprovals = createSelector(
     Object.values(rpcState.approvalRequests).filter(
       (c) => c.request_status.state === "Pending",
     ),
+);
+
+export type SwapReputation = {
+  successfulSwaps: number;
+  refundedSwaps: number;
+  failedSwaps: number;
+};
+
+export const EMPTY_SWAP_REPUTATION: SwapReputation = {
+  successfulSwaps: 0,
+  refundedSwaps: 0,
+  failedSwaps: 0,
+};
+
+const REFUNDED_SWAP_STATES = new Set<BobStateName>([
+  BobStateName.BtcRefunded,
+  BobStateName.BtcEarlyRefunded,
+  BobStateName.BtcMercyConfirmed,
+]);
+
+const FAILED_SWAP_STATES = new Set<BobStateName>([
+  BobStateName.BtcPunished,
+  BobStateName.BtcWithheld,
+]);
+
+export const selectSwapReputationByPeer = createSelector(
+  [selectSwapInfosRaw],
+  (swapInfos) => {
+    const reputationByPeer: Record<string, SwapReputation> = {};
+
+    if (!swapInfos) return reputationByPeer;
+
+    for (const swap of Object.values(swapInfos)) {
+      const peerId = swap.seller.peer_id;
+      const reputation =
+        reputationByPeer[peerId] ??
+        (reputationByPeer[peerId] = {
+          successfulSwaps: 0,
+          refundedSwaps: 0,
+          failedSwaps: 0,
+        });
+
+      if (swap.state_name === BobStateName.XmrRedeemed) {
+        reputation.successfulSwaps += 1;
+      } else if (REFUNDED_SWAP_STATES.has(swap.state_name)) {
+        reputation.refundedSwaps += 1;
+      } else if (FAILED_SWAP_STATES.has(swap.state_name)) {
+        reputation.failedSwaps += 1;
+      }
+    }
+
+    return reputationByPeer;
+  },
 );
 
 // TODO: This should be split into multiple selectors/hooks to avoid excessive re-rendering


### PR DESCRIPTION
## Summary
- aggregate maker swap reputation counts in a memoized selector
- reuse cached per-maker counts in offer cards instead of scanning every swap per card render

Refs #727.

## Verification
- git diff --check
- COREPACK_HOME=/private/tmp/codex-corepack-cache YARN_GLOBAL_FOLDER=/private/tmp/codex-yarn-global YARN_CACHE_FOLDER=/private/tmp/codex-yarn-cache corepack yarn eslint src/store/selectors.ts src/renderer/components/pages/swap/swap/init/deposit_and_choose_offer/MakerOfferItem.tsx --quiet

## Note
- Full `tsc --noEmit` is still blocked in this fresh clone because generated `src/models/tauriModel.ts` is absent.