### PR TITLE
chore(gui): remove unused testing library deps

### DIFF
--- a/src-gui/package.json
+++ b/src-gui/package.json
@@ -52,8 +52,6 @@
     "@eslint/js": "^9.9.0",
     "@redux-devtools/remote": "^0.9.5",
     "@tauri-apps/cli": "^2.0.0",
-    "@testing-library/react": "^16.0.1",
-    "@testing-library/user-event": "^14.5.2",
     "@types/humanize-duration": "^3.27.4",
     "@types/lodash": "^4.17.6",
     "@types/node": "^22.15.29",

--- a/src-gui/yarn.lock
+++ b/src-gui/yarn.lock
@@ -1591,35 +1591,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@testing-library/react@npm:^16.0.1":
-  version: 16.3.1
-  resolution: "@testing-library/react@npm:16.3.1"
-  dependencies:
-    "@babel/runtime": "npm:^7.12.5"
-  peerDependencies:
-    "@testing-library/dom": ^10.0.0
-    "@types/react": ^18.0.0 || ^19.0.0
-    "@types/react-dom": ^18.0.0 || ^19.0.0
-    react: ^18.0.0 || ^19.0.0
-    react-dom: ^18.0.0 || ^19.0.0
-  peerDependenciesMeta:
-    "@types/react":
-      optional: true
-    "@types/react-dom":
-      optional: true
-  checksum: 10c0/5a26ceaa4ab1d065be722d93e3b019883864ae038f9fd1c974f5b8a173f5f35a25768ecb2baa02a783299f009cbcd09fa7ee0b8b3d360d1c0f81535436358b28
-  languageName: node
-  linkType: hard
-
-"@testing-library/user-event@npm:^14.5.2":
-  version: 14.6.1
-  resolution: "@testing-library/user-event@npm:14.6.1"
-  peerDependencies:
-    "@testing-library/dom": ">=7.21.4"
-  checksum: 10c0/75fea130a52bf320d35d46ed54f3eec77e71a56911b8b69a3fe29497b0b9947b2dc80d30f04054ad4ce7f577856ae3e5397ea7dff0ef14944d3909784c7a93fe
-  languageName: node
-  linkType: hard
-
 "@types/babel__core@npm:^7.20.5":
   version: 7.20.5
   resolution: "@types/babel__core@npm:7.20.5"
@@ -6134,8 +6105,6 @@ __metadata:
     "@tauri-apps/plugin-process": "npm:^2.3.0"
     "@tauri-apps/plugin-store": "npm:^2.4.0"
     "@tauri-apps/plugin-updater": "npm:^2.9.0"
-    "@testing-library/react": "npm:^16.0.1"
-    "@testing-library/user-event": "npm:^14.5.2"
     "@types/humanize-duration": "npm:^3.27.4"
     "@types/lodash": "npm:^4.17.6"
     "@types/node": "npm:^22.15.29"


### PR DESCRIPTION
## Summary
- Remove unused `@testing-library/react` and `@testing-library/user-event` from `src-gui`.
- Update the Yarn lockfile to drop the direct entries for those packages.

## Verification
- `rg -n '@testing-library/(react|user-event)' src-gui` (no matches)
- `find src-gui -name '*test*' -o -name '*spec*'` (no files)
- `git diff --check`

Refs #775.

I could not run a full Yarn install/build in this environment because dependency installation for this public repo was blocked by the local safety policy. AI assistance used: OpenAI Codex helped inspect usage and prepare the patch; I reviewed the resulting two-file dependency-only diff.