### PR TITLE
Fix monero-sys test expectations

### DIFF
--- a/monero-sys/src/bridge.h
+++ b/monero-sys/src/bridge.h
@@ -242,6 +242,11 @@ namespace Monero
         return std::make_unique<std::string>(signature);
     }
 
+    inline bool verifySignedMessage(const Wallet &wallet, const std::string &message, const std::string &address, const std::string &signature)
+    {
+        return wallet.verifySignedMessage(message, address, signature);
+    }
+
     /**
      * Get a reserve proof that proves the wallet has a certain amount of Monero.
      * If `all` is true, proves the entire balance; otherwise proves at least `amount` piconero.

--- a/monero-sys/src/bridge.rs
+++ b/monero-sys/src/bridge.rs
@@ -391,6 +391,14 @@ pub mod ffi {
             sign_with_view_key: bool,
         ) -> Result<UniquePtr<CxxString>>;
 
+        /// Verify that a signed message matches an address.
+        fn verifySignedMessage(
+            wallet: &Wallet,
+            message: &CxxString,
+            address: &CxxString,
+            signature: &CxxString,
+        ) -> Result<bool>;
+
         /// Get the number of subaddresses for a given account index.
         fn numSubaddresses(wallet: &Wallet, account_index: u32) -> usize;
 

--- a/monero-sys/src/lib.rs
+++ b/monero-sys/src/lib.rs
@@ -1114,6 +1114,21 @@ impl WalletHandle {
         .await?
     }
 
+    /// Verify a message signature against a wallet address.
+    pub async fn verify_signed_message(
+        &self,
+        message: &str,
+        address: &str,
+        signature: &str,
+    ) -> anyhow::Result<bool> {
+        let message = message.to_string();
+        let address = address.to_string();
+        let signature = signature.to_string();
+
+        self.call(move |wallet| wallet.verify_signed_message(&message, &address, &signature))
+            .await?
+    }
+
     /// Get a reserve proof that proves the wallet has a certain amount of XMR.
     ///
     /// # Arguments
@@ -2723,6 +2738,21 @@ impl FfiWallet {
         }
 
         Ok(signature)
+    }
+
+    /// Verify a message signature against a wallet address.
+    pub fn verify_signed_message(
+        &self,
+        message: &str,
+        address: &str,
+        signature: &str,
+    ) -> anyhow::Result<bool> {
+        let_cxx_string!(message_cxx = message);
+        let_cxx_string!(address_cxx = address);
+        let_cxx_string!(signature_cxx = signature);
+
+        ffi::verifySignedMessage(&self.inner, &message_cxx, &address_cxx, &signature_cxx)
+            .context("Failed to verify signed message: FFI call failed with exception")
     }
 
     /// Get a reserve proof that proves the wallet has a certain amount of XMR.

--- a/monero-sys/tests/sign_message.rs
+++ b/monero-sys/tests/sign_message.rs
@@ -43,6 +43,12 @@ async fn test_sign_message() -> anyhow::Result<()> {
         signature_spend.len() > 10,
         "Signature should be reasonably long"
     );
+    assert!(
+        wallet
+            .verify_signed_message(test_message, &main_address.to_string(), &signature_spend)
+            .await?,
+        "Spend key signature should verify against the main address"
+    );
 
     tracing::info!("Testing message signing with view key (default address)");
     let signature_view = wallet
@@ -55,6 +61,22 @@ async fn test_sign_message() -> anyhow::Result<()> {
     assert!(
         signature_view.len() > 10,
         "Signature should be reasonably long"
+    );
+    assert!(
+        wallet
+            .verify_signed_message(test_message, &main_address.to_string(), &signature_view)
+            .await?,
+        "View key signature should verify against the main address"
+    );
+    assert!(
+        !wallet
+            .verify_signed_message(
+                "tampered message",
+                &main_address.to_string(),
+                &signature_view
+            )
+            .await?,
+        "Signature should not verify for a different message"
     );
 
     // Signatures should be different when using different keys
@@ -75,10 +97,11 @@ async fn test_sign_message() -> anyhow::Result<()> {
         "Signature should not be empty"
     );
 
-    // When using the same key and same address (main address), signatures should be the same
-    assert_eq!(
-        signature_spend, signature_explicit,
-        "Signatures should be the same when using same key and address"
+    assert!(
+        wallet
+            .verify_signed_message(test_message, &main_address.to_string(), &signature_explicit)
+            .await?,
+        "Explicit address signature should verify against the main address"
     );
 
     tracing::info!("Testing empty message signing");
@@ -94,6 +117,9 @@ async fn test_sign_message() -> anyhow::Result<()> {
     );
 
     tracing::info!("All message signing tests passed!");
+
+    drop(wallet);
+    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
 
     Ok(())
 }

--- a/monero-sys/tests/simple.rs
+++ b/monero-sys/tests/simple.rs
@@ -53,11 +53,17 @@ async fn main() -> anyhow::Result<()> {
     assert!(balance > Amount::ZERO);
     assert!(unlocked_balance > Amount::ZERO);
 
+    let subaddress_index = wallet.subaddress_summaries(0).await?.len() as u32;
+    wallet
+        .create_subaddress(0, "simple self-transfer target".to_string())
+        .await?;
+    let transfer_address = wallet.address(0, subaddress_index).await?;
+
     let transfer_amount = Amount::ONE_XMR;
-    tracing::info!("Transferring 1 XMR to ourselves");
+    tracing::info!(%transfer_address, "Transferring 1 XMR to a wallet subaddress");
 
     wallet
-        .transfer_single_destination(&wallet.main_address().await?, transfer_amount)
+        .transfer_single_destination(&transfer_address, transfer_amount)
         .await
         .unwrap();
 
@@ -75,6 +81,9 @@ async fn main() -> anyhow::Result<()> {
     assert!(new_balance > Amount::ZERO);
     assert!(new_balance <= balance);
     assert!(new_unlocked_balance <= balance - transfer_amount);
+
+    drop(wallet);
+    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
 
     Ok(())
 }


### PR DESCRIPTION
## Summary
- expose `Wallet::verifySignedMessage` through `monero-sys` so signed-message tests assert signature validity instead of deterministic bytes
- update `sign_message` to verify spend-key, view-key, explicit-address signatures and reject a tampered message
- send the `simple` test self-transfer to a newly-created subaddress, since Monero does not produce usable tx keys for primary-address self-transfers

## Verification
- `cargo test -p monero-sys --test sign_message --no-fail-fast`
- `cargo test -p monero-sys --test simple --no-fail-fast`
- `cargo fmt -p monero-sys -- --check`
- `git diff --check`

Addresses the `monero-sys` slice of #724.

/claim #724