### PR TITLE
chore: re-add electrum.eigenwallet.org as default Electrum server

### DIFF
--- a/src-gui/src/store/defaults.ts
+++ b/src-gui/src/store/defaults.ts
@@ -21,7 +21,6 @@ export const NEGATIVE_NODES_MAINNET = [
   "tcp://electrum.coinucopia.io:50001",
   "tcp://se-mma-crypto-payments-001.mullvad.net:50001",
   "tcp://electrum2.bluewallet.io:50777",
-  "tcp://electrum.eigenwallet.org:22293",
 ];
 
 export const NEGATIVE_NODES_TESTNET = [
@@ -50,6 +49,7 @@ export const DEFAULT_NODES: Record<Network, Record<Blockchain, string[]>> = {
   },
   [Network.Mainnet]: {
     [Blockchain.Bitcoin]: [
+      "tcp://electrum.eigenwallet.org:22293",
       "ssl://electrum.blockstream.info:50002",
       "ssl://bitcoin.stackwallet.com:50002",
       "ssl://b.1209k.com:50002",

--- a/swap-env/src/defaults.rs
+++ b/swap-env/src/defaults.rs
@@ -58,6 +58,8 @@ pub fn default_rendezvous_points() -> Vec<Multiaddr> {
 
 pub fn default_electrum_servers_mainnet() -> Vec<Url> {
     vec![
+        Url::parse("tcp://electrum.eigenwallet.org:22293")
+            .expect("default electrum server url to be valid"),
         Url::parse("ssl://electrum.blockstream.info:50002")
             .expect("default electrum server url to be valid"),
         Url::parse("ssl://bitcoin.stackwallet.com:50002")


### PR DESCRIPTION
Re-adds `tcp://electrum.eigenwallet.org:22293` to the mainnet default Electrum server lists (`swap-env/src/defaults.rs` and `src-gui/src/store/defaults.ts`) and removes it from `NEGATIVE_NODES_MAINNET` so it's no longer stripped from user configs. Effectively reverts the mainnet portion of #979.