### PR TITLE
fix(monero-sys): avoid wallet listener handle cycles

### DIFF
--- a/monero-harness/src/lib.rs
+++ b/monero-harness/src/lib.rs
@@ -531,7 +531,7 @@ impl MoneroWallet {
 
     /// Get non-strict balance per subaddress for main account (index 0).
     pub async fn balance_per_subaddress(&self) -> Result<HashMap<u32, u64>> {
-        Ok(self.wallet.balance_per_subaddress().await)
+        self.wallet.balance_per_subaddress().await
     }
 
     pub async fn refresh(&self) -> Result<()> {

--- a/monero-sys/src/lib.rs
+++ b/monero-sys/src/lib.rs
@@ -682,10 +682,12 @@ impl WalletHandle {
     /// Returns a map of subaddress index -> balance (in atomic units).
     /// strict: If true, only includes confirmed and unlocked balance.
     ///         If false, pending and unconfirmed transactions are also included.
-    pub async fn balance_per_subaddress(&self) -> std::collections::HashMap<u32, u64> {
+    pub async fn balance_per_subaddress(
+        &self,
+    ) -> anyhow::Result<std::collections::HashMap<u32, u64>> {
         self.call(move |wallet| wallet.balance_per_subaddress_sync())
             .await
-            .expect("wallet thread closed while fetching balance per subaddress")
+            .context("Couldn't complete wallet call")
     }
 
     /// Check if the wallet is synchronized.

--- a/monero-sys/src/lib.rs
+++ b/monero-sys/src/lib.rs
@@ -17,7 +17,7 @@ pub use bridge::wallet_listener;
 pub use bridge::{TraceListener, WalletEventListener, WalletListenerBox};
 pub use database::{Database, RecentWallet};
 use std::panic::{AssertUnwindSafe, catch_unwind};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, Weak};
 use std::{
     any::Any, cmp::Ordering, collections::HashMap, fmt::Display, future::Future, ops::Deref,
     pin::Pin, time::Duration,
@@ -3219,7 +3219,7 @@ impl Deref for TransactionInfoHandle {
 /// This listener does things on certain events like storing the wallet to disk.
 /// This is supposed to improve upon the behaviour of wallet2
 pub struct WalletHandleListener {
-    wallet: Arc<WalletHandle>,
+    wallet: Weak<WalletHandle>,
     /// We need a handle to the runtime to be able to spawn tasks
     rt_handle: tokio::runtime::Handle,
     /// We throttle the saving of the wallet to disk to avoid storing the wallet too often
@@ -3234,6 +3234,7 @@ impl WalletHandleListener {
     pub fn new(wallet: Arc<WalletHandle>) -> Self {
         // Get the current runtime handle
         let rt_handle = tokio::runtime::Handle::current();
+        let wallet = Arc::downgrade(&wallet);
 
         // Create a throttle wrapper around the save job
         let store_job = {
@@ -3241,7 +3242,10 @@ impl WalletHandleListener {
             let rt = rt_handle.clone();
 
             move |()| {
-                let wallet = wallet.clone();
+                let Some(wallet) = wallet.upgrade() else {
+                    tracing::trace!("Skipping wallet store because wallet handle is gone");
+                    return;
+                };
                 let rt = rt.clone();
 
                 rt.spawn(async move {
@@ -3291,7 +3295,10 @@ impl WalletEventListener for WalletHandleListener {
         // When the wallet finishes refreshing, we start the refresh thread again.
         // The purpose of this is to ensure that if the user does a rescan (restore height changed)
         // We start the refresh thread again after the rescan is complete.
-        let handle = self.wallet.clone();
+        let Some(handle) = self.wallet.upgrade() else {
+            tracing::trace!("Skipping refresh thread restart because wallet handle is gone");
+            return;
+        };
         self.rt_handle.spawn(async move {
             if let Err(e) = handle.start_refresh_thread().await {
                 tracing::error!(error=%e, "Failed to start refresh thread");

--- a/monero-wallet/src/listener.rs
+++ b/monero-wallet/src/listener.rs
@@ -1,4 +1,7 @@
-use std::{sync::Arc, time::Duration};
+use std::{
+    sync::{Arc, Weak},
+    time::Duration,
+};
 
 use monero_sys::WalletEventListener;
 
@@ -29,13 +32,17 @@ impl TauriWalletListener {
 
     pub async fn new(tauri_handle: TauriHandle, wallet: Arc<Wallet>) -> Self {
         let rt_handle = tokio::runtime::Handle::current();
+        let wallet: Weak<Wallet> = Arc::downgrade(&wallet);
 
         let balance_job = {
             let wallet = wallet.clone();
             let tauri = tauri_handle.clone();
             let rt = rt_handle.clone();
             move |()| {
-                let wallet = wallet.clone();
+                let Some(wallet) = wallet.upgrade() else {
+                    tracing::trace!("Skipping balance update because wallet handle is gone");
+                    return;
+                };
                 let tauri = tauri.clone();
                 let rt = rt.clone();
                 rt.spawn(async move {
@@ -64,7 +71,10 @@ impl TauriWalletListener {
             let tauri = tauri_handle.clone();
             let rt = rt_handle.clone();
             move |()| {
-                let wallet = wallet.clone();
+                let Some(wallet) = wallet.upgrade() else {
+                    tracing::trace!("Skipping history update because wallet handle is gone");
+                    return;
+                };
                 let tauri = tauri.clone();
                 let rt = rt.clone();
                 rt.spawn(async move {
@@ -86,7 +96,10 @@ impl TauriWalletListener {
             let tauri = tauri_handle.clone();
             let rt = rt_handle.clone();
             move |()| {
-                let wallet = wallet.clone();
+                let Some(wallet) = wallet.upgrade() else {
+                    tracing::trace!("Skipping sync update because wallet handle is gone");
+                    return;
+                };
                 let tauri = tauri.clone();
                 let rt = rt.clone();
                 rt.spawn(async move {


### PR DESCRIPTION
Refs #695

## Summary
- Stop wallet event listeners from holding strong wallet handles.
- Downgrade `WalletHandleListener` and `TauriWalletListener` captures to `Weak`.
- Skip deferred store/UI/refresh jobs once the wallet handle has gone away instead of queueing work against a closed wallet channel.
- Return an error from `balance_per_subaddress` instead of panicking if the wallet channel is closed.

## Why
The #695 logs show wallet callbacks queueing `store_in_current_file` / refresh work around a closed channel, then panicking on closed-channel sends. Weak captures keep callback work tied to live handles only, and the remaining subaddress balance helper now propagates the closed-channel error like the rest of the wallet API.

## Verification
- `git diff --check`
- `RUSTUP_TOOLCHAIN=stable cargo fmt --check`
- `cargo check` not fully run locally: `monero-sys` build script requires the Monero C++ source/submodule and stopped at `Target file src/wallet/api/wallet.cpp not found`