### PR TITLE
refactor: fix typos in identifiers

### DIFF
--- a/bitcoin-wallet/src/core.rs
+++ b/bitcoin-wallet/src/core.rs
@@ -80,11 +80,11 @@ pub mod bitcoin_address {
         address: &str,
         expected_network: bitcoin::Network,
     ) -> Result<bitcoin::Address> {
-        let addres = bitcoin::Address::from_str(address)?;
-        let addres = addres.require_network(expected_network).with_context(|| {
+        let address = bitcoin::Address::from_str(address)?;
+        let address = address.require_network(expected_network).with_context(|| {
             format!("Bitcoin address network mismatch, expected `{expected_network:?}`")
         })?;
-        Ok(addres)
+        Ok(address)
     }
 
     /// Parse the address and validate the network.

--- a/monero-rpc-pool/src/proxy.rs
+++ b/monero-rpc-pool/src/proxy.rs
@@ -229,7 +229,7 @@ async fn proxy_to_multiple_nodes(
                         push_error(
                             &mut collected_errors,
                             failed_node,
-                            HandlerError::PhyiscalError(error),
+                            HandlerError::PhysicalError(error),
                         );
                     }
                     continue;
@@ -247,7 +247,7 @@ async fn proxy_to_multiple_nodes(
             {
                 Ok(response) => response,
                 Err(e) => {
-                    push_error(&mut collected_errors, node, HandlerError::PhyiscalError(e));
+                    push_error(&mut collected_errors, node, HandlerError::PhysicalError(e));
                     continue;
                 }
             }
@@ -691,7 +691,7 @@ impl HandlerError {
         let (status_code, error_message) = match self {
             HandlerError::NoNodes => (StatusCode::SERVICE_UNAVAILABLE, "No nodes available"),
             HandlerError::PoolError(_) => (StatusCode::INTERNAL_SERVER_ERROR, "Pool error"),
-            HandlerError::PhyiscalError(_) => (StatusCode::BAD_GATEWAY, "Connection error"),
+            HandlerError::PhysicalError(_) => (StatusCode::BAD_GATEWAY, "Connection error"),
             HandlerError::HttpError(status) => (*status, "HTTP error"),
             HandlerError::JsonRpcError(_) => (StatusCode::BAD_GATEWAY, "JSON-RPC error"),
             HandlerError::AllRequestsFailed(_) => (StatusCode::BAD_GATEWAY, "All requests failed"),
@@ -721,7 +721,7 @@ impl HandlerError {
 enum HandlerError {
     NoNodes,
     PoolError(String),
-    PhyiscalError(SingleRequestError),
+    PhysicalError(SingleRequestError),
     HttpError(axum::http::StatusCode),
     JsonRpcError(String),
     AllRequestsFailed(Vec<((String, String, u16), HandlerError)>),
@@ -740,7 +740,7 @@ impl std::fmt::Display for HandlerError {
         match self {
             HandlerError::NoNodes => write!(f, "No nodes available"),
             HandlerError::PoolError(msg) => write!(f, "Pool error: {msg}"),
-            HandlerError::PhyiscalError(msg) => write!(f, "Request error: {msg}"),
+            HandlerError::PhysicalError(msg) => write!(f, "Request error: {msg}"),
             HandlerError::JsonRpcError(msg) => write!(f, "JSON-RPC error: {msg}"),
             HandlerError::AllRequestsFailed(errors) => {
                 write!(f, "All requests failed: [")?;

--- a/monero-tests/tests/subaddresses.rs
+++ b/monero-tests/tests/subaddresses.rs
@@ -13,7 +13,7 @@ async fn subaddress_methods_and_balances() -> anyhow::Result<()> {
     let cli = Cli::default();
     let wallets = vec!["alice"];
     // Disable background sync so we rely on tx proofs / explicit scanning
-    let (monero, _container, _wallet_conainers) =
+    let (monero, _container, _wallet_containers) =
         monero_harness::Monero::new_with_sync_specified(&cli, wallets, false).await?;
 
     tracing::info!("Starting miner");

--- a/monero-tests/tests/transaction_keys.rs
+++ b/monero-tests/tests/transaction_keys.rs
@@ -14,7 +14,7 @@ async fn monero_transfers() -> anyhow::Result<()> {
     let cli = Cli::default();
     let wallets = vec!["alice", "bob", "candice"];
     // Disable background sync for these wallet -- this way we _have_ to use the transfer proof to discover the transactions.
-    let (monero, _container, _wallet_conainers) =
+    let (monero, _container, _wallet_containers) =
         monero_harness::Monero::new_with_sync_specified(&cli, wallets, false).await?;
 
     tracing::info!("Starting miner");

--- a/monero-tests/tests/transfers.rs
+++ b/monero-tests/tests/transfers.rs
@@ -15,7 +15,7 @@ async fn monero_transfers() -> anyhow::Result<()> {
     let cli = Cli::default();
     let wallets = vec!["alice", "bob"];
     // Disable background sync for these wallet -- this way we _have_ to use the transfer proof to discover the transactions.
-    let (monero, _container, _wallet_conainers) =
+    let (monero, _container, _wallet_containers) =
         monero_harness::Monero::new_with_sync_specified(&cli, wallets, false).await?;
 
     tracing::info!("Starting miner");

--- a/monero-tests/tests/transfers_wrong_key.rs
+++ b/monero-tests/tests/transfers_wrong_key.rs
@@ -12,7 +12,7 @@ async fn monero_transfers_wrong_key() {
     let cli = Cli::default();
     let wallets = vec!["alice"];
     // Disable background sync for this wallet -- this way we _have_ to use the transfer proof to discover the transactions.
-    let (monero, _container, _wallet_conainers) =
+    let (monero, _container, _wallet_containers) =
         monero_harness::Monero::new_with_sync_specified(&cli, wallets, false)
             .await
             .unwrap();

--- a/swap-asb/src/command.rs
+++ b/swap-asb/src/command.rs
@@ -602,7 +602,7 @@ mod tests {
     }
 
     #[test]
-    fn ensure_refund_command_mappin_mainnet() {
+    fn ensure_refund_command_mapping_mainnet() {
         let default_mainnet_conf_path = env::Mainnet::get_config_file_defaults()
             .unwrap()
             .config_path;

--- a/swap-core/src/bitcoin.rs
+++ b/swap-core/src/bitcoin.rs
@@ -340,7 +340,7 @@ mod tests {
     }
 
     #[test]
-    fn given_inclusion_after_lastest_known_block_at_least_depth_0() {
+    fn given_inclusion_after_latest_known_block_at_least_depth_0() {
         let included_in = 10;
         let latest_block = 9;
 

--- a/swap-core/src/bitcoin/lock.rs
+++ b/swap-core/src/bitcoin/lock.rs
@@ -213,7 +213,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn given_bob_sends_good_psbt_when_reconstructing_then_succeeeds() {
+    async fn given_bob_sends_good_psbt_when_reconstructing_then_succeeds() {
         let (A, B, wallet) = setup().await;
         let agreed_amount = Amount::from_sat(10000);
         let spending_fee = Amount::from_sat(1000);

--- a/swap-core/src/bitcoin/reclaim.rs
+++ b/swap-core/src/bitcoin/reclaim.rs
@@ -15,7 +15,7 @@ use super::timelocks::RemainingRefundTimelock;
 pub struct TxReclaim {
     inner: Transaction,
     digest: Sighash,
-    amensty_output_descriptor: Descriptor<::bitcoin::PublicKey>,
+    amnesty_output_descriptor: Descriptor<::bitcoin::PublicKey>,
     watch_script: ScriptBuf,
 }
 
@@ -45,7 +45,7 @@ impl TxReclaim {
         Ok(Self {
             inner: tx_reclaim,
             digest,
-            amensty_output_descriptor: tx_refund.amnesty_output_descriptor.clone(),
+            amnesty_output_descriptor: tx_refund.amnesty_output_descriptor.clone(),
             watch_script: refund_address.script_pubkey(),
         })
     }
@@ -112,7 +112,7 @@ impl TxReclaim {
         };
 
         let mut tx_refund = self.inner;
-        self.amensty_output_descriptor
+        self.amnesty_output_descriptor
             .satisfy(&mut tx_refund.input[0], satisfier)?;
 
         Ok(tx_refund)

--- a/swap-core/src/monero/primitives.rs
+++ b/swap-core/src/monero/primitives.rs
@@ -589,7 +589,7 @@ mod tests {
     }
 
     #[test]
-    fn geting_max_bitcoin_to_trade_with_balance_smaller_than_locking_fee() {
+    fn getting_max_bitcoin_to_trade_with_balance_smaller_than_locking_fee() {
         let ask = bitcoin::Amount::from_sat(382_900);
         let xmr = Amount::parse_monero("0.00001").unwrap();
         let btc = xmr.max_bitcoin_for_price(ask).unwrap();

--- a/swap-feed/src/rate.rs
+++ b/swap-feed/src/rate.rs
@@ -318,7 +318,7 @@ mod tests {
     }
 
     #[test]
-    fn given_spread_of_two_percent_when_caluclating_sell_quote_factor_between_should_be_two_percent()
+    fn given_spread_of_two_percent_when_calculating_sell_quote_factor_between_should_be_two_percent()
      {
         let asking_price = bitcoin::Amount::from_btc(0.004).unwrap();
 

--- a/swap-p2p/src/protocols/swap_setup/alice.rs
+++ b/swap-p2p/src/protocols/swap_setup/alice.rs
@@ -579,7 +579,7 @@ async fn run_swap_setup(
         &mut substream,
         state1
             .next_message()
-            .context("Couldn't construct Mesage1")?,
+            .context("Couldn't construct Message1")?,
     )
     .await
     .context("Failed to send message1")?;

--- a/swap/src/cli/api/request.rs
+++ b/swap/src/cli/api/request.rs
@@ -939,7 +939,7 @@ pub async fn get_swap_info(
     let addresses = db
         .get_addresses(peer_id)
         .await
-        .with_context(|| "Could not get addressess")?;
+        .with_context(|| "Could not get addresses")?;
 
     let start_date = db.get_swap_start_date(args.swap_id).await?;
 

--- a/swap/src/cli/event_loop.rs
+++ b/swap/src/cli/event_loop.rs
@@ -33,7 +33,7 @@ static EXECUTION_SETUP_MAX_ELAPSED_TIME: Duration = Duration::from_secs(120);
 // This is used for:
 // - Requesting quotes
 // - Requesting cooperative XMR redeem
-static REQUEST_RESPONSE_PROTOCOL_RETRY_MAX_ELASPED_TIME: Duration = Duration::from_secs(60);
+static REQUEST_RESPONSE_PROTOCOL_RETRY_MAX_ELAPSED_TIME: Duration = Duration::from_secs(60);
 
 // Used for deciding how long to wait at most between retries.
 static RETRY_MAX_INTERVAL: Duration = Duration::from_secs(5);
@@ -749,7 +749,7 @@ impl EventLoopHandle {
         // We want to give up eventually here
         let backoff = retry::give_up_eventually(
             RETRY_MAX_INTERVAL,
-            REQUEST_RESPONSE_PROTOCOL_RETRY_MAX_ELASPED_TIME,
+            REQUEST_RESPONSE_PROTOCOL_RETRY_MAX_ELAPSED_TIME,
         );
 
         let span = tracing::Span::current();
@@ -788,7 +788,7 @@ impl EventLoopHandle {
         // We want to give up eventually here
         let backoff = retry::give_up_eventually(
             RETRY_MAX_INTERVAL,
-            REQUEST_RESPONSE_PROTOCOL_RETRY_MAX_ELASPED_TIME,
+            REQUEST_RESPONSE_PROTOCOL_RETRY_MAX_ELAPSED_TIME,
         );
 
         backoff::future::retry_notify(backoff, || async {


### PR DESCRIPTION
Small tidy-up of typos - this time Rust code, as a follow-up to the [comment-only fix](https://github.com/eigenwallet/core/pull/1023).

There are **no breaking changes**.

**NOTE:** There is still "fullfilled" typo in the codebase, but I am not touching it as it would affect the wire format.