### PR TITLE
docs: fix typos in comments and doc comments

### DIFF
--- a/bitcoin-wallet/src/wallet.rs
+++ b/bitcoin-wallet/src/wallet.rs
@@ -759,7 +759,7 @@ impl Wallet {
     }
 
     /// Broadcast a transaction, but only if it's not already in the mempool/blockchain.
-    /// Return txid and a subcription to it's status in either case.
+    /// Return txid and a subscription to it's status in either case.
     pub async fn ensure_broadcasted(
         &self,
         tx: Transaction,
@@ -1465,7 +1465,7 @@ where
         // because we are draining the wallet (using all inputs) and
         // always have one output of constant size
         //
-        // The only changable part is the amount of the output.
+        // The only changeable part is the amount of the output.
         // If we increase the fee, the output amount simply will decrease
         //
         // The inputs are constant, so only the output amount changes.
@@ -1565,11 +1565,11 @@ where
             Some(max_giveable) if max_giveable < DUST_AMOUNT => (Amount::ZERO, fee),
             Some(max_giveable) => {
                 // If we have enough funds, we subtract the fee from the max giveable
-                // and return the resul
+                // and return the result
                 match max_giveable.checked_sub(fee) {
                     Some(max_giveable) => (max_giveable, fee),
                     // Let's say we have 2000 sats in the wallet
-                    // The dummy script choses 0 sats as a fee
+                    // The dummy script chooses 0 sats as a fee
                     // and drains the 2000 sats
                     //
                     // Our smart fee estimation says we need 2500 sats to get the transaction confirmed
@@ -2683,7 +2683,7 @@ pub mod pre_1_0_0_bdk {
     const SLED_TREE_NAME: &str = "default_tree";
 
     /// The is the old bdk wallet before the migration.
-    /// We need to contruct it before migration to get the keys and revelation indeces.
+    /// We need to construct it before migration to get the keys and revelation indices.
     pub struct OldWallet<D = Tree> {
         wallet: Arc<TokioMutex<bdk::Wallet<D>>>,
         network: Network,

--- a/libp2p-rendezvous-node/src/swarm.rs
+++ b/libp2p-rendezvous-node/src/swarm.rs
@@ -205,7 +205,7 @@ where
 
 pub struct Addresses<'a>(pub &'a [Multiaddr]);
 
-// Prints an array of multiaddresses as a comma seperated string
+// Prints an array of multiaddresses as a comma separated string
 impl fmt::Display for Addresses<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let display = self

--- a/libp2p-tor/examples/ping-onion.rs
+++ b/libp2p-tor/examples/ping-onion.rs
@@ -22,7 +22,7 @@
 //!
 //! See ../src/tutorial.rs for a step-by-step guide building the example below.
 //!
-//! This example requires two seperate computers, one of which has to be reachable from the
+//! This example requires two separate computers, one of which has to be reachable from the
 //! internet.
 //!
 //! On the first computer run:

--- a/monero-sys/src/lib.rs
+++ b/monero-sys/src/lib.rs
@@ -2971,7 +2971,7 @@ impl SyncProgress {
         }
     }
 
-    /// Create a new sync progress object with zero progess.
+    /// Create a new sync progress object with zero progress.
     fn zero() -> Self {
         Self {
             current_block: 0,

--- a/monero-tests/tests/transaction_keys.rs
+++ b/monero-tests/tests/transaction_keys.rs
@@ -13,7 +13,7 @@ async fn monero_transfers() -> anyhow::Result<()> {
 
     let cli = Cli::default();
     let wallets = vec!["alice", "bob", "candice"];
-    // Disbale background sync for these wallet -- this way we _have_ to use the transfer proof to discover the transactions.
+    // Disable background sync for these wallet -- this way we _have_ to use the transfer proof to discover the transactions.
     let (monero, _container, _wallet_conainers) =
         monero_harness::Monero::new_with_sync_specified(&cli, wallets, false).await?;
 

--- a/monero-wallet-ng/src/verify.rs
+++ b/monero-wallet-ng/src/verify.rs
@@ -35,7 +35,7 @@ pub enum VerifyError {
 /// * `Ok(false)` if the amounts don't match or no outputs were found
 /// * `Err(...)` if there was an error fetching or scanning the transaction
 ///
-/// Note: This doesn't register any subaddresses which means it will only detect outputs that are sent to the primary addres of the wallet.
+/// Note: This doesn't register any subaddresses which means it will only detect outputs that are sent to the primary address of the wallet.
 pub async fn verify_transfer<P: ProvidesTransactions>(
     provider: &P,
     tx_id: [u8; 32],

--- a/monero-wallet/src/wallets.rs
+++ b/monero-wallet/src/wallets.rs
@@ -38,7 +38,7 @@ pub struct Wallets {
     /// Keep the main wallet open and synced.
     main_wallet: Arc<Wallet>,
     /// Since Network::Regtest isn't a thing we have to use an extra flag.
-    /// When we're in regtest mode, we need to unplug some safty nets to make the wallet work.
+    /// When we're in regtest mode, we need to unplug some safety nets to make the wallet work.
     regtest: bool,
     /// A handle we use to send status updates to the UI i.e. when
     /// waiting for a transaction to be confirmed.

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -160,7 +160,7 @@ pub async fn initialize_context(
     testnet: bool,
     state: tauri::State<'_, State>,
 ) -> Result<(), String> {
-    // We want to prevent multiple initalizations at the same time
+    // We want to prevent multiple initializations at the same time
     let _context_lock = state
         .context_lock
         .try_lock()

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -16,7 +16,7 @@ struct State {
     /// [`Context`] uses RwLock internally which means we do not need write access to the context
     /// to modify its internal state.
     ///
-    /// However, we want to avoid multiple processes intializing the context at the same time.
+    /// However, we want to avoid multiple processes initializing the context at the same time.
     pub context_lock: Mutex<()>,
     pub handle: TauriHandle,
 }

--- a/swap-core/src/bitcoin/lock.rs
+++ b/swap-core/src/bitcoin/lock.rs
@@ -127,7 +127,7 @@ impl TxLock {
         self.output_descriptor.script_pubkey()
     }
 
-    /// Retreive the index of the locked output in the transaction outputs
+    /// Retrieve the index of the locked output in the transaction outputs
     /// vector
     fn lock_output_vout(&self) -> usize {
         self.inner

--- a/swap-core/src/bitcoin/timelocks.rs
+++ b/swap-core/src/bitcoin/timelocks.rs
@@ -165,7 +165,7 @@ pub enum ExpiredTimelocks {
 impl ExpiredTimelocks {
     /// Check whether the timelock on the cancel transaction has expired.
     ///
-    /// Retuns `true` even if the swap has already been canceled or punished.
+    /// Returns `true` even if the swap has already been canceled or punished.
     pub fn cancel_timelock_expired(&self) -> bool {
         !matches!(self, ExpiredTimelocks::None { .. })
     }

--- a/swap-orchestrator/src/main.rs
+++ b/swap-orchestrator/src/main.rs
@@ -108,7 +108,7 @@ fn main() {
             bitcoin: bitcoin_network,
         },
         images: OrchestratorImages {
-            // TODO: These containers should be conditonally removed / disabled,
+            // TODO: These containers should be conditionally removed / disabled,
             // depending on if they are used by the asb
             monerod: OrchestratorImage::Registry(images::MONEROD_IMAGE.to_string()),
             electrs: OrchestratorImage::Registry(images::ELECTRS_IMAGE.to_string()),

--- a/swap-p2p/src/patches/identify.rs
+++ b/swap-p2p/src/patches/identify.rs
@@ -13,7 +13,7 @@ use crate::libp2p_ext::MultiAddrExt;
 /// 1. privacy (by avoiding to share local addresses with other peers)
 /// 2. preventing the Swarm from trying to dial addresses that we probably cannot reach anyway
 ///
-/// TODO: Add a clipply rule to forbid the normal identify behaviour from being used in the codebase
+/// TODO: Add a clippy rule to forbid the normal identify behaviour from being used in the codebase
 pub struct Behaviour {
     inner: identify::Behaviour,
 }

--- a/swap-p2p/src/protocols/quote.rs
+++ b/swap-p2p/src/protocols/quote.rs
@@ -97,7 +97,7 @@ pub struct ReserveProofWithAddress {
     #[typeshare(serialized_as = "string")]
     pub address: monero_address::MoneroAddress,
     pub proof: String,
-    // TOOD: Technically redundant as convention tells us its the peer id but it'd be nice to be able to verify reserve proofs isolatedly
+    // TODO: Technically redundant as convention tells us its the peer id but it'd be nice to be able to verify reserve proofs isolatedly
     pub message: String,
 }
 

--- a/swap-p2p/src/protocols/quotes.rs
+++ b/swap-p2p/src/protocols/quotes.rs
@@ -32,7 +32,7 @@ pub struct Behaviour {
     /// Track connected peers
     connection_tracker: ConnectionTracker,
 
-    /// Peers which have explictly told us that they do not support our protocol
+    /// Peers which have explicitly told us that they do not support our protocol
     does_not_support: HashSet<PeerId>,
 
     /// Peers to dispatch a quote request to as soon as we are connected to them

--- a/swap-p2p/src/protocols/redial.rs
+++ b/swap-p2p/src/protocols/redial.rs
@@ -195,7 +195,7 @@ impl NetworkBehaviour for Behaviour {
             // Check if we discovered a new address for some peer
             // TODO: Use the AddressTracker here instead
             FromSwarm::NewExternalAddrOfPeer(event) => {
-                // TOOD: Ensure that if the address contains a peer id it matches the peer id in the event
+                // TODO: Ensure that if the address contains a peer id it matches the peer id in the event
                 if self.insert_address(&event.peer_id, event.addr.clone()) {
                     tracing::trace!(peer = %event.peer_id, address = %event.addr, "Cached an address for a peer");
                 }

--- a/swap-p2p/src/protocols/rendezvous/register.rs
+++ b/swap-p2p/src/protocols/rendezvous/register.rs
@@ -104,7 +104,7 @@ impl Behaviour {
             // We want to redial all of the nodes periodically because we only dispatch requests once we are connected
             redial.add_peer(peer_id.clone());
 
-            // Schedule an intitial register
+            // Schedule an initial register
             pending_to_dispatch.insert(peer_id, Box::pin(future::ready(())));
         }
 
@@ -191,7 +191,7 @@ impl NetworkBehaviour for Behaviour {
         while let Poll::Ready(Some((peer_id, _))) = self.pending_to_dispatch.poll_next_unpin(cx) {
             self.to_dispatch.push_back(peer_id);
 
-            // We assume that if we have queued a register to be dispatched, then we are not registed anymore
+            // We assume that if we have queued a register to be dispatched, then we are not registered anymore
             // because we only queue a register if we failed to register or the ttl expired
             self.registered.remove(&peer_id);
         }

--- a/swap-p2p/src/protocols/swap_setup/bob.rs
+++ b/swap-p2p/src/protocols/swap_setup/bob.rs
@@ -779,4 +779,4 @@ impl From<SwapSetupResult> for out_event::bob::OutEvent {
 // - Case where Alice does not support the protocol at all
 // - Case where Connection dies before the swap setup is started
 // - Case where Connection dies during the swap setup protocol
-// TODO: Extract actualy protocol logic into a callback of sorts or some type of event/state system
+// TODO: Extract actual protocol logic into a callback of sorts or some type of event/state system

--- a/swap/src/cli/api.rs
+++ b/swap/src/cli/api.rs
@@ -436,7 +436,7 @@ mod builder {
     use super::*;
     use crate::cli::api::context::EventLoopState;
 
-    /// A conveniant builder struct for [`Context`].
+    /// A convenient builder struct for [`Context`].
     #[must_use = "ContextBuilder must be built to be useful"]
     pub struct ContextBuilder {
         monero_config: Option<MoneroNodeConfig>,

--- a/swap/src/cli/behaviour.rs
+++ b/swap/src/cli/behaviour.rs
@@ -25,7 +25,7 @@ const MAX_REDIAL_INTERVAL: Duration = Duration::from_secs(30);
 #[behaviour(to_swarm = "OutEvent")]
 #[allow(missing_debug_implementations)]
 pub struct Behaviour {
-    /// Fetch a quote from a specifc peer, usually before starting a swap
+    /// Fetch a quote from a specific peer, usually before starting a swap
     pub direct_quote: quote::Behaviour,
     /// Periodically request quotes from any peers that might offer them
     pub quotes: quotes_cached::Behaviour,

--- a/swap/src/cli/event_loop.rs
+++ b/swap/src/cli/event_loop.rs
@@ -540,7 +540,7 @@ impl EventLoop {
                     // This registers the swap_id -> peer_id and swap_id -> transfer_proof_sender
                     self.registered_swap_handlers.insert(swap_id, (peer_id, sender, span.clone()));
 
-                    // Instruct the swarm to contineously redial the peer
+                    // Instruct the swarm to continuously redial the peer
                     // TODO: We must remove it again once the swap is complete, otherwise we will redial indefinitely
                     self.swarm.behaviour_mut().redial.add_peer(peer_id);
 

--- a/swap/src/common/mod.rs
+++ b/swap/src/common/mod.rs
@@ -218,14 +218,14 @@ pub fn redact(input: &str) -> String {
     redact_with(input, &mut replacements)
 }
 
-/// Same as [`redact`] but retrieves palceholders from and stores them
+/// Same as [`redact`] but retrieves placeholders from and stores them
 /// in a specified hashmap.
 pub fn redact_with(input: &str, replacements: &mut HashMap<String, String>) -> String {
     // TODO: verify regex patterns
     const MONERO_ADDR_REGEX: &str = r#"[48][1-9A-HJ-NP-Za-km-z]{94}"#;
     const BITCOIN_ADDR_REGEX: &str = r#"\b[13][a-km-zA-HJ-NP-Z1-9]{25,34}\b"#;
     // Both XMR and BTC transactions have
-    // a 64 bit hex id so they aren't distinguishible
+    // a 64 bit hex id so they aren't distinguishable
     const TX_ID_REGEX: &str = r#"\b[a-fA-F0-9]{64}\b"#;
     const SWAP_ID_REGEX: &str =
         r#"\b[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89aAbB][a-f0-9]{3}-[a-f0-9]{12}\b"#;
@@ -260,7 +260,7 @@ pub fn redact_with(input: &str, replacements: &mut HashMap<String, String>) -> S
     // allocate string variable to operate on
     let mut redacted = input.to_owned();
 
-    // Finally we go through the input string and replace each occurance of an
+    // Finally we go through the input string and replace each occurrence of an
     // address we want to redact with the corresponding placeholder
     for (address, placeholder) in replacements.iter() {
         redacted = redacted.replace(address, placeholder);

--- a/swap/src/network/transport.rs
+++ b/swap/src/network/transport.rs
@@ -8,7 +8,7 @@ use libp2p::{PeerId, Transport, identity, yamux};
 use std::time::Duration;
 
 const AUTH_AND_MULTIPLEX_TIMEOUT: Duration = Duration::from_secs(15);
-// We have 5 protcols, not more than 2 of which should be active at the same time.
+// We have 5 protocols, not more than 2 of which should be active at the same time.
 const MAX_NUM_STREAMS: usize = 5;
 
 /// "Completes" a transport by applying the authentication and multiplexing

--- a/swap/src/protocol/alice/swap.rs
+++ b/swap/src/protocol/alice/swap.rs
@@ -373,11 +373,11 @@ where
                        state3,
                    }
                 },
-                // If we send Bob the transfer proof, but for whatever reason we do not receive an acknoledgement from him
+                // If we send Bob the transfer proof, but for whatever reason we do not receive an acknowledgement from him
                 // we would be stuck in this state forever until the timelock expires.
                 //
                 // By listening for the encrypted signature here we can still proceed to the next state
-                // even if Bob does not respond with an acknoledgement but sends us the encrypted signature immediately.
+                // even if Bob does not respond with an acknowledgement but sends us the encrypted signature immediately.
                 enc_sig = event_loop_handle.recv_encrypted_signature() => {
                     tracing::info!("Received encrypted signature");
 
@@ -591,7 +591,7 @@ where
         } => {
             let backoff = backoff::ExponentialBackoffBuilder::new()
                 .with_max_elapsed_time(None)
-                // No need to be super agressive here
+                // No need to be super aggressive here
                 .with_max_interval(Duration::from_secs(60 * 10))
                 .build();
 
@@ -837,7 +837,7 @@ where
                 return Ok(AliceState::XmrRefunded { state3: None });
             };
 
-            // Fetch the burn decision again, incase it was udpated via the controller
+            // Fetch the burn decision again, incase it was updated via the controller
             if let Some(burn_decision) = event_loop_handle.get_burn_on_refund_instruction().await {
                 state3.should_publish_tx_withhold = Some(burn_decision);
             }

--- a/swap/tests/harness/mod.rs
+++ b/swap/tests/harness/mod.rs
@@ -110,7 +110,7 @@ pub async fn setup_test<T, F, C>(
     let developer_tip_monero_wallet_subaddress = developer_tip_monero_wallet
         .main_wallet()
         .await
-        // explicitly use a suabddress here to test the addtional tx key logic
+        // explicitly use a suabddress here to test the additional tx key logic
         .address(0, 2)
         .await
         .unwrap()
@@ -820,7 +820,7 @@ pub struct TestContext {
     // Store the container ID as String instead of reference
     monerod_container_id: String,
 
-    // Handle for the Monero deamon. This allows us to skip waiting times by generating
+    // Handle for the Monero daemon. This allows us to skip waiting times by generating
     // blocks instantly
     pub monero: Monero,
 }


### PR DESCRIPTION
Yo! I'm Andrzej - happy to be poking around Eigenwallet code and would love to help make it a bit better over time.

I kept spotting small typos while reading through the code, so I figured I would send a tidy-up pass. Comments and rustdoc only - nothing touches identifiers, behavior, or public APIs. Pure "easier on the eyes" stuff.