### PR TITLE
fix(ci): build Linux AppImage on Ubuntu 22.04

### DIFF
--- a/.github/workflows/build-gui-release-binaries.yml
+++ b/.github/workflows/build-gui-release-binaries.yml
@@ -66,6 +66,9 @@ jobs:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          # Bundled Wayland libraries can conflict with the host graphics stack on Fedora.
+          LINUXDEPLOY_EXCLUDED_LIBRARIES: >-
+            libwayland-client.so.0*;libwayland-cursor.so.0*;libwayland-egl.so.1*;libwayland-server.so.0*
         with:
           # Empty releaseId for PRs prevents uploading to GitHub releases
           # Empty strings are treated as an omitted argument: https://github.com/actions/runner/issues/924
@@ -103,6 +106,21 @@ jobs:
             ./eigenwallet.AppImage --appimage-extract >/dev/null
           )
 
+          wayland_violations="$(
+            find "$workdir/squashfs-root/usr/lib" \
+              \( -type f -o -type l \) \
+              \( -name 'libwayland-client.so.0*' \
+                -o -name 'libwayland-cursor.so.0*' \
+                -o -name 'libwayland-egl.so.1*' \
+                -o -name 'libwayland-server.so.0*' \) \
+              -print 2>/dev/null || true
+          )"
+          if [[ -n "$wayland_violations" ]]; then
+            echo "The AppImage still bundles host graphics-stack Wayland libraries:" >&2
+            printf '%s\n' "$wayland_violations" >&2
+            exit 1
+          fi
+
           find "$workdir/squashfs-root" -type f -print0 \
             | xargs -0 grep -aohE 'GLIBC_[0-9]+\.[0-9]+|GLIBCXX_3\.4\.[0-9]+' \
             > "$workdir/symbol-versions.txt" || true
@@ -125,6 +143,7 @@ jobs:
           fi
 
           echo "AppImage GLIBC/GLIBCXX requirements are compatible with Debian 12."
+          echo "AppImage does not bundle the Wayland libraries known to break Fedora."
 
       # TODO: Remove this duplication of the steps in build-release-binaries.yml
       - name: Install GnuPG (macOS)

--- a/.github/workflows/build-gui-release-binaries.yml
+++ b/.github/workflows/build-gui-release-binaries.yml
@@ -38,7 +38,8 @@ jobs:
             target: "aarch64-apple-darwin"
           - host: "macos-15-intel" # for Intel based macs.
             target: "x86_64-apple-darwin"
-          - host: "ubuntu-24.04"
+          # Build Linux bundles on Jammy to keep GLIBC requirements compatible with stable distros.
+          - host: "ubuntu-22.04"
             target: "x86_64-unknown-linux-gnu"
           - host: "ubuntu-24.04" # cross build windows from ubuntu
             target: "x86_64-pc-windows-gnu"
@@ -73,6 +74,57 @@ jobs:
           projectPath: src-tauri
           tauriScript: yarn tauri
           args: --target ${{ matrix.target }}
+
+      - name: Check Linux AppImage compatibility
+        if: matrix.target == 'x86_64-unknown-linux-gnu'
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          appimage_dir="target/${{ matrix.target }}/release/bundle/appimage"
+          if [[ ! -d "$appimage_dir" ]]; then
+            echo "No AppImage artifact directory found at $appimage_dir." >&2
+            exit 1
+          fi
+
+          appimage="$(find "$appimage_dir" -maxdepth 1 -type f -name "*.AppImage" -print -quit)"
+          if [[ -z "$appimage" ]]; then
+            echo "No AppImage artifact found." >&2
+            exit 1
+          fi
+
+          workdir="$(mktemp -d)"
+          trap 'rm -rf "$workdir"' EXIT
+
+          cp "$appimage" "$workdir/eigenwallet.AppImage"
+          chmod +x "$workdir/eigenwallet.AppImage"
+          (
+            cd "$workdir"
+            ./eigenwallet.AppImage --appimage-extract >/dev/null
+          )
+
+          find "$workdir/squashfs-root" -type f -print0 \
+            | xargs -0 grep -aohE 'GLIBC_[0-9]+\.[0-9]+|GLIBCXX_3\.4\.[0-9]+' \
+            > "$workdir/symbol-versions.txt" || true
+
+          glibc_violations="$(
+            sed -n 's/^GLIBC_//p' "$workdir/symbol-versions.txt" \
+              | sort -Vu \
+              | awk -F. '($1 > 2 || ($1 == 2 && $2 > 36)) { print "GLIBC_" $0 }'
+          )"
+          glibcxx_violations="$(
+            sed -n 's/^GLIBCXX_3\.4\.//p' "$workdir/symbol-versions.txt" \
+              | sort -n -u \
+              | awk '($1 > 30) { print "GLIBCXX_3.4." $1 }'
+          )"
+
+          if [[ -n "$glibc_violations$glibcxx_violations" ]]; then
+            echo "The AppImage still requires symbols newer than Debian 12 provides:" >&2
+            printf '%s\n%s\n' "$glibc_violations" "$glibcxx_violations" | sed '/^$/d' >&2
+            exit 1
+          fi
+
+          echo "AppImage GLIBC/GLIBCXX requirements are compatible with Debian 12."
 
       # TODO: Remove this duplication of the steps in build-release-binaries.yml
       - name: Install GnuPG (macOS)

--- a/docs/content/getting_started/install_instructions.mdx
+++ b/docs/content/getting_started/install_instructions.mdx
@@ -47,7 +47,7 @@ Choose your platform and follow the instructions.
   </Tabs.Tab>
   <Tabs.Tab>
     <Callout type="info">
-      The AppImage might not work on older distributions (older than Ubuntu 24) due to an upstream bug. Try the Flatpak instead.
+      The AppImage targets Ubuntu 22.04, Debian 12, and newer distributions. Try the Flatpak instead on older systems.
     </Callout>
 
     For newer Linux distributions, you can download the AppImage and run it directly. It includes all dependencies.
@@ -178,4 +178,3 @@ Each release includes `.asc` signature files alongside the binaries.
   <Cards.Card arrow title="Guide: Building from Source" href="/contributing/building_from_source">
   </Cards.Card>
 </Cards>
-


### PR DESCRIPTION
Fixes #204.

## Summary
- build the Linux GUI/AppImage matrix entry on `ubuntu-22.04` so bundled system libraries do not inherit Ubuntu 24.04 GLIBC requirements
- set `LINUXDEPLOY_EXCLUDED_LIBRARIES` during the Tauri build so linuxdeploy does not bundle the Wayland libraries that trigger the Fedora `EGL_BAD_PARAMETER` crash
- add a Linux AppImage compatibility check that extracts the artifact, rejects those bundled Wayland libraries if they remain, and fails if bundled files require symbols newer than Debian 12 (`GLIBC_2.36`, `GLIBCXX_3.4.30`)
- update the Linux install note to describe the AppImage target as Ubuntu 22.04 / Debian 12 and newer

## Testing
- `git diff --check`
- Ruby YAML parse for all workflows and composite action files
- `bash -n` on the AppImage compatibility shell block
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/build-gui-release-binaries.yml`
- `cd docs && corepack enable && yarn install --immutable && yarn build`

I could not run the full Tauri release build locally; this needs the GitHub Actions Linux runner environment. The PR checks currently require maintainer approval for forked workflow execution.