### PR TITLE
Remove unused src-tauri serde dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13525,8 +13525,6 @@ version = "4.6.1"
 dependencies = [
  "dfx-swiss-sdk",
  "rustls 0.23.37",
- "serde",
- "serde_json",
  "swap",
  "swap-p2p",
  "tauri",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -18,8 +18,6 @@ swap-p2p = { path = "../swap-p2p" }
 dfx-swiss-sdk = { workspace = true }
 
 rustls = { version = "0.23.26", default-features = false, features = ["ring"] }
-serde = { version = "1", features = [ "derive" ] }
-serde_json = "1"
 
 tracing = "0.1"
 zip = "4.0.0"


### PR DESCRIPTION
## Summary
- remove unused direct `serde` and `serde_json` dependencies from `src-tauri`
- refresh `Cargo.lock` so the `unstoppableswap-gui-rs` package dependency list matches

Part of #775.

## Validation
- `rg -n "serde|serde_json|Serialize|Deserialize" src-tauri/src src-tauri/build.rs` finds no direct uses
- `cargo +1.90.0 metadata --manifest-path src-tauri\Cargo.toml --format-version 1 --no-deps`
- `cargo +1.90.0 check --manifest-path src-tauri\Cargo.toml --all-targets --all-features` is blocked locally before reaching this crate by the existing `monero-sys` patch application failure:
  `Failed to apply patch to src/wallet/api/wallet.cpp: error applying hunk #1`