### PR TITLE
Optimize CLI log copy buffer

### DIFF
--- a/src-gui/src/renderer/components/other/RenderedCliLog.tsx
+++ b/src-gui/src/renderer/components/other/RenderedCliLog.tsx
@@ -1,20 +1,20 @@
 import { Box, Chip, Typography } from "@mui/material";
 import { CliLog } from "models/cliModel";
 import { HashedLog } from "store/features/logsSlice";
-import { ReactNode, useMemo, useState } from "react";
+import { memo, ReactNode, useMemo, useState } from "react";
 import { logsToRawString } from "utils/parseUtils";
 import ScrollablePaperTextBox from "./ScrollablePaperTextBox";
 
-function RenderedCliLog({ log }: { log: CliLog }) {
-  const { timestamp, level, fields, target } = log;
+const levelColorMap = {
+  DEBUG: "#1976d2", // Blue
+  INFO: "#388e3c", // Green
+  WARN: "#fbc02d", // Yellow
+  ERROR: "#d32f2f", // Red
+  TRACE: "#8e24aa", // Purple
+} as const;
 
-  const levelColorMap = {
-    DEBUG: "#1976d2", // Blue
-    INFO: "#388e3c", // Green
-    WARN: "#fbc02d", // Yellow
-    ERROR: "#d32f2f", // Red
-    TRACE: "#8e24aa", // Purple
-  };
+const RenderedCliLog = memo(function RenderedCliLog({ log }: { log: CliLog }) {
+  const { timestamp, level, fields, target } = log;
 
   return (
     <Box sx={{ display: "flex", flexDirection: "column" }}>
@@ -57,7 +57,7 @@ function RenderedCliLog({ log }: { log: CliLog }) {
       </Box>
     </Box>
   );
-}
+});
 
 export default function CliLogsBox({
   label,
@@ -79,8 +79,10 @@ export default function CliLogsBox({
       return logs;
     }
 
+    const normalizedSearchQuery = searchQuery.toLowerCase();
+
     return logs.filter(({ log }) =>
-      JSON.stringify(log).toLowerCase().includes(searchQuery.toLowerCase()),
+      JSON.stringify(log).toLowerCase().includes(normalizedSearchQuery),
     );
   }, [logs, searchQuery]);
 
@@ -101,11 +103,13 @@ export default function CliLogsBox({
     [filteredLogs],
   );
 
+  const copyValue = useMemo(() => logsToRawString(rawStrings), [rawStrings]);
+
   return (
     <ScrollablePaperTextBox
       minHeight={minHeight}
       title={label}
-      copyValue={logsToRawString(rawStrings)}
+      copyValue={copyValue}
       searchQuery={searchQuery}
       setSearchQuery={setSearchQuery}
       topRightButton={topRightButton}


### PR DESCRIPTION
## Summary

- Memoize the raw copy payload in `CliLogsBox` so large daemon/swap log strings are only rebuilt when the filtered log list changes.
- Normalize the search query once per filter pass instead of once per log row.

## Why

This targets the UI performance bounty in #727. The log viewer can hold large daemon/session logs; previously every render, including each search input state update, rebuilt the full `logsToRawString(...)` copy value. Keeping that derivation memoized avoids redundant string work while preserving the existing filtered-copy behavior.

## Testing

- `corepack yarn eslint src/renderer/components/other/RenderedCliLog.tsx --quiet`
- `PATH="$HOME/.cargo/bin:$PATH" corepack yarn gen-bindings`
- `corepack yarn tsc`

If this is accepted for the bounty, I can provide the payout address requested by the maintainer.

Fixes part of #727