### PR TITLE
feat(orchestrator): support GH_TOKEN for private build-context repos

### DIFF
--- a/swap-orchestrator/README.md
+++ b/swap-orchestrator/README.md
@@ -42,6 +42,8 @@ Run the command below to start the wizard. It’ll guide you through a bunch of 
 
 To also ship the `asb` tracing logs and the `bitcoind`/`monerod`/`electrs` container logs to a Loki endpoint, set `PROMTAIL_LOKI_PUSH_URL`, `PROMTAIL_LOKI_PUSH_TOKEN`, and `PROMTAIL_INSTANCE` before running the orchestrator — this adds `promtail` and `docker-socket-proxy` services to the generated `docker-compose.yml`. All streams are labelled with `host=<instance>`; the daemon logs additionally carry `job=node` and `container=<name>`.
 
+If the `asb`/`asb-controller`/`rendezvous-node` images are built from a **private** GitHub repository, set `GH_TOKEN` to a token with read access before running the orchestrator. The token is inlined into the build-context URL in the generated `docker-compose.yml` so `docker compose build` can clone the repository. Treat the generated `docker-compose.yml` as a secret in this case.
+
 ```bash
 ./orchestrator
 ```

--- a/swap-orchestrator/README.md
+++ b/swap-orchestrator/README.md
@@ -42,7 +42,7 @@ Run the command below to start the wizard. It’ll guide you through a bunch of 
 
 To also ship the `asb` tracing logs and the `bitcoind`/`monerod`/`electrs` container logs to a Loki endpoint, set `PROMTAIL_LOKI_PUSH_URL`, `PROMTAIL_LOKI_PUSH_TOKEN`, and `PROMTAIL_INSTANCE` before running the orchestrator — this adds `promtail` and `docker-socket-proxy` services to the generated `docker-compose.yml`. All streams are labelled with `host=<instance>`; the daemon logs additionally carry `job=node` and `container=<name>`.
 
-If the `asb`/`asb-controller`/`rendezvous-node` images are built from a **private** GitHub repository, set `GH_TOKEN` to a token with read access before running the orchestrator. The token is inlined into the build-context URL in the generated `docker-compose.yml` so `docker compose build` can clone the repository. Treat the generated `docker-compose.yml` as a secret in this case.
+If the `asb`/`asb-controller`/`rendezvous-node` images are built from a **private** GitHub repository, set `GH_TOKEN` to a token with read access before running the orchestrator. The token is inlined into the build-context URL in the generated `docker-compose.yml` so `docker compose build` can clone the repository.
 
 ```bash
 ./orchestrator

--- a/swap-orchestrator/src/compose.rs
+++ b/swap-orchestrator/src/compose.rs
@@ -158,8 +158,9 @@ impl OrchestratorDirectories {
 /// See: https://docs.docker.com/reference/compose-file/build/#illustrative-example
 #[derive(Debug, Clone)]
 pub struct DockerBuildInput {
-    // Usually this is the root of the Cargo workspace
-    pub context: &'static str,
+    // Usually this is the root of the Cargo workspace. May embed a token in the
+    // URL userinfo when building from a private repository.
+    pub context: String,
     // Usually this is the path to the Dockerfile
     pub dockerfile: &'static str,
 }

--- a/swap-orchestrator/src/compose.rs
+++ b/swap-orchestrator/src/compose.rs
@@ -158,8 +158,7 @@ impl OrchestratorDirectories {
 /// See: https://docs.docker.com/reference/compose-file/build/#illustrative-example
 #[derive(Debug, Clone)]
 pub struct DockerBuildInput {
-    // Usually this is the root of the Cargo workspace. May embed a token in the
-    // URL userinfo when building from a private repository.
+    // Root of the Cargo workspace; may embed a token in the URL userinfo for a private repo.
     pub context: String,
     // Usually this is the path to the Dockerfile
     pub dockerfile: &'static str,

--- a/swap-orchestrator/src/images.rs
+++ b/swap-orchestrator/src/images.rs
@@ -41,11 +41,9 @@ pub static PROMTAIL_IMAGE: &str = "grafana/promtail@sha256:8b2aa61745bc4a9343cc4
 /// docker-socket-proxy 0.3.0 (https://hub.docker.com/r/tecnativa/docker-socket-proxy)
 pub static DOCKER_SOCKET_PROXY_IMAGE: &str = "tecnativa/docker-socket-proxy@sha256:9e4b9e7517a6b660f2cc903a19b257b1852d5b3344794e3ea334ff00ae677ac2";
 
-/// Build-context URL for the images built from source.
-///
-/// When `gh_token` is `Some`, the token is inlined as the URL userinfo so
-/// `docker compose build` can clone a private repository. This means the
-/// token is written into the generated `docker-compose.yml` in plaintext.
+/// Build-context URL for the source-built images. A `gh_token` is inlined into
+/// the URL userinfo so Docker can fetch a private repository — note this writes
+/// the token into `docker-compose.yml` in plaintext.
 pub fn source_build_context(gh_token: Option<&str>) -> String {
     match gh_token {
         Some(token) => PINNED_GIT_REPOSITORY.replacen("https://", &format!("https://{token}@"), 1),
@@ -53,13 +51,10 @@ pub fn source_build_context(gh_token: Option<&str>) -> String {
     }
 }
 
-/// These are built from source. The `context` is the (optionally
-/// authenticated) git URL from [`source_build_context`], pointing at the root
-/// of the Cargo workspace.
+/// Source-built images; `context` comes from [`source_build_context`].
 pub fn asb_image_from_source(context: &str) -> DockerBuildInput {
     DockerBuildInput {
         context: context.to_string(),
-        // The Dockerfile of the asb is in the swap-asb crate
         dockerfile: "./swap-asb/Dockerfile",
     }
 }
@@ -67,7 +62,6 @@ pub fn asb_image_from_source(context: &str) -> DockerBuildInput {
 pub fn asb_controller_image_from_source(context: &str) -> DockerBuildInput {
     DockerBuildInput {
         context: context.to_string(),
-        // The Dockerfile of the asb-controller is in the swap-controller crate
         dockerfile: "./swap-controller/Dockerfile",
     }
 }
@@ -75,7 +69,6 @@ pub fn asb_controller_image_from_source(context: &str) -> DockerBuildInput {
 pub fn rendezvous_node_image_from_source(context: &str) -> DockerBuildInput {
     DockerBuildInput {
         context: context.to_string(),
-        // The Dockerfile of the rendezvous node is in the libp2p-rendezvous-node crate
         dockerfile: "./libp2p-rendezvous-node/Dockerfile",
     }
 }

--- a/swap-orchestrator/src/images.rs
+++ b/swap-orchestrator/src/images.rs
@@ -41,24 +41,41 @@ pub static PROMTAIL_IMAGE: &str = "grafana/promtail@sha256:8b2aa61745bc4a9343cc4
 /// docker-socket-proxy 0.3.0 (https://hub.docker.com/r/tecnativa/docker-socket-proxy)
 pub static DOCKER_SOCKET_PROXY_IMAGE: &str = "tecnativa/docker-socket-proxy@sha256:9e4b9e7517a6b660f2cc903a19b257b1852d5b3344794e3ea334ff00ae677ac2";
 
-/// These are built from source
-pub static ASB_IMAGE_FROM_SOURCE: DockerBuildInput = DockerBuildInput {
-    // The context is the root of the Cargo workspace
-    context: PINNED_GIT_REPOSITORY,
-    // The Dockerfile of the asb is in the swap-asb crate
-    dockerfile: "./swap-asb/Dockerfile",
-};
+/// Build-context URL for the images built from source.
+///
+/// When `gh_token` is `Some`, the token is inlined as the URL userinfo so
+/// `docker compose build` can clone a private repository. This means the
+/// token is written into the generated `docker-compose.yml` in plaintext.
+pub fn source_build_context(gh_token: Option<&str>) -> String {
+    match gh_token {
+        Some(token) => PINNED_GIT_REPOSITORY.replacen("https://", &format!("https://{token}@"), 1),
+        None => PINNED_GIT_REPOSITORY.to_string(),
+    }
+}
 
-pub static ASB_CONTROLLER_IMAGE_FROM_SOURCE: DockerBuildInput = DockerBuildInput {
-    // The context is the root of the Cargo workspace
-    context: PINNED_GIT_REPOSITORY,
-    // The Dockerfile of the asb-controller is in the swap-controller crate
-    dockerfile: "./swap-controller/Dockerfile",
-};
+/// These are built from source. The `context` is the (optionally
+/// authenticated) git URL from [`source_build_context`], pointing at the root
+/// of the Cargo workspace.
+pub fn asb_image_from_source(context: &str) -> DockerBuildInput {
+    DockerBuildInput {
+        context: context.to_string(),
+        // The Dockerfile of the asb is in the swap-asb crate
+        dockerfile: "./swap-asb/Dockerfile",
+    }
+}
 
-pub static RENDEZVOUS_NODE_IMAGE_FROM_SOURCE: DockerBuildInput = DockerBuildInput {
-    // The context is the root of the Cargo workspace
-    context: PINNED_GIT_REPOSITORY,
-    // The Dockerfile of the rendezvous node is in the libp2p-rendezvous-node crate
-    dockerfile: "./libp2p-rendezvous-node/Dockerfile",
-};
+pub fn asb_controller_image_from_source(context: &str) -> DockerBuildInput {
+    DockerBuildInput {
+        context: context.to_string(),
+        // The Dockerfile of the asb-controller is in the swap-controller crate
+        dockerfile: "./swap-controller/Dockerfile",
+    }
+}
+
+pub fn rendezvous_node_image_from_source(context: &str) -> DockerBuildInput {
+    DockerBuildInput {
+        context: context.to_string(),
+        // The Dockerfile of the rendezvous node is in the libp2p-rendezvous-node crate
+        dockerfile: "./libp2p-rendezvous-node/Dockerfile",
+    }
+}

--- a/swap-orchestrator/src/main.rs
+++ b/swap-orchestrator/src/main.rs
@@ -141,11 +141,8 @@ fn read_promtail_config_from_env() -> Option<PromtailConfig> {
     })
 }
 
-/// Reads the GitHub token used to clone the build-context repository.
-///
-/// Returns `None` if `GH_TOKEN` is unset or empty. When set, the token is
-/// inlined into the source-build context URL so `docker compose build` can
-/// clone a private repository — see [`images::source_build_context`].
+/// `GH_TOKEN` for fetching a private build-context repository; `None` if unset
+/// or empty. See [`images::source_build_context`].
 fn read_gh_token_from_env() -> Option<String> {
     let token = std::env::var("GH_TOKEN").ok()?;
     let token = token.trim();
@@ -162,8 +159,7 @@ fn main() {
     // Promtail log shipping is opt-in via env vars; same rationale as the
     // Cloudflare integration above.
     let promtail_config = read_promtail_config_from_env();
-    // GH_TOKEN is opt-in: when set, it is inlined into the source-build
-    // context URL so a private repository can be cloned at build time.
+    // Opt-in: inlined into the build-context URL so Docker can fetch a private repo.
     let gh_token = read_gh_token_from_env();
     let source_build_context = images::source_build_context(gh_token.as_deref());
 
@@ -403,14 +399,6 @@ fn main() {
 
     println!();
     println!("Run `docker compose up -d` to start the services.");
-
-    if gh_token.is_some() {
-        println!();
-        println!(
-            "GH_TOKEN detected: inlined into the build-context URL in {} so Docker can clone the private repository. Keep this file secret.",
-            DOCKER_COMPOSE_FILE
-        );
-    }
 
     if let Some(cf) = cloudflared_config.as_ref() {
         print_cloudflared_instructions(cf);

--- a/swap-orchestrator/src/main.rs
+++ b/swap-orchestrator/src/main.rs
@@ -141,6 +141,20 @@ fn read_promtail_config_from_env() -> Option<PromtailConfig> {
     })
 }
 
+/// Reads the GitHub token used to clone the build-context repository.
+///
+/// Returns `None` if `GH_TOKEN` is unset or empty. When set, the token is
+/// inlined into the source-build context URL so `docker compose build` can
+/// clone a private repository — see [`images::source_build_context`].
+fn read_gh_token_from_env() -> Option<String> {
+    let token = std::env::var("GH_TOKEN").ok()?;
+    let token = token.trim();
+    if token.is_empty() {
+        return None;
+    }
+    Some(token.to_string())
+}
+
 fn main() {
     // Cloudflare Tunnel is opt-in via env vars so existing deployments
     // keep working unchanged.
@@ -148,6 +162,10 @@ fn main() {
     // Promtail log shipping is opt-in via env vars; same rationale as the
     // Cloudflare integration above.
     let promtail_config = read_promtail_config_from_env();
+    // GH_TOKEN is opt-in: when set, it is inlined into the source-build
+    // context URL so a private repository can be cloned at build time.
+    let gh_token = read_gh_token_from_env();
+    let source_build_context = images::source_build_context(gh_token.as_deref());
 
     let want_tor = prompt::tor_for_daemons();
     let (bitcoin_network, monero_network) = prompt::network();
@@ -180,17 +198,17 @@ fn main() {
             bitcoind: OrchestratorImage::Registry(images::BITCOIND_IMAGE.to_string()),
             tor: OrchestratorImage::Registry(images::TOR_IMAGE.to_string()),
             // TODO: Allow pre-built images here
-            asb: OrchestratorImage::Build(images::ASB_IMAGE_FROM_SOURCE.clone()),
+            asb: OrchestratorImage::Build(images::asb_image_from_source(&source_build_context)),
             // TODO: Allow pre-built images here
-            asb_controller: OrchestratorImage::Build(
-                images::ASB_CONTROLLER_IMAGE_FROM_SOURCE.clone(),
-            ),
+            asb_controller: OrchestratorImage::Build(images::asb_controller_image_from_source(
+                &source_build_context,
+            )),
             asb_tracing_logger: OrchestratorImage::Registry(
                 images::ASB_TRACING_LOGGER_IMAGE.to_string(),
             ),
-            rendezvous_node: OrchestratorImage::Build(
-                images::RENDEZVOUS_NODE_IMAGE_FROM_SOURCE.clone(),
-            ),
+            rendezvous_node: OrchestratorImage::Build(images::rendezvous_node_image_from_source(
+                &source_build_context,
+            )),
             cloudflared: OrchestratorImage::Registry(images::CLOUDFLARED_IMAGE.to_string()),
             promtail: OrchestratorImage::Registry(images::PROMTAIL_IMAGE.to_string()),
             docker_socket_proxy: OrchestratorImage::Registry(
@@ -385,6 +403,14 @@ fn main() {
 
     println!();
     println!("Run `docker compose up -d` to start the services.");
+
+    if gh_token.is_some() {
+        println!();
+        println!(
+            "GH_TOKEN detected: inlined into the build-context URL in {} so Docker can clone the private repository. Keep this file secret.",
+            DOCKER_COMPOSE_FILE
+        );
+    }
 
     if let Some(cf) = cloudflared_config.as_ref() {
         print_cloudflared_instructions(cf);

--- a/swap-orchestrator/tests/spec.rs
+++ b/swap-orchestrator/tests/spec.rs
@@ -33,9 +33,9 @@ fn make_input(
             electrs: OrchestratorImage::Registry(images::ELECTRS_IMAGE.to_string()),
             bitcoind: OrchestratorImage::Registry(images::BITCOIND_IMAGE.to_string()),
             tor: OrchestratorImage::Registry(images::TOR_IMAGE.to_string()),
-            rendezvous_node: OrchestratorImage::Build(
-                images::rendezvous_node_image_from_source(&source_build_context),
-            ),
+            rendezvous_node: OrchestratorImage::Build(images::rendezvous_node_image_from_source(
+                &source_build_context,
+            )),
             asb: OrchestratorImage::Build(images::asb_image_from_source(&source_build_context)),
             asb_controller: OrchestratorImage::Build(images::asb_controller_image_from_source(
                 &source_build_context,

--- a/swap-orchestrator/tests/spec.rs
+++ b/swap-orchestrator/tests/spec.rs
@@ -12,6 +12,7 @@ fn make_input(
     cloudflared: Option<CloudflaredConfig>,
     promtail: Option<PromtailConfig>,
 ) -> OrchestratorInput {
+    let source_build_context = images::source_build_context(None);
     OrchestratorInput {
         ports: OrchestratorPorts {
             monerod_rpc: 38081,
@@ -33,12 +34,12 @@ fn make_input(
             bitcoind: OrchestratorImage::Registry(images::BITCOIND_IMAGE.to_string()),
             tor: OrchestratorImage::Registry(images::TOR_IMAGE.to_string()),
             rendezvous_node: OrchestratorImage::Build(
-                images::RENDEZVOUS_NODE_IMAGE_FROM_SOURCE.clone(),
+                images::rendezvous_node_image_from_source(&source_build_context),
             ),
-            asb: OrchestratorImage::Build(images::ASB_IMAGE_FROM_SOURCE.clone()),
-            asb_controller: OrchestratorImage::Build(
-                images::ASB_CONTROLLER_IMAGE_FROM_SOURCE.clone(),
-            ),
+            asb: OrchestratorImage::Build(images::asb_image_from_source(&source_build_context)),
+            asb_controller: OrchestratorImage::Build(images::asb_controller_image_from_source(
+                &source_build_context,
+            )),
             asb_tracing_logger: OrchestratorImage::Registry(
                 images::ASB_TRACING_LOGGER_IMAGE.to_string(),
             ),
@@ -95,6 +96,31 @@ fn test_orchestrator_spec_generation() {
         Some(sample_promtail_config()),
     )
     .to_spec();
+}
+
+#[test]
+fn test_gh_token_inlined_into_build_context() {
+    let context = images::source_build_context(Some("ghp_exampletoken"));
+    assert!(context.starts_with("https://ghp_exampletoken@github.com/"));
+
+    // A spec built from the authenticated context must still validate, and the
+    // token must reach the build attribute of every source-built service.
+    let mut input = make_input(false, None, None);
+    input.images.asb = OrchestratorImage::Build(images::asb_image_from_source(&context));
+    input.images.asb_controller =
+        OrchestratorImage::Build(images::asb_controller_image_from_source(&context));
+    input.images.rendezvous_node =
+        OrchestratorImage::Build(images::rendezvous_node_image_from_source(&context));
+
+    let compose = input.to_spec();
+    assert_eq!(compose.matches("ghp_exampletoken@github.com").count(), 3);
+}
+
+#[test]
+fn test_source_build_context_without_token_is_clean() {
+    let context = images::source_build_context(None);
+    assert!(context.starts_with("https://github.com/"));
+    assert!(!context.contains('@'));
 }
 
 #[test]


### PR DESCRIPTION
Adds opt-in `GH_TOKEN` support: when set, the token is inlined into the source-built images' git build-context URL so `docker compose build` can fetch a private repository. No effect when unset.