### PR TITLE
Remove unused libp2p-tor tor-llcrypto dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5895,7 +5895,6 @@ dependencies = [
  "tor-cell",
  "tor-hscrypto",
  "tor-hsservice",
- "tor-llcrypto",
  "tor-proto",
  "tor-rtcompat",
  "tracing",

--- a/libp2p-tor/Cargo.toml
+++ b/libp2p-tor/Cargo.toml
@@ -22,7 +22,6 @@ safelog = { workspace = true }
 tor-cell = { workspace = true, optional = true }
 tor-hscrypto = { workspace = true, optional = true }
 tor-hsservice = { workspace = true, optional = true }
-tor-llcrypto = { workspace = true, optional = true }
 tor-proto = { workspace = true, optional = true }
 tor-rtcompat = { workspace = true, features = ["tokio", "rustls"] }
 tracing = { workspace = true }
@@ -39,7 +38,6 @@ listen-onion-service = [
   "arti-client/experimental-api",
   "dep:tor-hscrypto",
   "dep:tor-hsservice",
-  "dep:tor-llcrypto",
   "dep:tor-cell",
   "dep:tor-proto",
 ]


### PR DESCRIPTION
## Summary

Refs #775.

Removes the unused direct optional `tor-llcrypto` dependency from `libp2p-tor`. The crate does not reference `tor_llcrypto` directly, and `listen-onion-service` continues to compile with its remaining direct Tor dependencies (`tor-hscrypto`, `tor-hsservice`, `tor-cell`, and `tor-proto`). `Cargo.lock` now drops `tor-llcrypto` from `libp2p-tor`'s direct dependency list.

## Validation

- `cargo +1.90.0 check --manifest-path libp2p-tor\Cargo.toml --all-targets`
- `cargo +1.90.0 check --manifest-path libp2p-tor\Cargo.toml --all-targets --all-features`

I also tried `cargo +1.90.0 check --workspace --all-features`; it is currently blocked by an unrelated `monero-sys` build-script patch failure while applying the wallet API patch to `src/wallet/api/wallet.cpp`.