### PR TITLE
Fix current swap-core unit tests

### DIFF
--- a/bitcoin-wallet/src/wallet.rs
+++ b/bitcoin-wallet/src/wallet.rs
@@ -2934,15 +2934,15 @@ impl BitcoinWallet for Wallet<Connection, StaticFeeRate> {
     }
 
     async fn balance(&self) -> Result<Amount> {
-        unimplemented!("stub method called erroneously")
+        Wallet::balance(self).await
     }
 
     async fn balance_info(&self) -> Result<Balance> {
-        unimplemented!("stub method called erroneously")
+        Wallet::balance_info(self).await
     }
 
     async fn new_address(&self) -> Result<Address> {
-        unimplemented!("stub method called erroneously")
+        Wallet::new_address(self).await
     }
 
     async fn send_to_address(
@@ -2952,7 +2952,7 @@ impl BitcoinWallet for Wallet<Connection, StaticFeeRate> {
         spending_fee: Amount,
         change_override: Option<Address>,
     ) -> Result<Psbt> {
-        unimplemented!("stub method called erroneously")
+        Wallet::send_to_address(self, address, amount, spending_fee, change_override).await
     }
 
     async fn send_to_address_dynamic_fee(
@@ -2961,15 +2961,15 @@ impl BitcoinWallet for Wallet<Connection, StaticFeeRate> {
         amount: Amount,
         change_override: Option<Address>,
     ) -> Result<Psbt> {
-        unimplemented!("stub method called erroneously")
+        Wallet::send_to_address_dynamic_fee(self, address, amount, change_override).await
     }
 
     async fn sweep_balance_to_address_dynamic_fee(&self, address: Address) -> Result<Psbt> {
-        unimplemented!("stub method called erroneously")
+        Wallet::sweep_balance_to_address_dynamic_fee(self, address).await
     }
 
     async fn sign_and_finalize(&self, psbt: Psbt) -> Result<bitcoin::Transaction> {
-        unimplemented!("stub method called erroneously")
+        Wallet::sign_and_finalize(self, psbt).await
     }
 
     async fn sync(&self) -> Result<()> {
@@ -2992,7 +2992,7 @@ impl BitcoinWallet for Wallet<Connection, StaticFeeRate> {
     }
 
     async fn max_giveable(&self, locking_script_size: usize) -> Result<(Amount, Amount)> {
-        unimplemented!("stub method called erroneously")
+        Wallet::max_giveable(self, locking_script_size).await
     }
 
     async fn estimate_fee(
@@ -3000,15 +3000,15 @@ impl BitcoinWallet for Wallet<Connection, StaticFeeRate> {
         weight: Weight,
         transfer_amount: Option<Amount>,
     ) -> Result<Amount> {
-        unimplemented!("stub method called erroneously")
+        Wallet::estimate_fee(self, weight, transfer_amount).await
     }
 
     fn network(&self) -> Network {
-        unimplemented!("stub method called erroneously")
+        Wallet::network(self)
     }
 
     fn finality_confirmations(&self) -> u32 {
-        unimplemented!("stub method called erroneously")
+        Wallet::finality_confirmations(self)
     }
 
     async fn wallet_export(&self, role: &str) -> Result<FullyNodedExport> {

--- a/swap-core/src/monero/primitives.rs
+++ b/swap-core/src/monero/primitives.rs
@@ -506,10 +506,7 @@ mod tests {
     fn parse_monero_overflows() {
         let overflow_pics = "18446744.073709551616";
         let error = Amount::parse_monero(overflow_pics).unwrap_err();
-        assert_eq!(
-            error.downcast_ref::<OverflowError>().unwrap(),
-            &OverflowError(overflow_pics.to_owned())
-        );
+        assert_eq!(error.to_string(), format!("{} too big", overflow_pics));
     }
 
     #[test]


### PR DESCRIPTION
Refs #724

Problem:
- `swap-core` unit tests still failed when the test wallet was used through `dyn BitcoinWallet`; helper methods in the test wallet impl still panicked instead of calling the real wallet code.
- `parse_monero_overflows` expected an old custom overflow error, while `Amount::parse_monero` now returns the current generic error.

Changes:
- Delegate the `Wallet<Connection, StaticFeeRate>` test-wallet trait methods used by the unit tests to the existing wallet implementations.
- Update the Monero overflow assertion to match the current parser error.

Verification:
- `cargo test -p swap-core --lib` -> 68 passed.
- `cargo test --no-fail-fast -p swap-core -p swap-feed -p swap-orchestrator` -> passed for all targets in that group.
- `rustfmt --edition 2024 --check bitcoin-wallet/src/wallet.rs swap-core/src/monero/primitives.rs` -> passed.
- `git diff --check` -> passed.

Local verification note: Cargo could not fetch the Arti `arti-corpora` submodule from GitLab in this environment, so the cargo test runs used a temporary local path override for the cached Arti checkout. That override is not part of this PR. I also tried `cargo test -p swap-asb`; it did not reach repo tests because the local Monero submodules could not be fetched from GitHub after retries.

AI assistance: OpenAI Codex helped prepare and test this patch.