### PR TITLE
chore: remove unused monero-wallet-ng dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6663,14 +6663,12 @@ dependencies = [
 name = "monero-wallet-ng"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "backoff",
  "curve25519-dalek",
  "hex",
  "monero-daemon-rpc",
  "monero-interface",
  "monero-oxide",
- "monero-simple-request-rpc",
  "monero-wallet 0.1.0 (git+https://github.com/kayabaNerve/monero-oxide.git)",
  "rand 0.8.5",
  "serde",

--- a/monero-wallet-ng/Cargo.toml
+++ b/monero-wallet-ng/Cargo.toml
@@ -4,8 +4,6 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-# Error handling
-anyhow = { workspace = true }
 backoff = { workspace = true }
 thiserror = { workspace = true }
 
@@ -28,7 +26,6 @@ monero-daemon-rpc = { workspace = true }
 monero-interface = { workspace = true }
 monero-oxide = { workspace = true }
 monero-oxide-wallet = { workspace = true }
-monero-simple-request-rpc = { workspace = true }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }


### PR DESCRIPTION
## Summary

- Remove unused `anyhow` from `monero-wallet-ng`.
- Remove unused `monero-simple-request-rpc` from `monero-wallet-ng`.
- Update `Cargo.lock` accordingly.

This is a narrow, non-overlapping pass for #775; it does not touch the GUI dependency cleanup in #1027.

## Verification

- `cargo check -p monero-wallet-ng`
- `cargo check -p monero-wallet-ng --tests`
- `cargo machete --with-metadata` (the package is no longer reported; existing unrelated workspace reports remain)
- `git diff --check`

AI-assisted with Codex; I reviewed the diff and verification output before submitting.