### PR TITLE
docs: update Flatpak runtime install command

### DIFF
--- a/docs/content/getting_started/install_instructions.mdx
+++ b/docs/content/getting_started/install_instructions.mdx
@@ -81,7 +81,7 @@ Choose your platform and follow the instructions.
     # Add eigenwallet repo
     flatpak remote-add --if-not-exists eigenwallet https://eigenwallet.github.io/core/eigenwallet.flatpakrepo
     # Add dependencies
-    flatpak install flathub org.gnome.Platform//47
+    flatpak install flathub org.gnome.Platform//48
     # Install eigenwallet
     flatpak install eigenwallet org.eigenwallet.app
     ```


### PR DESCRIPTION
For #840.

The Flatpak manifest already targets GNOME 48 after #853, but the Linux install docs still tell users to install the EOL `org.gnome.Platform//47` runtime. This updates the documented dependency command to `org.gnome.Platform//48` so the docs match the current manifest and supported runtime.

Verification:
- `rg -n "org\.gnome\.Platform//47|//47" docs flatpak` returns no matches
- `git diff --check`

Disclosure: I used AI assistance to inspect the repo and prepare this docs-only change.