### PR TITLE
chore: remove unused monero-wallet dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6619,8 +6619,6 @@ name = "monero-wallet"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "backoff",
- "curve25519-dalek",
  "hex",
  "monero-address",
  "monero-daemon-rpc",
@@ -6633,7 +6631,6 @@ dependencies = [
  "throttle",
  "tokio",
  "tracing",
- "tracing-subscriber",
  "uuid",
  "zeroize",
 ]

--- a/monero-wallet/Cargo.toml
+++ b/monero-wallet/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2024"
 [dependencies]
 # Error handling
 anyhow = { workspace = true }
-backoff = { workspace = true }
 
 # Other stuff
 monero-address = { workspace = true }
@@ -21,7 +20,6 @@ tokio = { workspace = true, features = ["process", "fs", "net", "parking_lot", "
 
 # Tracing
 tracing = { workspace = true }
-tracing-subscriber = { workspace = true }
 
 # monero-oxide
 monero-daemon-rpc = { workspace = true }
@@ -30,6 +28,5 @@ monero-simple-request-rpc = { workspace = true }
 monero-wallet-ng = { path = "../monero-wallet-ng" }
 
 # Cryptography
-curve25519-dalek = { workspace = true }
 hex = { workspace = true }
 zeroize = { workspace = true }


### PR DESCRIPTION
## Summary
- remove unused `backoff` from `monero-wallet`
- remove unused `curve25519-dalek` from `monero-wallet`
- remove unused `tracing-subscriber` from `monero-wallet`
- update `Cargo.lock` accordingly

This is a narrow, non-overlapping pass for #775. It does not touch the `monero-wallet-ng`, `src-gui`, or `bitcoin-wallet` dependency cleanup work already discussed there.

## Verification
- `rg -n "\\b(backoff|curve25519_dalek|tracing_subscriber|curve25519-dalek|tracing-subscriber)\\b" monero-wallet` returned no matches
- `cargo metadata --no-deps --format-version 1 --manifest-path monero-wallet/Cargo.toml | jq -r ".packages[] | select(.name == \"monero-wallet\" and .source == null) | .dependencies[].name"` confirms the removed crates are absent from the local package dependencies
- `cargo machete --with-metadata` no longer reports `monero-wallet`; unrelated workspace findings remain
- `git diff --check`

Blocked:
- `cargo check --manifest-path monero-wallet/Cargo.toml`
- `cargo check --manifest-path monero-wallet/Cargo.toml --tests`

Both Cargo checks fail before compiling this package because `monero-sys` requires initialized Monero submodules in this checkout: `monero-sys/build.rs` cannot find `src/wallet/api/wallet.cpp`. `git submodule status` shows `monero-sys/monero` and `monero-sys/monero-depends` are not initialized.

AI-assisted with Codex; I reviewed the diff and verification output before submitting.