### PR TITLE
chore: remove unused monero-rpc-pool rustls dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6520,7 +6520,6 @@ dependencies = [
  "monero-address",
  "rand 0.8.5",
  "reqwest 0.11.27",
- "rustls 0.21.12",
  "serde",
  "serde_json",
  "sqlx",

--- a/monero-rpc-pool/Cargo.toml
+++ b/monero-rpc-pool/Cargo.toml
@@ -52,8 +52,6 @@ hyper = { version = "1", features = ["full"] }
 hyper-util = { version = "0.1", features = ["full"] }
 tower-http = { version = "0.6.6", features = ["cors"] }
 
-# TLS/Security
-rustls = { version = "0.21", features = ["dangerous_configuration"] }
 tokio-rustls = "0.26"
 
 # Tor networking


### PR DESCRIPTION
For #775.

## Summary
- remove unused direct `rustls` dependency from `monero-rpc-pool`
- keep the existing `tokio-rustls` dependency, which is what the crate imports for rustls types
- update `Cargo.lock` accordingly

This is a narrow, non-overlapping cleanup. It does not touch the bitcoin-wallet, libp2p-tor, monero-wallet, monero-wallet-ng, or GUI dependency cleanup PRs already open.

## Verification
- `cargo check -p monero-rpc-pool --all-targets`
- `cargo metadata --format-version=1 --no-deps | jq -r '.packages[] | select(.name=="monero-rpc-pool") | .dependencies[].name' | rg '^rustls$'` returned no matches
- `cargo machete --with-metadata` no longer reports `monero-rpc-pool`
- `git diff --check`

AI-assisted with Codex; I reviewed the diff and verification output before submitting.
