### PR TITLE
Fix deterministic swap-asb RPC bind validation

### DIFF
--- a/swap-asb/src/command.rs
+++ b/swap-asb/src/command.rs
@@ -1,9 +1,9 @@
-use anyhow::{Context, Result, bail};
+use anyhow::{Result, bail};
 use bitcoin::Address;
 use bitcoin::address::NetworkUnchecked;
 use bitcoin_wallet::{Amount, bitcoin_address};
 use std::ffi::OsString;
-use std::net::ToSocketAddrs;
+use std::net::IpAddr;
 use std::path::PathBuf;
 use structopt::StructOpt;
 use swap_env::defaults::GetDefaults;
@@ -445,10 +445,10 @@ pub struct RecoverCommandParams {
 
 fn validate_rpc_bind_args(host: &Option<String>, port: &Option<u16>) -> Result<()> {
     match (host, port) {
-        (Some(host_str), Some(port_val)) => {
-            let _ = (&host_str[..], *port_val)
-                .to_socket_addrs()
-                .context("Invalid or unknown socket address")?;
+        (Some(host_str), Some(_)) => {
+            if !is_valid_rpc_bind_host(host_str) {
+                bail!("Invalid RPC bind host `{host_str}`");
+            }
 
             Ok(())
         }
@@ -464,6 +464,26 @@ fn validate_rpc_bind_args(host: &Option<String>, port: &Option<u16>) -> Result<(
             );
         }
     }
+}
+
+fn is_valid_rpc_bind_host(host: &str) -> bool {
+    if host.is_empty() || host.trim() != host {
+        return false;
+    }
+
+    if host.parse::<IpAddr>().is_ok() {
+        return true;
+    }
+
+    host.split('.').all(|label| {
+        !label.is_empty()
+            && label.len() <= 63
+            && !label.starts_with('-')
+            && !label.ends_with('-')
+            && label
+                .bytes()
+                .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-')
+    })
 }
 
 #[cfg(test)]
@@ -994,6 +1014,7 @@ mod tests {
         validate_rpc_bind_args(&Some("127.0.0.1".to_string()), &Some(9944)).unwrap();
         validate_rpc_bind_args(&Some("0.0.0.0".to_string()), &Some(8080)).unwrap();
         validate_rpc_bind_args(&Some("localhost".to_string()), &Some(3000)).unwrap();
+        validate_rpc_bind_args(&Some("example.invalid".to_string()), &Some(3000)).unwrap();
 
         // One Some, one None should be invalid
         assert!(validate_rpc_bind_args(&Some("127.0.0.1".to_string()), &None).is_err());
@@ -1001,6 +1022,8 @@ mod tests {
 
         // Invalid host should be invalid
         assert!(validate_rpc_bind_args(&Some("invalid@host".to_string()), &Some(9944)).is_err());
+        assert!(validate_rpc_bind_args(&Some("invalid host".to_string()), &Some(9944)).is_err());
+        assert!(validate_rpc_bind_args(&Some("-invalid".to_string()), &Some(9944)).is_err());
         assert!(validate_rpc_bind_args(&Some("".to_string()), &Some(9944)).is_err());
     }
 }


### PR DESCRIPTION
## Summary
- replace DNS-based `to_socket_addrs()` validation for `--rpc-bind-host` with deterministic syntax validation
- keep the existing requirement that `--rpc-bind-host` and `--rpc-bind-port` are provided together
- extend `test_rpc_bind_validation` to cover a non-resolving hostname and malformed hostnames

## Notes
This is intended as a narrow `swap-asb` contribution toward #724. It should not overlap with #1007 (`swap-core`) or #1008 (`swap` binary tests).

The unit test should not depend on local DNS/host resolver behavior just to validate CLI arguments. Valid IP literals are still accepted through `IpAddr`; hostnames are checked by label syntax instead of resolution.

## Verification
- `git diff --check`
- Attempted `cargo test -p swap-asb test_rpc_bind_validation --no-fail-fast` in a Rust 1.90 Docker container after initializing Monero submodules. The build reached dependency/native setup but stopped before running `swap-asb` tests in `monero-sys` patch application: `Failed to apply patch to src/wallet/api/wallet.cpp`.
- Attempted `cargo fmt --check`; the workspace reports unrelated pre-existing formatting diffs outside this PR. The formatting hunk reported for the touched file was applied.