### PR TITLE
Add dedicated monero-sys trace log

### DIFF
--- a/swap/src/common/tracing_util.rs
+++ b/swap/src/common/tracing_util.rs
@@ -5,11 +5,11 @@ use std::str::FromStr;
 use anyhow::Result;
 use tracing_appender::rolling::{RollingFileAppender, Rotation};
 use tracing_subscriber::filter::{Directive, LevelFilter};
-use tracing_subscriber::fmt::MakeWriter;
 use tracing_subscriber::fmt::time::UtcTime;
+use tracing_subscriber::fmt::MakeWriter;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
-use tracing_subscriber::{EnvFilter, Layer, fmt};
+use tracing_subscriber::{fmt, EnvFilter, Layer};
 
 use crate::cli::api::tauri_bindings::{TauriEmitter, TauriHandle, TauriLogEvent};
 
@@ -116,6 +116,18 @@ pub fn init(
         24
     );
 
+    // Write monero-sys and its C++ bridge logs to a verbose log file
+    // (tracing-monero-sys*.log).
+    let monero_sys_file_layer = json_rolling_layer!(
+        &dir,
+        "tracing-monero-sys",
+        env_filter_with_all_crates(vec![(
+            crates::MONERO_SYS_CRATES.to_vec(),
+            LevelFilter::TRACE
+        )]),
+        24
+    );
+
     // Layer for writing to the terminal
     let terminal_layer = fmt::layer()
         .with_writer(std::io::stderr)
@@ -173,6 +185,7 @@ pub fn init(
         .with(tor_file_layer)
         .with(libp2p_file_layer)
         .with(monero_wallet_file_layer)
+        .with(monero_sys_file_layer)
         .with(final_terminal_layer)
         .with(tauri_layer);
 
@@ -181,7 +194,7 @@ pub fn init(
     // Now we can use the tracing macros to log messages
     tracing::info!(
         logs_dir = %dir.as_ref().display(),
-        "Initialized tracing. General logs go to swap-all.log; verbose logs: tracing*.log (ours), tracing-tor*.log (tor), tracing-libp2p*.log (libp2p)"
+        "Initialized tracing. General logs go to swap-all.log; verbose logs: tracing*.log (ours), tracing-tor*.log (tor), tracing-libp2p*.log (libp2p), tracing-monero-wallet*.log (monero wallet), tracing-monero-sys*.log (monero-sys)"
     );
 
     Ok(())
@@ -267,12 +280,32 @@ mod crates {
     ];
 
     pub const MONERO_WALLET_CRATES: &[&str] = &["monero_cpp", "monero_rpc_pool"];
+
+    pub const MONERO_SYS_CRATES: &[&str] = &["monero_sys", "monero_cpp"];
 }
 
 /// A writer that forwards tracing log messages to the tauri guest.
 #[derive(Clone)]
 pub struct TauriWriter {
     tauri_handle: Option<TauriHandle>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn monero_sys_filter_includes_rust_and_cpp_targets() {
+        let filter = env_filter_with_all_crates(vec![(
+            crates::MONERO_SYS_CRATES.to_vec(),
+            LevelFilter::TRACE,
+        )])
+        .unwrap()
+        .to_string();
+
+        assert!(filter.contains("monero_sys=trace"));
+        assert!(filter.contains("monero_cpp=trace"));
+    }
 }
 
 impl TauriWriter {

--- a/swap/src/common/tracing_util.rs
+++ b/swap/src/common/tracing_util.rs
@@ -13,6 +13,9 @@ use tracing_subscriber::{fmt, EnvFilter, Layer};
 
 use crate::cli::api::tauri_bindings::{TauriEmitter, TauriHandle, TauriLogEvent};
 
+const MONERO_SYS_LOG_MAX_FILES: usize = 1;
+const MONERO_SYS_LOG_ROTATION: Rotation = Rotation::HOURLY;
+
 /// Creates a tracing layer that writes to a rolling file appender.
 macro_rules! json_rolling_layer {
     ($dir:expr, $prefix:expr, $env_filter:expr, $max_files:expr) => {
@@ -117,7 +120,8 @@ pub fn init(
     );
 
     // Write monero-sys and its C++ bridge logs to a verbose log file
-    // (tracing-monero-sys*.log).
+    // (tracing-monero-sys*.log). Keep only the current hourly file because
+    // these TRACE logs are meant for recent crash diagnosis and can be noisy.
     let monero_sys_file_layer = json_rolling_layer!(
         &dir,
         "tracing-monero-sys",
@@ -125,7 +129,8 @@ pub fn init(
             crates::MONERO_SYS_CRATES.to_vec(),
             LevelFilter::TRACE
         )]),
-        24
+        MONERO_SYS_LOG_MAX_FILES,
+        MONERO_SYS_LOG_ROTATION
     );
 
     // Layer for writing to the terminal
@@ -305,6 +310,12 @@ mod tests {
 
         assert!(filter.contains("monero_sys=trace"));
         assert!(filter.contains("monero_cpp=trace"));
+    }
+
+    #[test]
+    fn monero_sys_log_keeps_only_one_hourly_file() {
+        assert_eq!(MONERO_SYS_LOG_MAX_FILES, 1);
+        assert_eq!(MONERO_SYS_LOG_ROTATION, Rotation::HOURLY);
     }
 }
 


### PR DESCRIPTION
## Summary
- add a dedicated rolling JSON log file for `monero_sys` and `monero_cpp` trace output
- limit `tracing-monero-sys*.log` retention to the current hourly file
- include `tracing-monero-sys*.log` in the tracing initialization message
- add focused unit tests for the monero-sys filter targets and retention setting

## Context
Refs #695. This implements the trace-log slice requested in the issue discussion so monero-sys and the C++ bridge can be inspected without digging through the general log. It does not change wallet behavior.

## Verification
- `rustfmt --check swap/src/common/tracing_util.rs`
- `cargo test -p swap --lib monero_sys --no-default-features`
- `cargo c --all-features`
- `cargo c --tests`
- `cargo c --all-targets`

The compile checks pass with existing warnings only.

## AI Disclosure
I used AI assistance for code navigation and drafting. I reviewed the patch and ran the checks above.

## Bounty Payout
If this is accepted for the issue bounty, please use this XMR address:

`4BJZ3vyR6UVX91mSfthoJw5R8pfBUTCbPXLqmKKh3GWtdLpc1bmL3cDZkRCcbYVNvV5dSEVv6912RFGZBAs9TNmwLkfzQE7`