### PR TITLE
Remove unused monero-tests dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6594,14 +6594,11 @@ name = "monero-tests"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "curve25519-dalek",
  "hex",
  "monero-address",
- "monero-daemon-rpc",
  "monero-harness",
  "monero-interface",
  "monero-oxide-ext",
- "monero-simple-request-rpc",
  "monero-sys",
  "monero-wallet 0.1.0 (git+https://github.com/kayabaNerve/monero-oxide.git)",
  "monero-wallet-ng",
@@ -6610,7 +6607,6 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "uuid",
  "zeroize",
 ]
 

--- a/monero-tests/Cargo.toml
+++ b/monero-tests/Cargo.toml
@@ -5,24 +5,20 @@ edition = "2024"
 
 [dev-dependencies]
 monero-address = { workspace = true }
-monero-daemon-rpc = { workspace = true }
 monero-harness = { path = "../monero-harness" }
 monero-interface = { workspace = true }
 monero-oxide-ext = { path = "../monero-oxide-ext" }
 monero-oxide-wallet = { workspace = true }
-monero-simple-request-rpc = { workspace = true }
 monero-sys = { path = "../monero-sys" }
 monero-wallet-ng = { path = "../monero-wallet-ng" }
 testcontainers = { workspace = true }
 
 anyhow = { workspace = true }
-curve25519-dalek = { workspace = true }
 hex = { workspace = true }
 rand = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
-uuid = { workspace = true }
 zeroize = { workspace = true }
 
 # Each test counts as a seperate crate, and would individually get


### PR DESCRIPTION
Summary:
- Removes four unused direct dev-dependencies from `monero-tests`: `curve25519-dalek`, `monero-daemon-rpc`, `monero-simple-request-rpc`, and `uuid`.
- Updates the `monero-tests` package dependency list in `Cargo.lock`.

This is another focused cleanup for #775.

Validation:
- `cargo +1.90.0 metadata --manifest-path monero-tests\Cargo.toml --format-version 1 --no-deps`
- `rg -n "curve25519|monero_daemon_rpc|monero_simple_request_rpc|uuid|Uuid" monero-tests` returns no matches
- `cargo machete --with-metadata` no longer reports `monero-tests`
- `cargo +1.90.0 check --manifest-path monero-tests\Cargo.toml --tests` is still blocked locally by the pre-existing `monero-sys` build script patch failure before/after this change (`Failed to apply patch to src/wallet/api/wallet.cpp`)