### PR TITLE
Remove stale React Redux type package

### DIFF
--- a/src-gui/package.json
+++ b/src-gui/package.json
@@ -59,7 +59,6 @@
     "@types/node": "^22.15.29",
     "@types/react": "^19.1.6",
     "@types/react-dom": "^19.1.5",
-    "@types/react-redux": "^7.1.34",
     "@types/semver": "^7.5.8",
     "@vitejs/plugin-react": "^4.2.1",
     "babel-plugin-react-compiler": "^1.0.0",

--- a/src-gui/yarn.lock
+++ b/src-gui/yarn.lock
@@ -173,7 +173,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.23.2, @babel/runtime@npm:^7.26.9, @babel/runtime@npm:^7.28.4, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.8.7, @babel/runtime@npm:^7.9.2":
+"@babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.23.2, @babel/runtime@npm:^7.26.9, @babel/runtime@npm:^7.28.4, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.8.7":
   version: 7.28.4
   resolution: "@babel/runtime@npm:7.28.4"
   checksum: 10c0/792ce7af9750fb9b93879cc9d1db175701c4689da890e6ced242ea0207c9da411ccf16dc04e689cc01158b28d7898c40d75598f4559109f761c12ce01e959bf7
@@ -1675,17 +1675,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/hoist-non-react-statics@npm:^3.3.0":
-  version: 3.3.7
-  resolution: "@types/hoist-non-react-statics@npm:3.3.7"
-  dependencies:
-    hoist-non-react-statics: "npm:^3.3.0"
-  peerDependencies:
-    "@types/react": "*"
-  checksum: 10c0/ed8f4e88338f7d021d0f956adf6089d2a12b2e254a03c05292324f2e986d2376eb9efdb8a4f04596823e8fca88c9d06361d20dab4a2a00dc935fb36ac911de55
-  languageName: node
-  linkType: hard
-
 "@types/humanize-duration@npm:^3.27.4":
   version: 3.27.4
   resolution: "@types/humanize-duration@npm:3.27.4"
@@ -1755,18 +1744,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react-redux@npm:^7.1.34":
-  version: 7.1.34
-  resolution: "@types/react-redux@npm:7.1.34"
-  dependencies:
-    "@types/hoist-non-react-statics": "npm:^3.3.0"
-    "@types/react": "npm:*"
-    hoist-non-react-statics: "npm:^3.3.0"
-    redux: "npm:^4.0.0"
-  checksum: 10c0/6750964ec656eb6973b0e4fda787549aee5dbc266a0f0e78fc9efb417b4965c0b060d10b99a7b7fa0c8812b8a0a07d97a1ef46d094bf64fee07144e8bbad781a
-  languageName: node
-  linkType: hard
-
 "@types/react-transition-group@npm:^4.4.12":
   version: 4.4.12
   resolution: "@types/react-transition-group@npm:4.4.12"
@@ -1776,7 +1753,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react@npm:*, @types/react@npm:^19.1.6":
+"@types/react@npm:^19.1.6":
   version: 19.2.7
   resolution: "@types/react@npm:19.2.7"
   dependencies:
@@ -3661,7 +3638,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hoist-non-react-statics@npm:^3.3.0, hoist-non-react-statics@npm:^3.3.1":
+"hoist-non-react-statics@npm:^3.3.1":
   version: 3.3.2
   resolution: "hoist-non-react-statics@npm:3.3.2"
   dependencies:
@@ -5199,15 +5176,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"redux@npm:^4.0.0":
-  version: 4.2.1
-  resolution: "redux@npm:4.2.1"
-  dependencies:
-    "@babel/runtime": "npm:^7.9.2"
-  checksum: 10c0/136d98b3d5dbed1cd6279c8c18a6a74c416db98b8a432a46836bdd668475de6279a2d4fd9d1363f63904e00f0678a8a3e7fa532c897163340baf1e71bb42c742
-  languageName: node
-  linkType: hard
-
 "redux@npm:^5.0.1":
   version: 5.0.1
   resolution: "redux@npm:5.0.1"
@@ -6141,7 +6109,6 @@ __metadata:
     "@types/node": "npm:^22.15.29"
     "@types/react": "npm:^19.1.6"
     "@types/react-dom": "npm:^19.1.5"
-    "@types/react-redux": "npm:^7.1.34"
     "@types/semver": "npm:^7.5.8"
     "@vitejs/plugin-react": "npm:^4.2.1"
     babel-plugin-react-compiler: "npm:^1.0.0"


### PR DESCRIPTION
## Implementation notes

- Removed the stale `@types/react-redux` dev dependency from `src-gui/package.json`.
- Updated `src-gui/yarn.lock` with Yarn 4.12.0; this also drops transitive entries that were only needed by that legacy types package.
- Kept `react-redux` itself unchanged. `react-redux@9.2.0` ships its own types at `dist/react-redux.d.ts`.

## Verification output

- `npm view react-redux@9.2.0 types` -> `dist/react-redux.d.ts`
- `npm exec --yes --package @yarnpkg/cli-dist@4.12.0 yarn -- --cwd src-gui install --immutable` -> passes with existing peer dependency warnings
- `git diff --check` -> passes
- `npm exec --yes --package @yarnpkg/cli-dist@4.12.0 yarn -- --cwd src-gui tsc` -> blocked by missing generated `src/models/tauriModel` bindings in this checkout; the reported errors are from that missing generated file
- `cargo c --all-features`, `cargo c --tests`, `cargo c --all-targets` -> not runnable in this environment because `cargo` is not installed

Fixes #775