### PR TITLE
feat(asb, controller): get external bitcoin redeem address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - CLI: Outbound Tor dials are now concurrency-limited and spaced out, with a separate higher-throughput lane for high-priority peers, so bursts of dials no longer overwhelm the embedded Tor client.
+- ASB+CONTROLLER: New `get-external-bitcoin-redeem-address` command returns the external Bitcoin redeem address currently used by the ASB (or `null` if the internal wallet is used).
 
 ## [4.6.1] - 2026-05-15
 

--- a/swap-controller-api/src/lib.rs
+++ b/swap-controller-api/src/lib.rs
@@ -134,6 +134,11 @@ pub struct SetBurnOnRefundRequest {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ExternalBitcoinRedeemAddressResponse {
+    pub address: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct QuoteResponse {
     /// Price offered per 1 XMR, in satoshis.
     #[serde(with = "bitcoin::amount::serde::as_sat")]
@@ -197,6 +202,10 @@ pub trait AsbApi {
     ) -> Result<(), ErrorObjectOwned>;
     #[method(name = "clear_external_bitcoin_redeem_address")]
     async fn clear_external_bitcoin_redeem_address(&self) -> Result<(), ErrorObjectOwned>;
+    #[method(name = "get_external_bitcoin_redeem_address")]
+    async fn get_external_bitcoin_redeem_address(
+        &self,
+    ) -> Result<ExternalBitcoinRedeemAddressResponse, ErrorObjectOwned>;
     #[method(name = "refresh_bitcoin_wallet")]
     async fn refresh_bitcoin_wallet(&self) -> Result<(), ErrorObjectOwned>;
     #[method(name = "get_current_quote")]

--- a/swap-controller/src/cli.rs
+++ b/swap-controller/src/cli.rs
@@ -53,6 +53,8 @@ pub enum Cmd {
     /// Clear the external bitcoin redeem address. Future swaps will be redeemed into
     /// the internal Bitcoin wallet. Also updates config.toml.
     ClearExternalBitcoinRedeemAddress,
+    /// Show the external bitcoin redeem address currently used (if any).
+    GetExternalBitcoinRedeemAddress,
     /// Grant mercy (release the anti-spam deposit) for a swap in BtcWithheld state
     GrantMercy {
         /// The swap ID

--- a/swap-controller/src/main.rs
+++ b/swap-controller/src/main.rs
@@ -165,6 +165,15 @@ async fn dispatch(cmd: Cmd, client: impl AsbApiClient) -> anyhow::Result<()> {
                 "Cleared external Bitcoin redeem address. Future swaps will be redeemed into the internal Bitcoin wallet."
             );
         }
+        Cmd::GetExternalBitcoinRedeemAddress => {
+            let response = client.get_external_bitcoin_redeem_address().await?;
+            match response.address {
+                Some(address) => println!("External Bitcoin redeem address: {address}"),
+                None => println!(
+                    "No external Bitcoin redeem address set. Swaps are redeemed into the internal Bitcoin wallet."
+                ),
+            }
+        }
         Cmd::GrantMercy { swap_id } => {
             client.grant_mercy(swap_id).await?;
             println!("Mercy granted for swap {swap_id}");

--- a/swap/src/asb/event_loop.rs
+++ b/swap/src/asb/event_loop.rs
@@ -618,6 +618,9 @@ where
                             let result = self.handle_set_external_bitcoin_redeem_address(address).await;
                             let _ = respond_to.send(result);
                         }
+                        EventLoopRequest::GetExternalBitcoinRedeemAddress { respond_to } => {
+                            let _ = respond_to.send(self.external_redeem_address.clone());
+                        }
                     }
                 }
             }
@@ -1341,6 +1344,9 @@ mod service {
             address: Option<bitcoin::Address>,
             respond_to: oneshot::Sender<Result<(), anyhow::Error>>,
         },
+        GetExternalBitcoinRedeemAddress {
+            respond_to: oneshot::Sender<Option<bitcoin::Address>>,
+        },
     }
 
     /// Tower service for communicating with the EventLoop
@@ -1472,6 +1478,17 @@ mod service {
                 .map_err(|_| anyhow::anyhow!("EventLoop service is down"))?;
             rx.await
                 .map_err(|_| anyhow::anyhow!("EventLoop service did not respond"))?
+        }
+
+        pub async fn get_external_bitcoin_redeem_address(
+            &self,
+        ) -> anyhow::Result<Option<bitcoin::Address>> {
+            let (tx, rx) = oneshot::channel();
+            self.sender
+                .send(EventLoopRequest::GetExternalBitcoinRedeemAddress { respond_to: tx })
+                .map_err(|_| anyhow::anyhow!("EventLoop service is down"))?;
+            rx.await
+                .map_err(|_| anyhow::anyhow!("EventLoop service did not respond"))
         }
 
         pub async fn clear_external_bitcoin_redeem_address(&self) -> anyhow::Result<()> {

--- a/swap/src/asb/rpc/server.rs
+++ b/swap/src/asb/rpc/server.rs
@@ -11,10 +11,11 @@ use rust_decimal::{Decimal, RoundingStrategy};
 use std::sync::Arc;
 use swap_controller_api::{
     ActiveConnectionsResponse, AsbApiServer, BitcoinBalanceResponse, BitcoinSeedResponse,
-    MoneroAddressResponse, MoneroBalanceResponse, MoneroSeedResponse, MultiaddressesResponse,
-    OnionServiceStatusResponse, PeerIdResponse, QuoteResponse, RegistrationStatusItem,
-    RegistrationStatusResponse, RendezvousConnectionStatus, RendezvousRegistrationStatus, Swap,
-    WithdrawBtcResponse, WormholeServiceItem, WormholeServicesResponse,
+    ExternalBitcoinRedeemAddressResponse, MoneroAddressResponse, MoneroBalanceResponse,
+    MoneroSeedResponse, MultiaddressesResponse, OnionServiceStatusResponse, PeerIdResponse,
+    QuoteResponse, RegistrationStatusItem, RegistrationStatusResponse, RendezvousConnectionStatus,
+    RendezvousRegistrationStatus, Swap, WithdrawBtcResponse, WormholeServiceItem,
+    WormholeServicesResponse,
 };
 use swap_core::monero::PICONERO_OFFSET;
 use tokio_util::task::AbortOnDropHandle;
@@ -368,6 +369,20 @@ impl AsbApiServer for RpcImpl {
             .into_json_rpc_result()?;
 
         Ok(())
+    }
+
+    async fn get_external_bitcoin_redeem_address(
+        &self,
+    ) -> Result<ExternalBitcoinRedeemAddressResponse, ErrorObjectOwned> {
+        let address = self
+            .event_loop_service
+            .get_external_bitcoin_redeem_address()
+            .await
+            .into_json_rpc_result()?;
+
+        Ok(ExternalBitcoinRedeemAddressResponse {
+            address: address.map(|a| a.to_string()),
+        })
     }
 
     async fn get_current_quote(&self) -> Result<QuoteResponse, ErrorObjectOwned> {


### PR DESCRIPTION
Adds a `get-external-bitcoin-redeem-address` RPC/CLI command that returns the external Bitcoin redeem address currently used by the ASB, or null if the internal wallet is used.