### PR TITLE
Surface the real Monero transaction construction error

### DIFF
--- a/monero-sys/src/lib.rs
+++ b/monero-sys/src/lib.rs
@@ -1004,7 +1004,9 @@ impl WalletHandle {
                 let (txid, amount, fee) = match result {
                     Ok(values) => values,
                     Err(e) => {
-                        wallet.dispose_pending_transaction(pending_tx);
+                        if let Err(dispose_error) = wallet.dispose_pending_transaction(pending_tx) {
+                            tracing::error!(error=%dispose_error, "Failed to dispose pending transaction after validation error");
+                        }
                         return Err(e);
                     }
                 };
@@ -1032,16 +1034,20 @@ impl WalletHandle {
                     let receipt_result =
                         wallet.publish_pending_transaction(&mut pending_tx, &[address]);
 
-                    // Dispose the pending transaction independent of whether the publish was successful or not
-                    wallet.dispose_pending_transaction(pending_tx);
+                    // Dispose independent of whether the publish succeeded. Log the
+                    // disposal error rather than propagating it, so it can't mask a
+                    // publish result that may have already moved funds.
+                    if let Err(dispose_error) = wallet.dispose_pending_transaction(pending_tx) {
+                        tracing::error!(error=%dispose_error, "Failed to dispose pending transaction after publishing");
+                    }
 
                     let receipt = receipt_result?;
 
                     return Ok(Some((receipt, amount, fee)));
                 }
 
-                // Dispose the pending transaction if the user didn't approve
-                wallet.dispose_pending_transaction(pending_tx);
+                // Nothing was published, so propagate a disposal failure directly.
+                wallet.dispose_pending_transaction(pending_tx)?;
 
                 Ok(None)
             })
@@ -1233,7 +1239,9 @@ impl Wallet {
         // C++ objects leak when the map is dropped (PendingTransactionHandle has no
         // Drop impl). This must run while the wallet is still open.
         for (_, pending_tx) in self.pending_transactions.drain() {
-            self.wallet.dispose_pending_transaction(pending_tx);
+            if let Err(e) = self.wallet.dispose_pending_transaction(pending_tx) {
+                tracing::error!(error=%e, "Failed to dispose pending transaction during shutdown");
+            }
         }
 
         let result = self.manager.close_wallet(&mut self.wallet);
@@ -2379,9 +2387,12 @@ impl FfiWallet {
             .publish_pending_transaction(&mut pending_tx, &[*address])
             .context("Failed to publish sweep transaction");
 
-        // Dispose the pending transaction after we're done with it
-        // independent of whether the publish was successful or not
-        self.dispose_pending_transaction(pending_tx);
+        // Dispose the pending transaction after we're done with it, independent of
+        // whether the publish succeeded. Log a disposal error rather than
+        // propagating it, so a cleanup failure doesn't override the publish result.
+        if let Err(e) = self.dispose_pending_transaction(pending_tx) {
+            tracing::error!(error=%e, "Failed to dispose pending transaction after sweeping");
+        }
 
         result
     }
@@ -2407,9 +2418,12 @@ impl FfiWallet {
         // Publish the transaction
         let result = self.publish_pending_transaction(&mut pending_tx, &output_addresses);
 
-        // Dispose the pending transaction after we're done with it
-        // independent of whether the publish was successful or not
-        self.dispose_pending_transaction(pending_tx);
+        // Dispose the pending transaction after we're done with it, independent of
+        // whether the publish succeeded. Log a disposal error rather than
+        // propagating it, so a cleanup failure doesn't override the publish result.
+        if let Err(e) = self.dispose_pending_transaction(pending_tx) {
+            tracing::error!(error=%e, "Failed to dispose pending transaction after transferring");
+        }
 
         result
     }
@@ -2477,10 +2491,8 @@ impl FfiWallet {
             "Failed to create multi-destination transaction: FFI call failed with exception",
         )?;
 
-        self.finalize_created_pending_transaction(
-            raw_tx,
-            "Failed to create multi-destination transaction",
-        )
+        self.finalize_created_pending_transaction(raw_tx)
+            .context("Failed to create multi-destination transaction")
     }
 
     /// Wrap a freshly created pending transaction pointer, propagating any error
@@ -2492,19 +2504,20 @@ impl FfiWallet {
     fn finalize_created_pending_transaction(
         &mut self,
         raw_tx: *mut ffi::PendingTransaction,
-        error_context: &'static str,
     ) -> anyhow::Result<PendingTransactionHandle> {
         if raw_tx.is_null() {
-            self.check_error().context(error_context)?;
-            bail!("{}: wallet returned a null pending transaction", error_context);
+            self.check_error()?;
+            bail!("wallet returned a null pending transaction");
         }
 
         // A failed construction still allocates the object, so it must be
         // disposed rather than leaked when we propagate the error.
         let pending_tx = PendingTransactionHandle(raw_tx);
         if let Err(error) = pending_tx.check_error() {
-            self.dispose_pending_transaction(pending_tx);
-            return Err(error.context(error_context));
+            if let Err(dispose_error) = self.dispose_pending_transaction(pending_tx) {
+                tracing::error!(error=%dispose_error, "Failed to dispose pending transaction after construction error");
+            }
+            return Err(error);
         }
 
         Ok(pending_tx)
@@ -2524,7 +2537,8 @@ impl FfiWallet {
         let raw_tx = ffi::createSweepTransaction(self.inner.pinned(), &address_str)
             .context("Failed to create sweep transaction: FFI call failed with exception")?;
 
-        self.finalize_created_pending_transaction(raw_tx, "Failed to create sweep transaction")
+        self.finalize_created_pending_transaction(raw_tx)
+            .context("Failed to create sweep transaction")
     }
 
     /// Publish a pending transaction and return a receipt.
@@ -2652,14 +2666,20 @@ impl FfiWallet {
     /// Dispose (deallocate) a pending transaction object.
     /// Always call this before dropping a pending transaction object,
     /// otherwise we leak memory.
-    fn dispose_pending_transaction(&mut self, tx: PendingTransactionHandle) {
+    ///
+    /// Returns an error if the underlying FFI call fails. Callers decide whether
+    /// to propagate it: where it would mask a more important result (e.g. after a
+    /// publish attempt) it should be logged instead.
+    fn dispose_pending_transaction(
+        &mut self,
+        tx: PendingTransactionHandle,
+    ) -> anyhow::Result<()> {
         // Safety: we pass a valid pointer and we verified it's not used again since PendingTransaction is moved into this function
         unsafe {
             self.inner
                 .pinned()
                 .disposeTransaction(tx.0)
                 .context("Failed to dispose transaction: FFI call failed with exception")
-                .expect("Shouldn't panic");
         }
     }
 
@@ -2851,15 +2871,16 @@ impl PendingTransactionHandle {
         let status = self
             .status()
             .context("Failed to get pending transaction status: FFI call failed with exception")?;
+
+        if status == 0 {
+            return Ok(());
+        }
+
         let error_string = ffi::pendingTransactionErrorString(self)
             .context(
                 "Failed to get pending transaction error string: FFI call failed with exception",
             )?
             .to_string();
-
-        if status == 0 {
-            return Ok(());
-        }
 
         let error_type = if status == 2 { "critical" } else { "error" };
 

--- a/monero-sys/src/lib.rs
+++ b/monero-sys/src/lib.rs
@@ -2470,12 +2470,32 @@ impl FfiWallet {
             "Failed to create multi-destination transaction: FFI call failed with exception",
         )?;
 
+        self.finalize_created_pending_transaction(
+            raw_tx,
+            "Failed to create multi-destination transaction",
+        )
+    }
+
+    /// Wrap a freshly created pending transaction pointer, propagating any error
+    /// recorded during construction.
+    ///
+    /// wallet2 returns a non-null object even when construction fails, recording the
+    /// cause in the transaction's own status; checking it here keeps that error from
+    /// being masked by the empty-txid check during publishing.
+    fn finalize_created_pending_transaction(
+        &self,
+        raw_tx: *mut ffi::PendingTransaction,
+        error_context: &'static str,
+    ) -> anyhow::Result<PendingTransactionHandle> {
         if raw_tx.is_null() {
-            self.check_error()
-                .context("Failed to create multi-destination transaction")?;
+            self.check_error().context(error_context)?;
+            bail!("{}: wallet returned a null pending transaction", error_context);
         }
 
-        Ok(PendingTransactionHandle(raw_tx))
+        let pending_tx = PendingTransactionHandle(raw_tx);
+        pending_tx.check_error().context(error_context)?;
+
+        Ok(pending_tx)
     }
 
     /// Create a pending sweep transaction without publishing it.
@@ -2489,12 +2509,10 @@ impl FfiWallet {
 
         let_cxx_string!(address_str = address.to_string());
 
-        let pending_tx = PendingTransactionHandle(
-            ffi::createSweepTransaction(self.inner.pinned(), &address_str)
-                .context("Failed to create sweep transaction: FFI call failed with exception")?,
-        );
+        let raw_tx = ffi::createSweepTransaction(self.inner.pinned(), &address_str)
+            .context("Failed to create sweep transaction: FFI call failed with exception")?;
 
-        Ok(pending_tx)
+        self.finalize_created_pending_transaction(raw_tx, "Failed to create sweep transaction")
     }
 
     /// Publish a pending transaction and return a receipt.

--- a/monero-sys/src/lib.rs
+++ b/monero-sys/src/lib.rs
@@ -1229,6 +1229,13 @@ impl Wallet {
 
         tracing::info!("Wallet handle dropped, closing wallet and exiting thread",);
 
+        // Dispose any pending transactions still awaiting approval, otherwise their
+        // C++ objects leak when the map is dropped (PendingTransactionHandle has no
+        // Drop impl). This must run while the wallet is still open.
+        for (_, pending_tx) in self.pending_transactions.drain() {
+            self.wallet.dispose_pending_transaction(pending_tx);
+        }
+
         let result = self.manager.close_wallet(&mut self.wallet);
 
         if let Err(e) = result {
@@ -2483,7 +2490,7 @@ impl FfiWallet {
     /// cause in the transaction's own status; checking it here keeps that error from
     /// being masked by the empty-txid check during publishing.
     fn finalize_created_pending_transaction(
-        &self,
+        &mut self,
         raw_tx: *mut ffi::PendingTransaction,
         error_context: &'static str,
     ) -> anyhow::Result<PendingTransactionHandle> {
@@ -2492,8 +2499,13 @@ impl FfiWallet {
             bail!("{}: wallet returned a null pending transaction", error_context);
         }
 
+        // A failed construction still allocates the object, so it must be
+        // disposed rather than leaked when we propagate the error.
         let pending_tx = PendingTransactionHandle(raw_tx);
-        pending_tx.check_error().context(error_context)?;
+        if let Err(error) = pending_tx.check_error() {
+            self.dispose_pending_transaction(pending_tx);
+            return Err(error.context(error_context));
+        }
 
         Ok(pending_tx)
     }

--- a/monero-sys/tests/transaction_construction_error.rs
+++ b/monero-sys/tests/transaction_construction_error.rs
@@ -1,0 +1,82 @@
+//! Regression test for transaction construction error reporting.
+//!
+//! wallet2 returns a non-null `PendingTransaction` even when construction fails,
+//! recording the real cause (e.g. "not enough money") in the object's own status
+//! rather than returning a null pointer. If we don't inspect that status right
+//! after creation, the failure is later masked by the empty-txid check, which
+//! reports the misleading "Expected 1 txid, got 0" instead.
+//!
+//! This drives a freshly created (and therefore empty) stagenet wallet, which
+//! makes `create_transactions_2` throw `not_enough_money` deterministically.
+
+use futures::FutureExt;
+use monero_oxide_ext::Amount;
+use monero_sys::{ApprovalCallback, Daemon, SyncProgress, WalletHandle};
+use std::sync::Arc;
+
+const STAGENET_REMOTE_NODE: &str = "http://node.sethforprivacy.com:38089";
+
+#[tokio::test]
+async fn construction_failure_surfaces_real_error() -> anyhow::Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter("info,monero_sys=debug")
+        .with_test_writer()
+        .init();
+
+    let temp_dir = tempfile::tempdir().unwrap();
+    let daemon = Daemon::try_from(STAGENET_REMOTE_NODE).unwrap();
+
+    let wallet_path = temp_dir.path().join("empty_wallet").display().to_string();
+
+    // A freshly generated wallet starts empty with its restore height at the
+    // current chain tip, so there is nothing to scan and it syncs near-instantly.
+    let wallet =
+        WalletHandle::open_or_create(wallet_path, daemon, monero_address::Network::Stagenet, false)
+            .await
+            .expect("Failed to create wallet");
+
+    wallet
+        .wait_until_synced(None::<fn(SyncProgress)>)
+        .await
+        .expect("Failed to sync wallet");
+
+    assert_eq!(
+        wallet.unlocked_balance().await?,
+        Amount::ZERO,
+        "A freshly created wallet should have no funds",
+    );
+
+    // Construction fails before approval is ever requested, so this must not run.
+    let approval_callback: ApprovalCallback = Arc::new(|_txid, _amount, _fee| {
+        async {
+            panic!("approval callback must not run when construction fails");
+            #[allow(unreachable_code)]
+            false
+        }
+        .boxed()
+    });
+
+    let address = wallet.main_address().await?;
+
+    let error = match wallet
+        .transfer_with_approval(&address, Some(Amount::ONE_XMR), approval_callback)
+        .await
+    {
+        Ok(_) => panic!("Transferring from an empty wallet must fail"),
+        Err(error) => error,
+    };
+
+    let message = format!("{error:#}");
+    tracing::info!(%message, "Got the transfer error");
+
+    assert!(
+        message.contains("not enough money"),
+        "Expected the real wallet2 construction error, got: {message}",
+    );
+    assert!(
+        !message.contains("Expected 1 txid"),
+        "The txid-count symptom masked the real error: {message}",
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
When wallet2 can't build a transaction it doesn't return null — it hands back a non-null PendingTransaction with the real reason stashed in its status ("not enough money to transfer…" and friends). We only checked for null, so on failure we'd carry on and later trip over the empty txid list, reporting "Expected 1 txid, got 0" instead of the actual cause. That's what was behind the confusing "Failed to lock Monero" errors.

The fix checks the pending transaction's own status right after creation, in both the multi-dest and sweep paths (single-dest goes through multi-dest), so the genuine error propagates instead of the txid-count symptom.

There's also an integration test that spins up an empty stagenet wallet and tries to send from it, which makes wallet2 throw not_enough_money. It asserts we get the real message and not the txid one — and I checked it fails the old way when the new status check is removed.