### PR TITLE
feat(tor): cap concurrent outbound Tor dials in the CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- CLI: Outbound Tor dials are now concurrency-limited and spaced out, with a separate higher-throughput lane for high-priority peers, so bursts of dials no longer overwhelm the embedded Tor client.
+
 ## [4.6.1] - 2026-05-15
 
 - ASB+CONTROLLER: New `set-external-bitcoin-redeem-address` command with parameter `address` (string) allows you to udpate the external bitcoin redeem address at runtime.

--- a/libp2p-tor/Cargo.toml
+++ b/libp2p-tor/Cargo.toml
@@ -29,7 +29,7 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 libp2p = { workspace = true, features = ["tokio", "noise", "yamux", "ping", "macros", "tcp", "tls"] }
-tokio = { workspace = true, features = ["macros"] }
+tokio = { workspace = true, features = ["macros", "test-util"] }
 tokio-test = "0.4.4"
 tracing-subscriber = { workspace = true }
 

--- a/libp2p-tor/src/dial_limiter.rs
+++ b/libp2p-tor/src/dial_limiter.rs
@@ -1,0 +1,432 @@
+use libp2p::{Multiaddr, PeerId, multiaddr::Protocol};
+use std::{
+    collections::{HashMap, VecDeque},
+    num::NonZeroUsize,
+    sync::{Arc, RwLock},
+    time::Duration,
+};
+use thiserror::Error;
+use tokio::{
+    sync::{mpsc, oneshot},
+    time::Instant,
+};
+
+#[derive(Debug, Error)]
+pub enum TorDialLimiterError {
+    #[error("Tor dial limiter is closed")]
+    Closed,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum TorDialPriority {
+    #[default]
+    Normal,
+    High,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct TorDialPriorityTracker {
+    peer_priorities: Arc<RwLock<HashMap<PeerId, TorDialPriority>>>,
+}
+
+impl TorDialPriorityTracker {
+    pub fn set_peer_priority(&self, peer_id: PeerId, priority: TorDialPriority) {
+        let mut peer_priorities = self
+            .peer_priorities
+            .write()
+            .expect("Tor dial priority tracker lock to not be poisoned");
+
+        if priority == TorDialPriority::Normal {
+            peer_priorities.remove(&peer_id);
+            return;
+        }
+
+        peer_priorities.insert(peer_id, priority);
+    }
+
+    pub fn mark_high_priority(&self, peer_id: PeerId) {
+        self.set_peer_priority(peer_id, TorDialPriority::High);
+    }
+
+    pub fn remove_peer_priority(&self, peer_id: &PeerId) {
+        let mut peer_priorities = self
+            .peer_priorities
+            .write()
+            .expect("Tor dial priority tracker lock to not be poisoned");
+
+        peer_priorities.remove(peer_id);
+    }
+
+    #[must_use]
+    pub fn peer_priority(&self, peer_id: Option<&PeerId>) -> TorDialPriority {
+        let Some(peer_id) = peer_id else {
+            return TorDialPriority::Normal;
+        };
+
+        let peer_priorities = self
+            .peer_priorities
+            .read()
+            .expect("Tor dial priority tracker lock to not be poisoned");
+
+        peer_priorities
+            .get(peer_id)
+            .copied()
+            .unwrap_or(TorDialPriority::Normal)
+    }
+}
+
+/// Per-priority dial budget: how many dials of this priority may be in flight
+/// at once, and the minimum spacing between consecutive dial starts.
+#[derive(Debug, Clone, Copy)]
+pub struct TorDialPriorityConfig {
+    pub max_concurrent: NonZeroUsize,
+    pub min_delay: Duration,
+}
+
+#[derive(Clone)]
+pub struct TorDialLimiter {
+    request_sender: mpsc::UnboundedSender<DialRequest>,
+    priority_tracker: TorDialPriorityTracker,
+}
+
+impl TorDialLimiter {
+    /// Creates a limiter with an independent queue per priority. Each priority
+    /// has its own concurrency limit and its own minimum delay between dial
+    /// starts; the two priorities do not compete for a shared budget.
+    ///
+    /// This must be called from a Tokio runtime.
+    #[must_use]
+    pub fn new(
+        priority_tracker: TorDialPriorityTracker,
+        high: TorDialPriorityConfig,
+        normal: TorDialPriorityConfig,
+    ) -> Self {
+        let (request_sender, request_receiver) = mpsc::unbounded_channel();
+        let (release_sender, release_receiver) = mpsc::unbounded_channel();
+
+        tokio::spawn(run_limiter(
+            request_receiver,
+            release_receiver,
+            release_sender,
+            priority_tracker.clone(),
+            high,
+            normal,
+        ));
+
+        Self {
+            request_sender,
+            priority_tracker,
+        }
+    }
+
+    #[must_use]
+    pub fn priority_tracker(&self) -> TorDialPriorityTracker {
+        self.priority_tracker.clone()
+    }
+
+    /// Wait until a dial slot for this peer's priority is free.
+    ///
+    /// The priority is resolved once, here, and the request is routed into that
+    /// priority's queue. The returned [`TorDialPermit`] occupies a slot until it
+    /// is dropped, so it must be held for the entire duration of the dial.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the background limiter task has stopped.
+    pub async fn wait(&self, peer_id: Option<PeerId>) -> Result<TorDialPermit, TorDialLimiterError> {
+        let (permit_sender, permit_receiver) = oneshot::channel();
+        let request = DialRequest {
+            peer_id,
+            permit_sender,
+        };
+
+        self.request_sender
+            .send(request)
+            .map_err(|_| TorDialLimiterError::Closed)?;
+
+        permit_receiver
+            .await
+            .map_err(|_| TorDialLimiterError::Closed)
+    }
+}
+
+/// Occupies one dial slot of its priority for as long as it is alive. Dropping
+/// it frees the slot and lets the limiter release the next waiting dial.
+pub struct TorDialPermit {
+    priority: TorDialPriority,
+    release_sender: Option<mpsc::UnboundedSender<TorDialPriority>>,
+}
+
+impl TorDialPermit {
+    /// Stops this permit from freeing a slot on drop. Used when a permit was
+    /// minted but never handed to a waiter (the waiter was cancelled), so it
+    /// never occupied a slot.
+    fn disarm(&mut self) {
+        self.release_sender = None;
+    }
+}
+
+impl Drop for TorDialPermit {
+    fn drop(&mut self) {
+        if let Some(release_sender) = &self.release_sender {
+            let _ = release_sender.send(self.priority);
+        }
+    }
+}
+
+struct DialRequest {
+    peer_id: Option<PeerId>,
+    permit_sender: oneshot::Sender<TorDialPermit>,
+}
+
+struct PriorityQueue {
+    queue: VecDeque<DialRequest>,
+    in_flight: usize,
+    max_concurrent: usize,
+    min_delay: Duration,
+    /// Earliest instant at which the next dial of this priority may start.
+    next_release_at: Instant,
+}
+
+impl PriorityQueue {
+    fn new(config: TorDialPriorityConfig, now: Instant) -> Self {
+        Self {
+            queue: VecDeque::new(),
+            in_flight: 0,
+            max_concurrent: config.max_concurrent.get(),
+            min_delay: config.min_delay,
+            next_release_at: now,
+        }
+    }
+
+    /// Releases as many waiting dials as the concurrency limit and the delay
+    /// currently allow.
+    fn release_ready(
+        &mut self,
+        priority: TorDialPriority,
+        release_sender: &mpsc::UnboundedSender<TorDialPriority>,
+    ) {
+        while self.in_flight < self.max_concurrent && !self.queue.is_empty() {
+            let now = Instant::now();
+            if now < self.next_release_at {
+                break;
+            }
+
+            let request = self.queue.pop_front().expect("queue to be non-empty");
+            let permit = TorDialPermit {
+                priority,
+                release_sender: Some(release_sender.clone()),
+            };
+
+            match request.permit_sender.send(permit) {
+                Ok(()) => {
+                    self.in_flight += 1;
+                    self.next_release_at = now + self.min_delay;
+                }
+                // The waiter was cancelled before it could receive the permit,
+                // so it never occupied a slot and must not consume the delay.
+                Err(mut permit) => permit.disarm(),
+            }
+        }
+    }
+
+    /// The instant at which `release_ready` could make progress on its own (a
+    /// slot is free and dials are waiting, but the delay has not elapsed yet).
+    fn next_wake(&self) -> Option<Instant> {
+        if self.queue.is_empty() || self.in_flight >= self.max_concurrent {
+            return None;
+        }
+
+        Some(self.next_release_at)
+    }
+}
+
+async fn run_limiter(
+    mut request_receiver: mpsc::UnboundedReceiver<DialRequest>,
+    mut release_receiver: mpsc::UnboundedReceiver<TorDialPriority>,
+    release_sender: mpsc::UnboundedSender<TorDialPriority>,
+    priority_tracker: TorDialPriorityTracker,
+    high: TorDialPriorityConfig,
+    normal: TorDialPriorityConfig,
+) {
+    let now = Instant::now();
+    let mut high_queue = PriorityQueue::new(high, now);
+    let mut normal_queue = PriorityQueue::new(normal, now);
+    let mut request_closed = false;
+
+    loop {
+        high_queue.release_ready(TorDialPriority::High, &release_sender);
+        normal_queue.release_ready(TorDialPriority::Normal, &release_sender);
+
+        // Every limiter handle is gone, so no slot will ever free up again.
+        // Abandon the backlog; dropping the queues makes pending `wait()`
+        // callers observe `Closed` instead of hanging.
+        if request_closed {
+            return;
+        }
+
+        let next_wake = [high_queue.next_wake(), normal_queue.next_wake()]
+            .into_iter()
+            .flatten()
+            .min();
+
+        tokio::select! {
+            request = request_receiver.recv(), if !request_closed => {
+                match request {
+                    Some(request) => {
+                        let priority = priority_tracker.peer_priority(request.peer_id.as_ref());
+                        match priority {
+                            TorDialPriority::High => high_queue.queue.push_back(request),
+                            TorDialPriority::Normal => normal_queue.queue.push_back(request),
+                        }
+                    }
+                    None => request_closed = true,
+                }
+            }
+            Some(priority) = release_receiver.recv() => {
+                let queue = match priority {
+                    TorDialPriority::High => &mut high_queue,
+                    TorDialPriority::Normal => &mut normal_queue,
+                };
+                debug_assert!(queue.in_flight > 0, "release without a matching in-flight dial");
+                queue.in_flight = queue.in_flight.saturating_sub(1);
+            }
+            () = wait_until(next_wake) => {}
+        }
+    }
+}
+
+/// Sleeps until `deadline`, or never resolves if there is nothing to wait for.
+async fn wait_until(deadline: Option<Instant>) {
+    match deadline {
+        Some(deadline) => tokio::time::sleep_until(deadline).await,
+        None => std::future::pending().await,
+    }
+}
+
+pub(crate) fn extract_peer_id(address: &Multiaddr) -> Option<PeerId> {
+    let Protocol::P2p(peer_id) = address.iter().last()? else {
+        return None;
+    };
+
+    Some(peer_id)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config(max_concurrent: usize, min_delay: Duration) -> TorDialPriorityConfig {
+        TorDialPriorityConfig {
+            max_concurrent: NonZeroUsize::new(max_concurrent).expect("non-zero concurrency"),
+            min_delay,
+        }
+    }
+
+    /// High = 2 concurrent / 0.5s spacing, Normal = 1 concurrent / 4s spacing.
+    fn limiter(priority_tracker: TorDialPriorityTracker) -> TorDialLimiter {
+        TorDialLimiter::new(
+            priority_tracker,
+            config(2, Duration::from_millis(500)),
+            config(1, Duration::from_secs(4)),
+        )
+    }
+
+    async fn settle() {
+        for _ in 0..32 {
+            tokio::task::yield_now().await;
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn normal_dials_are_serialized_by_concurrency_and_delay() {
+        let limiter = limiter(TorDialPriorityTracker::default());
+
+        let first = limiter.wait(None).await.unwrap();
+
+        let second = tokio::spawn({
+            let limiter = limiter.clone();
+            async move { limiter.wait(None).await.unwrap() }
+        });
+
+        // Blocked by the concurrency limit of 1.
+        settle().await;
+        assert!(!second.is_finished());
+
+        // Even after the slot frees, the 4s delay since the first start applies.
+        drop(first);
+        settle().await;
+        assert!(!second.is_finished());
+
+        tokio::time::advance(Duration::from_secs(4)).await;
+        settle().await;
+        assert!(second.is_finished());
+        let _second = second.await.unwrap();
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn high_dials_respect_spacing_then_concurrency() {
+        let priority_tracker = TorDialPriorityTracker::default();
+        let limiter = limiter(priority_tracker.clone());
+
+        let spawn_wait = |peer: PeerId| {
+            priority_tracker.mark_high_priority(peer);
+            let limiter = limiter.clone();
+            tokio::spawn(async move { limiter.wait(Some(peer)).await.unwrap() })
+        };
+        let first = spawn_wait(PeerId::random());
+        let second = spawn_wait(PeerId::random());
+        let third = spawn_wait(PeerId::random());
+
+        // First starts immediately; the 0.5s spacing holds the second back.
+        settle().await;
+        assert!(first.is_finished());
+        assert!(!second.is_finished());
+
+        // Second starts after the spacing; now 2 are in flight (concurrency 2).
+        tokio::time::advance(Duration::from_millis(500)).await;
+        settle().await;
+        assert!(second.is_finished());
+
+        // Third is blocked by the concurrency limit, not just the delay.
+        tokio::time::advance(Duration::from_secs(10)).await;
+        settle().await;
+        assert!(!third.is_finished());
+
+        let first_permit = first.await.unwrap();
+        drop(first_permit);
+        settle().await;
+        assert!(third.is_finished());
+        let _ = second.await.unwrap();
+        let _ = third.await.unwrap();
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn priorities_do_not_block_each_other() {
+        let priority_tracker = TorDialPriorityTracker::default();
+        let limiter = limiter(priority_tracker.clone());
+
+        // Saturate the normal queue (concurrency 1).
+        let normal = limiter.wait(None).await.unwrap();
+
+        let normal_waiter = tokio::spawn({
+            let limiter = limiter.clone();
+            async move { limiter.wait(None).await.unwrap() }
+        });
+
+        let high_peer = PeerId::random();
+        priority_tracker.mark_high_priority(high_peer);
+        let high_waiter = tokio::spawn({
+            let limiter = limiter.clone();
+            async move { limiter.wait(Some(high_peer)).await.unwrap() }
+        });
+
+        // The high dial proceeds despite the normal queue being saturated.
+        settle().await;
+        assert!(high_waiter.is_finished());
+        assert!(!normal_waiter.is_finished());
+
+        drop(normal);
+        let _ = high_waiter.await.unwrap();
+    }
+}

--- a/libp2p-tor/src/lib.rs
+++ b/libp2p-tor/src/lib.rs
@@ -85,9 +85,15 @@ use tor_hsservice::{
 use tor_proto::client::stream::IncomingStreamRequest;
 
 mod address;
+mod dial_limiter;
 mod provider;
 
 use address::{dangerous_extract, safe_extract};
+use dial_limiter::extract_peer_id;
+pub use dial_limiter::{
+    TorDialLimiter, TorDialLimiterError, TorDialPermit, TorDialPriority, TorDialPriorityConfig,
+    TorDialPriorityTracker,
+};
 pub use provider::TokioTorStream;
 
 pub type TorError = arti_client::Error;
@@ -133,6 +139,9 @@ pub struct TorTransport {
 
     /// The Tor client.
     client: Arc<TorClient<TokioRustlsRuntime>>,
+
+    /// Limiter for outbound Tor dials.
+    dial_limiter: Option<TorDialLimiter>,
 
     /// Onion services we are listening on.
     #[cfg(feature = "listen-onion-service")]
@@ -201,6 +210,7 @@ impl TorTransport {
         Self {
             conversion_mode,
             client,
+            dial_limiter: None,
             #[cfg(feature = "listen-onion-service")]
             listeners: HashMap::new(),
             #[cfg(feature = "listen-onion-service")]
@@ -220,6 +230,13 @@ impl TorTransport {
     #[must_use]
     pub fn with_address_conversion(mut self, conversion_mode: AddressConversion) -> Self {
         self.conversion_mode = conversion_mode;
+        self
+    }
+
+    /// Set a shared outbound Tor dial limiter.
+    #[must_use]
+    pub fn with_dial_limiter(mut self, dial_limiter: TorDialLimiter) -> Self {
+        self.dial_limiter = Some(dial_limiter);
         self
     }
 
@@ -328,6 +345,8 @@ impl TorTransport {
 pub enum TorTransportError {
     #[error(transparent)]
     Client(#[from] TorError),
+    #[error(transparent)]
+    DialLimiter(#[from] TorDialLimiterError),
     #[cfg(feature = "listen-onion-service")]
     #[error(transparent)]
     Service(#[from] tor_hsservice::ClientError),
@@ -451,8 +470,18 @@ impl Transport for TorTransport {
         let tor_address =
             maybe_tor_addr.ok_or(TransportError::MultiaddrNotSupported(addr.clone()))?;
         let onion_client = self.client.clone();
+        let dial_limiter = self.dial_limiter.clone();
+        let peer_id = extract_peer_id(&addr);
 
         Ok(Box::pin(async move {
+            // Hold the dial permit for the entire duration of the dial: the slot
+            // is only freed once `_dial_permit` is dropped at the end of this
+            // scope (whether the connect succeeded or failed).
+            let _dial_permit = match dial_limiter {
+                Some(dial_limiter) => Some(dial_limiter.wait(peer_id).await?),
+                None => None,
+            };
+
             let stream = onion_client.connect(tor_address).await?;
 
             tracing::debug!(%addr, "Established connection to peer through Tor");

--- a/swap/src/cli/api.rs
+++ b/swap/src/cli/api.rs
@@ -833,16 +833,22 @@ mod builder {
                     wallet.clone(),
                     seed.derive_libp2p_identity(),
                     namespace,
-                    rendezvous_peer_ids,
+                    rendezvous_peer_ids.clone(),
                     db.clone(),
                 );
 
-                let mut swarm = crate::network::swarm::cli(
+                let (mut swarm, tor_priority_tracker) = crate::network::swarm::cli(
                     seed.derive_libp2p_identity(),
                     tor_client_for_swarm,
                     behaviour,
                 )
                 .await?;
+
+                if let Some(tor_priority_tracker) = &tor_priority_tracker {
+                    for peer_id in &rendezvous_peer_ids {
+                        tor_priority_tracker.mark_high_priority(*peer_id);
+                    }
+                }
 
                 // Add addresses of rendezvous points to the swarm
                 for (peer_id, addrs) in rendezvous_points {
@@ -860,8 +866,12 @@ mod builder {
                     }
                 }
 
-                let (event_loop, event_loop_handle) =
-                    crate::cli::EventLoop::new(swarm, db_for_swarm, self.tauri_handle.clone())?;
+                let (event_loop, event_loop_handle) = crate::cli::EventLoop::new(
+                    swarm,
+                    db_for_swarm,
+                    self.tauri_handle.clone(),
+                    tor_priority_tracker,
+                )?;
 
                 let event_loop_task = tokio::spawn(event_loop.run());
 

--- a/swap/src/cli/event_loop.rs
+++ b/swap/src/cli/event_loop.rs
@@ -16,6 +16,7 @@ use futures::{FutureExt, StreamExt};
 use libp2p::request_response::{OutboundFailure, OutboundRequestId, ResponseChannel};
 use libp2p::swarm::SwarmEvent;
 use libp2p::{PeerId, Swarm};
+use libp2p_tor::TorDialPriorityTracker;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
@@ -146,6 +147,8 @@ pub struct EventLoop {
     /// Channel for triggering a refresh of most backoffs. It will do things like redial disconnected peers,
     /// re-fetching quotes, rediscovering peers at rendezvous nodes, etc.
     refresh_requests: bmrng::unbounded::UnboundedRequestReceiverStream<(), ()>,
+
+    tor_priority_tracker: Option<TorDialPriorityTracker>,
 }
 
 impl EventLoop {
@@ -153,6 +156,7 @@ impl EventLoop {
         swarm: Swarm<Behaviour>,
         db: Arc<dyn Database + Send + Sync>,
         tauri_handle: Option<TauriHandle>,
+        tor_priority_tracker: Option<TorDialPriorityTracker>,
     ) -> Result<(Self, EventLoopHandle)> {
         // We still use a timeout here because we trust our own implementation of the swap setup protocol less than the libp2p library
         let (execution_setup_sender, execution_setup_receiver) =
@@ -191,6 +195,7 @@ impl EventLoop {
             cached_quotes_sender,
             tauri_handle,
             refresh_requests: refresh_receiver.into(),
+            tor_priority_tracker,
         };
 
         let handle = EventLoopHandle {
@@ -543,6 +548,9 @@ impl EventLoop {
                     // Instruct the swarm to continuously redial the peer
                     // TODO: We must remove it again once the swap is complete, otherwise we will redial indefinitely
                     self.swarm.behaviour_mut().redial.add_peer(peer_id);
+                    if let Some(tor_priority_tracker) = &self.tor_priority_tracker {
+                        tor_priority_tracker.mark_high_priority(peer_id);
+                    }
 
                     // Acknowledge the registration
                     let _ = responder.respond(());

--- a/swap/src/cli/transport.rs
+++ b/swap/src/cli/transport.rs
@@ -19,7 +19,7 @@ use tor_rtcompat::tokio::TokioRustlsRuntime;
 const TOR_DIAL_HIGH_PRIORITY_MAX_CONCURRENT: usize = 2;
 const TOR_DIAL_HIGH_PRIORITY_MIN_DELAY: Duration = Duration::from_millis(250);
 const TOR_DIAL_NORMAL_PRIORITY_MAX_CONCURRENT: usize = 2;
-const TOR_DIAL_NORMAL_PRIORITY_MIN_DELAY: Duration = Duration::from_millis(500);
+const TOR_DIAL_NORMAL_PRIORITY_MIN_DELAY: Duration = Duration::from_secs(1);
 
 fn new_tor_dial_limiter() -> (TorDialLimiter, TorDialPriorityTracker) {
     let priority_tracker = TorDialPriorityTracker::default();

--- a/swap/src/cli/transport.rs
+++ b/swap/src/cli/transport.rs
@@ -1,4 +1,6 @@
+use std::num::NonZeroUsize;
 use std::sync::Arc;
+use std::time::Duration;
 
 use crate::network::transport::authenticate_and_multiplex;
 use anyhow::Result;
@@ -7,8 +9,36 @@ use libp2p::core::muxing::StreamMuxerBox;
 use libp2p::core::transport::{Boxed, OptionalTransport};
 use libp2p::{PeerId, Transport, identity};
 use libp2p::{dns, tcp, websocket};
-use libp2p_tor::{AddressConversion, TorTransport};
+use libp2p_tor::{
+    AddressConversion, TorDialLimiter, TorDialPriorityConfig, TorDialPriorityTracker, TorTransport,
+};
 use tor_rtcompat::tokio::TokioRustlsRuntime;
+
+// High-priority Tor dials get more concurrency and tighter spacing than
+// normal ones.
+const TOR_DIAL_HIGH_PRIORITY_MAX_CONCURRENT: usize = 2;
+const TOR_DIAL_HIGH_PRIORITY_MIN_DELAY: Duration = Duration::from_millis(250);
+const TOR_DIAL_NORMAL_PRIORITY_MAX_CONCURRENT: usize = 2;
+const TOR_DIAL_NORMAL_PRIORITY_MIN_DELAY: Duration = Duration::from_millis(500);
+
+fn new_tor_dial_limiter() -> (TorDialLimiter, TorDialPriorityTracker) {
+    let priority_tracker = TorDialPriorityTracker::default();
+
+    let high = TorDialPriorityConfig {
+        max_concurrent: NonZeroUsize::new(TOR_DIAL_HIGH_PRIORITY_MAX_CONCURRENT)
+            .expect("TOR_DIAL_HIGH_PRIORITY_MAX_CONCURRENT to be non-zero"),
+        min_delay: TOR_DIAL_HIGH_PRIORITY_MIN_DELAY,
+    };
+    let normal = TorDialPriorityConfig {
+        max_concurrent: NonZeroUsize::new(TOR_DIAL_NORMAL_PRIORITY_MAX_CONCURRENT)
+            .expect("TOR_DIAL_NORMAL_PRIORITY_MAX_CONCURRENT to be non-zero"),
+        min_delay: TOR_DIAL_NORMAL_PRIORITY_MIN_DELAY,
+    };
+
+    let dial_limiter = TorDialLimiter::new(priority_tracker.clone(), high, normal);
+
+    (dial_limiter, priority_tracker)
+}
 
 /// Creates the libp2p transport for the swap CLI.
 ///
@@ -22,17 +52,33 @@ use tor_rtcompat::tokio::TokioRustlsRuntime;
 pub fn new(
     identity: &identity::Keypair,
     maybe_tor_client: Option<Arc<TorClient<TokioRustlsRuntime>>>,
-) -> Result<Boxed<(PeerId, StreamMuxerBox)>> {
+) -> Result<(
+    Boxed<(PeerId, StreamMuxerBox)>,
+    Option<TorDialPriorityTracker>,
+)> {
+    let (maybe_tor_dial_limiter, maybe_tor_priority_tracker) = if maybe_tor_client.is_some() {
+        let (dial_limiter, priority_tracker) = new_tor_dial_limiter();
+        (Some(dial_limiter), Some(priority_tracker))
+    } else {
+        (None, None)
+    };
+
     // Build the websocket transport first. WsConfig strips the /ws suffix and
     // delegates to its inner transport, so we give it a Tor-or-TCP+DNS chain so
     // that ws connections are routed over Tor when available.
     let ws_inner_tcp = tcp::tokio::Transport::new(tcp::Config::new().nodelay(true));
     let ws_inner_tcp_dns = dns::tokio::Transport::system(ws_inner_tcp)?;
     let ws_inner_tor: OptionalTransport<TorTransport> = match &maybe_tor_client {
-        Some(client) => OptionalTransport::some(TorTransport::from_client(
-            Arc::clone(client),
-            AddressConversion::IpAndDns,
-        )),
+        Some(client) => {
+            let mut transport =
+                TorTransport::from_client(Arc::clone(client), AddressConversion::IpAndDns);
+
+            if let Some(dial_limiter) = maybe_tor_dial_limiter.clone() {
+                transport = transport.with_dial_limiter(dial_limiter);
+            }
+
+            OptionalTransport::some(transport)
+        }
         None => OptionalTransport::none(),
     };
     let ws_inner = ws_inner_tor.or_transport(ws_inner_tcp_dns);
@@ -42,10 +88,15 @@ pub fn new(
     let tcp = tcp::tokio::Transport::new(tcp::Config::new().nodelay(true));
     let tcp_with_dns = dns::tokio::Transport::system(tcp)?;
     let maybe_tor_transport: OptionalTransport<TorTransport> = match maybe_tor_client {
-        Some(client) => OptionalTransport::some(TorTransport::from_client(
-            client,
-            AddressConversion::IpAndDns,
-        )),
+        Some(client) => {
+            let mut transport = TorTransport::from_client(client, AddressConversion::IpAndDns);
+
+            if let Some(dial_limiter) = maybe_tor_dial_limiter {
+                transport = transport.with_dial_limiter(dial_limiter);
+            }
+
+            OptionalTransport::some(transport)
+        }
         None => OptionalTransport::none(),
     };
     let plain_transport = maybe_tor_transport.or_transport(tcp_with_dns);
@@ -55,5 +106,8 @@ pub fn new(
     // /ws suffix) and establish a raw connection without a WebSocket handshake.
     let transport = ws_transport.or_transport(plain_transport).boxed();
 
-    authenticate_and_multiplex(transport, identity)
+    Ok((
+        authenticate_and_multiplex(transport, identity)?,
+        maybe_tor_priority_tracker,
+    ))
 }

--- a/swap/src/network/swarm.rs
+++ b/swap/src/network/swarm.rs
@@ -8,6 +8,7 @@ use libp2p::connection_limits::ConnectionLimits;
 use libp2p::swarm::NetworkBehaviour;
 use libp2p::{Multiaddr, Swarm, identity};
 use libp2p::{PeerId, SwarmBuilder};
+use libp2p_tor::TorDialPriorityTracker;
 use std::fmt::Debug;
 use std::sync::Arc;
 use std::time::Duration;
@@ -116,11 +117,11 @@ pub async fn cli<T>(
     identity: identity::Keypair,
     maybe_tor_client: Option<Arc<TorClient<TokioRustlsRuntime>>>,
     behaviour: T,
-) -> Result<Swarm<T>>
+) -> Result<(Swarm<T>, Option<TorDialPriorityTracker>)>
 where
     T: NetworkBehaviour,
 {
-    let transport = cli::transport::new(&identity, maybe_tor_client)?;
+    let (transport, tor_priority_tracker) = cli::transport::new(&identity, maybe_tor_client)?;
 
     let swarm = SwarmBuilder::with_existing_identity(identity)
         .with_tokio()
@@ -129,5 +130,5 @@ where
         .with_swarm_config(|cfg| cfg.with_idle_connection_timeout(IDLE_CONNECTION_TIMEOUT))
         .build();
 
-    Ok(swarm)
+    Ok((swarm, tor_priority_tracker))
 }

--- a/swap/tests/harness/mod.rs
+++ b/swap/tests/harness/mod.rs
@@ -760,10 +760,11 @@ impl BobParams {
             Vec::new(),
             db.clone(),
         );
-        let mut swarm = swarm::cli(identity.clone(), None, behaviour).await?;
+        let (mut swarm, tor_priority_tracker) =
+            swarm::cli(identity.clone(), None, behaviour).await?;
         swarm.add_peer_address(self.alice_peer_id, self.alice_address.clone());
 
-        cli::EventLoop::new(swarm, db.clone(), None)
+        cli::EventLoop::new(swarm, db.clone(), None, tor_priority_tracker)
     }
 }
 


### PR DESCRIPTION
Adds a shared `TorDialLimiter` that allows at most a fixed number of outbound Tor dials in flight at once (currently 5). When a slot frees, the highest-priority waiting dial is released next; equal-priority dials are FIFO.