### PR TITLE
Add monero-rpc-pool unit and integration tests

### DIFF
--- a/monero-rpc-pool/src/database.rs
+++ b/monero-rpc-pool/src/database.rs
@@ -179,12 +179,12 @@ impl Database {
 
     /// Get node statistics for a network
     pub async fn get_node_stats(&self, network: &str) -> Result<(i64, i64, i64)> {
-        let row = sqlx::query!(
+        let row = sqlx::query_as::<_, (i64, i64, i64)>(
             r#"
             SELECT 
                 COUNT(*) as total,
-                CAST(SUM(CASE WHEN stats.success_count > 0 THEN 1 ELSE 0 END) AS INTEGER) as "reachable!: i64",
-                CAST(SUM(CASE WHEN stats.success_count > stats.failure_count AND stats.success_count > 0 THEN 1 ELSE 0 END) AS INTEGER) as "reliable!: i64"
+                COALESCE(CAST(SUM(CASE WHEN stats.success_count > 0 THEN 1 ELSE 0 END) AS INTEGER), 0) as reachable,
+                COALESCE(CAST(SUM(CASE WHEN stats.success_count > stats.failure_count AND stats.success_count > 0 THEN 1 ELSE 0 END) AS INTEGER), 0) as reliable
             FROM monero_nodes n
             LEFT JOIN (
                 SELECT 
@@ -195,22 +195,22 @@ impl Database {
                 GROUP BY node_id
             ) stats ON n.id = stats.node_id
             WHERE n.network = ?
-            "#,
-            network
+            "#
         )
+        .bind(network)
         .fetch_one(&self.pool)
         .await?;
 
-        Ok((row.total, row.reachable, row.reliable))
+        Ok(row)
     }
 
     /// Get health check statistics for a network
     pub async fn get_health_check_stats(&self, network: &str) -> Result<(u64, u64)> {
-        let row = sqlx::query!(
+        let row = sqlx::query_as::<_, (i64, i64)>(
             r#"
             SELECT 
-                CAST(SUM(CASE WHEN hc.was_successful THEN 1 ELSE 0 END) AS INTEGER) as "successful!: i64",
-                CAST(SUM(CASE WHEN NOT hc.was_successful THEN 1 ELSE 0 END) AS INTEGER) as "unsuccessful!: i64"
+                COALESCE(CAST(SUM(CASE WHEN hc.was_successful THEN 1 ELSE 0 END) AS INTEGER), 0) as successful,
+                COALESCE(CAST(SUM(CASE WHEN NOT hc.was_successful THEN 1 ELSE 0 END) AS INTEGER), 0) as unsuccessful
             FROM (
                 SELECT hc.was_successful
                 FROM health_checks hc
@@ -219,14 +219,14 @@ impl Database {
                 ORDER BY hc.timestamp DESC
                 LIMIT 100
             ) hc
-            "#,
-            network
+            "#
         )
+        .bind(network)
         .fetch_one(&self.pool)
         .await?;
 
-        let successful = row.successful as u64;
-        let unsuccessful = row.unsuccessful as u64;
+        let successful = row.0 as u64;
+        let unsuccessful = row.1 as u64;
 
         Ok((successful, unsuccessful))
     }
@@ -292,5 +292,31 @@ impl Database {
             .collect();
 
         Ok(addresses)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_network_accepts_supported_values_case_insensitively() {
+        assert_eq!(parse_network("mainnet").unwrap(), Network::Mainnet);
+        assert_eq!(parse_network("STAGENET").unwrap(), Network::Stagenet);
+        assert_eq!(parse_network("TestNet").unwrap(), Network::Testnet);
+    }
+
+    #[test]
+    fn parse_network_rejects_invalid_values() {
+        let error = parse_network("regtest").unwrap_err();
+
+        assert!(error.to_string().contains("Invalid network: regtest"));
+    }
+
+    #[test]
+    fn network_to_string_matches_database_values() {
+        assert_eq!(network_to_string(&Network::Mainnet), "mainnet");
+        assert_eq!(network_to_string(&Network::Stagenet), "stagenet");
+        assert_eq!(network_to_string(&Network::Testnet), "testnet");
     }
 }

--- a/monero-rpc-pool/src/types.rs
+++ b/monero-rpc-pool/src/types.rs
@@ -97,3 +97,49 @@ impl NodeRecord {
         self.health.success_rate()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn node_address_formats_full_url_and_display() {
+        let address = NodeAddress::new("https".to_string(), "node.example".to_string(), 18089);
+
+        assert_eq!(address.full_url(), "https://node.example:18089");
+        assert_eq!(address.to_string(), "https://node.example:18089");
+    }
+
+    #[test]
+    fn node_health_success_rate_is_zero_without_samples() {
+        let health = NodeHealthStats::default();
+
+        assert_eq!(health.success_rate(), 0.0);
+    }
+
+    #[test]
+    fn node_health_success_rate_uses_successes_and_failures() {
+        let health = NodeHealthStats {
+            success_count: 3,
+            failure_count: 1,
+            ..Default::default()
+        };
+
+        assert_eq!(health.success_rate(), 0.75);
+    }
+
+    #[test]
+    fn node_record_delegates_url_and_success_rate_to_parts() {
+        let address = NodeAddress::new("http".to_string(), "node.local".to_string(), 18081);
+        let metadata = NodeMetadata::new(42, Network::Mainnet, Utc::now());
+        let health = NodeHealthStats {
+            success_count: 2,
+            failure_count: 2,
+            ..Default::default()
+        };
+        let record = NodeRecord::new(address, metadata, health);
+
+        assert_eq!(record.full_url(), "http://node.local:18081");
+        assert_eq!(record.success_rate(), 0.5);
+    }
+}

--- a/monero-rpc-pool/tests/pool_integration.rs
+++ b/monero-rpc-pool/tests/pool_integration.rs
@@ -1,0 +1,190 @@
+use std::{
+    path::PathBuf,
+    sync::Arc,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+use axum::{body::to_bytes, extract::State, http::StatusCode};
+use monero_address::Network;
+use monero_rpc_pool::{
+    AppState, config::Config, connection_pool::ConnectionPool, create_app_with_receiver,
+    database::Database, database::network_to_string, pool::NodePool, proxy::stats_handler,
+};
+use serde_json::Value;
+use tokio::time::timeout;
+
+struct TestDir {
+    path: PathBuf,
+}
+
+impl TestDir {
+    fn new(name: &str) -> Self {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock should be after unix epoch")
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!(
+            "monero-rpc-pool-{name}-{}-{unique}",
+            std::process::id()
+        ));
+
+        std::fs::create_dir_all(&path).expect("test data directory should be created");
+
+        Self { path }
+    }
+
+    fn path(&self) -> PathBuf {
+        self.path.clone()
+    }
+}
+
+impl Drop for TestDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.path);
+    }
+}
+
+#[tokio::test]
+async fn migrations_seed_default_nodes_and_zero_health_counts() {
+    let data_dir = TestDir::new("migration");
+    let db = Database::new(data_dir.path()).await.unwrap();
+
+    let (total, reachable, reliable) = db
+        .get_node_stats(network_to_string(&Network::Mainnet))
+        .await
+        .unwrap();
+    assert!(total > 0);
+    assert_eq!(reachable, 0);
+    assert_eq!(reliable, 0);
+
+    let (successful, unsuccessful) = db
+        .get_health_check_stats(network_to_string(&Network::Mainnet))
+        .await
+        .unwrap();
+    assert_eq!((successful, unsuccessful), (0, 0));
+
+    let empty_testnet_stats = db
+        .get_node_stats(network_to_string(&Network::Testnet))
+        .await
+        .unwrap();
+    assert_eq!(empty_testnet_stats, (0, 0, 0));
+}
+
+#[tokio::test]
+async fn database_records_health_checks_for_seeded_nodes() {
+    let data_dir = TestDir::new("health");
+    let db = Database::new(data_dir.path()).await.unwrap();
+    let node = db
+        .get_top_nodes_by_recent_success(network_to_string(&Network::Mainnet), 1)
+        .await
+        .unwrap()
+        .pop()
+        .expect("mainnet migrations should seed at least one node");
+
+    db.record_health_check(&node.scheme, &node.host, node.port, true, Some(120.0))
+        .await
+        .unwrap();
+    db.record_health_check(&node.scheme, &node.host, node.port, true, Some(80.0))
+        .await
+        .unwrap();
+    db.record_health_check(&node.scheme, &node.host, node.port, false, None)
+        .await
+        .unwrap();
+
+    let (successful, unsuccessful) = db
+        .get_health_check_stats(network_to_string(&Network::Mainnet))
+        .await
+        .unwrap();
+    assert_eq!((successful, unsuccessful), (2, 1));
+
+    let (_total, reachable, reliable) = db
+        .get_node_stats(network_to_string(&Network::Mainnet))
+        .await
+        .unwrap();
+    assert_eq!(reachable, 1);
+    assert_eq!(reliable, 1);
+
+    let reliable_nodes = db
+        .get_reliable_nodes(network_to_string(&Network::Mainnet))
+        .await
+        .unwrap();
+    assert_eq!(reliable_nodes.len(), 1);
+    assert_eq!(reliable_nodes[0].full_url(), node.full_url());
+    assert_eq!(reliable_nodes[0].health.success_count, 2);
+    assert_eq!(reliable_nodes[0].health.failure_count, 1);
+    assert_eq!(reliable_nodes[0].health.avg_latency_ms, Some(100.0));
+}
+
+#[tokio::test]
+async fn node_pool_status_reflects_recorded_health_checks() {
+    let data_dir = TestDir::new("pool");
+    let db = Database::new(data_dir.path()).await.unwrap();
+    let node = db
+        .get_top_nodes_by_recent_success(network_to_string(&Network::Mainnet), 1)
+        .await
+        .unwrap()
+        .pop()
+        .expect("mainnet migrations should seed at least one node");
+    let (pool, mut receiver) = NodePool::new(db, Network::Mainnet);
+
+    pool.record_success(&node.scheme, &node.host, node.port, 75.0)
+        .await
+        .unwrap();
+    pool.record_failure(&node.scheme, &node.host, node.port)
+        .await
+        .unwrap();
+    pool.publish_status_update().await.unwrap();
+
+    let published = timeout(Duration::from_secs(1), receiver.recv())
+        .await
+        .expect("status update should be published")
+        .unwrap();
+
+    assert!(published.total_node_count > 0);
+    assert_eq!(published.healthy_node_count, 1);
+    assert_eq!(published.successful_health_checks, 1);
+    assert_eq!(published.unsuccessful_health_checks, 1);
+    assert_eq!(published.top_reliable_nodes.len(), 1);
+    assert_eq!(published.top_reliable_nodes[0].url, node.full_url());
+    assert_eq!(published.top_reliable_nodes[0].success_rate, 0.5);
+}
+
+#[tokio::test]
+async fn stats_handler_returns_json_for_fresh_database() {
+    let data_dir = TestDir::new("stats");
+    let db = Database::new(data_dir.path()).await.unwrap();
+    let (node_pool, _receiver) = NodePool::new(db, Network::Mainnet);
+    let state = AppState {
+        node_pool: Arc::new(node_pool),
+        tor_client: None,
+        connection_pool: ConnectionPool::new(),
+    };
+
+    let response = stats_handler(State(state)).await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    let payload: Value = serde_json::from_slice(&body).unwrap();
+
+    assert_eq!(payload["status"], "healthy");
+    assert!(payload["total_node_count"].as_u64().unwrap() > 0);
+    assert_eq!(payload["successful_health_checks"].as_u64().unwrap(), 0);
+    assert_eq!(payload["unsuccessful_health_checks"].as_u64().unwrap(), 0);
+}
+
+#[tokio::test]
+async fn create_app_with_receiver_publishes_initial_status() {
+    let data_dir = TestDir::new("app");
+    let config = Config::new_random_port(data_dir.path(), Network::Mainnet);
+    let (_app, mut receiver, handle) = create_app_with_receiver(config).await.unwrap();
+
+    let status = timeout(Duration::from_secs(1), receiver.recv())
+        .await
+        .expect("initial status should be published")
+        .unwrap();
+
+    assert!(status.total_node_count > 0);
+    assert_eq!(status.successful_health_checks, 0);
+    assert_eq!(status.unsuccessful_health_checks, 0);
+    assert_eq!(handle.server_info().port, 0);
+}


### PR DESCRIPTION
## Summary
- add unit tests for network parsing, node URL formatting, and success-rate helpers
- add integration coverage for migrated DB seed data, health-check recording, NodePool status broadcasts, stats handler, and app creation
- make fresh-database aggregate status queries return zero counts instead of null aggregate errors

## Tests
- cargo test -p monero-rpc-pool --lib --tests --locked

Closes #801
/claim #801