### PR TITLE
feat(ASB): refuse to grant cooperative XMR redeem for malicious swaps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
-target/
-target-check/
+target
+target-check
 
 .vscode
 .claude/settings.local.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- ASB: The ASB will refuse to cooperate with cooperative XMR redeem requests if the swap in question was deemed malicious. A swap is considered malicious if the fee of TxCancel is more than 25% of the swap's total Bitcoin amount.
+
 ## [4.7.8] - 2026-05-28
 
 ## [4.6.7] - 2026-05-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- ASB: The ASB will refuse to cooperate with cooperative XMR redeem requests if the swap in question was deemed malicious. A swap is considered malicious if the fee of TxCancel is more than 25% of the swap's total Bitcoin amount.
+- ASB: The ASB will refuse to cooperate with cooperative XMR redeem requests if the swap in question was deemed malicious. A swap is considered malicious if for any reason the Bitcoin amount the ASB receives is less than 75% of what was sent into the swap originally.
 
 ## [4.7.8] - 2026-05-28
 

--- a/swap-core/src/bitcoin/punish.rs
+++ b/swap-core/src/bitcoin/punish.rs
@@ -99,6 +99,14 @@ impl TxPunish {
         Ok(tx_punish)
     }
 
+    // The amount of BTC sent to the punish address.
+    pub fn amount(&self) -> Amount {
+        self.inner
+            .tx_out(0)
+            .expect("TxPunish has exactly one output by construction")
+            .value
+    }
+
     pub fn weight() -> Weight {
         Weight::from_wu(548)
     }

--- a/swap-core/src/bitcoin/redeem.rs
+++ b/swap-core/src/bitcoin/redeem.rs
@@ -151,6 +151,14 @@ impl TxRedeem {
         Weight::from_wu(548)
     }
 
+    // The amount of BTC sent to the redeem address.
+    pub fn amount(&self) -> Amount {
+        self.inner
+            .tx_out(0)
+            .expect("TxRedeem has exactly one output by construction")
+            .value
+    }
+
     #[cfg(test)]
     pub fn inner(&self) -> Transaction {
         self.inner.clone()

--- a/swap-machine/src/alice/mod.rs
+++ b/swap-machine/src/alice/mod.rs
@@ -1130,6 +1130,24 @@ impl State3 {
             "Bitcoin refund transaction not found even though we saw it in the mempool previously",
         )
     }
+
+    // Check if the maximum possible BTC loss is < 1 / max_loss_part of the swap volume
+    pub fn check_max_loss_under_tolerance(&self, max_loss_part: u64) -> Result<bool> {
+        let max_tolerated_loss = bitcoin::Amount::from_sat(
+            self.btc
+                .to_sat()
+                .checked_div(max_loss_part)
+                .context("MAX_LOSS_PART is 0")?,
+        );
+
+        let final_btc = bitcoin::Amount::min(self.tx_redeem().amount(), self.tx_punish().amount());
+        let lost_btc = self
+            .btc
+            .checked_sub(final_btc)
+            .context("final BTC output is larger than total Bitcoin amount")?;
+
+        Ok(lost_btc <= max_tolerated_loss)
+    }
 }
 
 pub trait ReservesMonero {

--- a/swap/src/asb/event_loop.rs
+++ b/swap/src/asb/event_loop.rs
@@ -860,22 +860,29 @@ where
         };
 
         // === Background ===
-        // On 2026-05-25 an attacker managed to maliciously increase the fee
-        // on TxCancel to very high levels. As a result, a large part of the swap
-        // was lost to network fees. We will deny cooperative redeem in these
-        // cases.
+        // On 2026-05-25 an attacker managed to maliciously increase the fees
+        // in a way that causes Alice to get significantly less BTC.
         // ==================
 
-        // Interpret a fee of more than 1 / MAX_CANCEL_FEE_PART
+        // Interpret a loss of more than 1 / MAX_CANCEL_FEE_PART
         // of the swap amount to be maliciously high.
-        const MAX_CANCEL_FEE_PART: u64 = 4;
-        let max_tolerated_fee = state3
-            .btc
-            .to_sat()
-            .checked_div(MAX_CANCEL_FEE_PART)
-            .context("MAX_CANCEL_FEE_PART is 0")?;
+        const MAX_LOSS_PART: u64 = 4;
+        let max_tolerated_loss = bitcoin::Amount::from_sat(
+            state3
+                .btc
+                .to_sat()
+                .checked_div(MAX_LOSS_PART)
+                .context("MAX_CANCEL_FEE_PART is 0")?,
+        );
 
-        if state3.tx_cancel_fee.to_sat() > max_tolerated_fee {
+        let final_btc =
+            bitcoin::Amount::min(state3.tx_redeem().amount(), state3.tx_punish().amount());
+        let lost_btc = state3
+            .btc
+            .checked_sub(final_btc)
+            .context("final BTC output is larger than total Bitcoin amount")?;
+
+        if lost_btc > max_tolerated_loss {
             tracing::info!(
                 swap_id = %swap_id,
                 reason = "malicious swap",
@@ -895,7 +902,7 @@ where
                     anyhow!("Failed to send rejection for cooperative Monero redeem request")
                 })?;
             bail!(
-                "Malicious swap detected (TxCancel network fee > 1/{MAX_CANCEL_FEE_PART} of swap amount)"
+                "Malicious swap detected (swap lost us more than 1/{MAX_LOSS_PART} of swap amount)"
             )
         }
 

--- a/swap/src/asb/event_loop.rs
+++ b/swap/src/asb/event_loop.rs
@@ -867,22 +867,8 @@ where
         // Interpret a loss of more than 1 / MAX_CANCEL_FEE_PART
         // of the swap amount to be maliciously high.
         const MAX_LOSS_PART: u64 = 4;
-        let max_tolerated_loss = bitcoin::Amount::from_sat(
-            state3
-                .btc
-                .to_sat()
-                .checked_div(MAX_LOSS_PART)
-                .context("MAX_CANCEL_FEE_PART is 0")?,
-        );
 
-        let final_btc =
-            bitcoin::Amount::min(state3.tx_redeem().amount(), state3.tx_punish().amount());
-        let lost_btc = state3
-            .btc
-            .checked_sub(final_btc)
-            .context("final BTC output is larger than total Bitcoin amount")?;
-
-        if lost_btc > max_tolerated_loss {
+        if state3.check_max_loss_under_tolerance(MAX_LOSS_PART)? == false {
             tracing::info!(
                 swap_id = %swap_id,
                 reason = "malicious swap",

--- a/swap/src/asb/event_loop.rs
+++ b/swap/src/asb/event_loop.rs
@@ -859,6 +859,46 @@ where
             bail!("swap in invalid state")
         };
 
+        // === Background ===
+        // On 2026-05-25 an attacker managed to maliciously increase the fee
+        // on TxCancel to very high levels. As a result, a large part of the swap
+        // was lost to network fees. We will deny cooperative redeem in these
+        // cases.
+        // ==================
+
+        // Interpret a fee of more than 1 / MAX_CANCEL_FEE_PART
+        // of the swap amount to be maliciously high.
+        const MAX_CANCEL_FEE_PART: u64 = 4;
+        let max_tolerated_fee = state3
+            .btc
+            .to_sat()
+            .checked_div(MAX_CANCEL_FEE_PART)
+            .context("MAX_CANCEL_FEE_PART is 0")?;
+
+        if state3.tx_cancel_fee.to_sat() > max_tolerated_fee {
+            tracing::info!(
+                swap_id = %swap_id,
+                reason = "malicious swap",
+                "Rejecting cooperative Monero redeem request"
+            );
+            self.swarm
+                .behaviour_mut()
+                .cooperative_xmr_redeem
+                .send_response(
+                    channel,
+                    Rejected {
+                        swap_id,
+                        reason: CooperativeXmrRedeemRejectReason::MaliciousRequest,
+                    },
+                )
+                .map_err(|_| {
+                    anyhow!("Failed to send rejection for cooperative Monero redeem request")
+                })?;
+            bail!(
+                "Malicious swap detected (TxCancel network fee > 1/{MAX_CANCEL_FEE_PART} of swap amount)"
+            )
+        }
+
         self.swarm
             .behaviour_mut()
             .cooperative_xmr_redeem

--- a/swap/tests/alice_refuses_cooperative_redeem_for_malicious_swap.rs
+++ b/swap/tests/alice_refuses_cooperative_redeem_for_malicious_swap.rs
@@ -1,0 +1,65 @@
+pub mod harness;
+
+use harness::FastPunishConfig;
+use harness::bob_run_until::is_btc_locked;
+use swap::asb::FixedRate;
+use swap::network::cooperative_xmr_redeem_after_punish::CooperativeXmrRedeemRejectReason;
+use swap::protocol::alice::AliceState;
+use swap::protocol::bob::BobState;
+use swap::protocol::{alice, bob};
+
+/// Bob locks BTC, Alice locks XMR, Bob goes dark, Alice punishes. We then tamper
+/// with Alice's persisted state so the swap looks malicious (abnormally high
+/// TxCancel fee -> large BTC loss). When the punished Bob asks Alice to
+/// cooperatively redeem the XMR, Alice must refuse with `MaliciousRequest`.
+#[tokio::test]
+async fn alice_refuses_cooperative_redeem_for_malicious_swap() {
+    harness::setup_test(FastPunishConfig, None, None, |mut ctx| async move {
+        let (bob_swap, bob_join_handle) = ctx.bob_swap().await;
+        let bob_swap_id = bob_swap.id;
+        let bob_swap = tokio::spawn(bob::run_until(bob_swap, is_btc_locked));
+
+        let alice_swap = ctx.alice_next_swap().await;
+        let alice_swap = tokio::spawn(alice::run(alice_swap, FixedRate::default()));
+
+        let bob_state = bob_swap.await??;
+        assert!(matches!(bob_state, BobState::BtcLocked { .. }));
+
+        let alice_state = alice_swap.await??;
+        ctx.assert_alice_punished(alice_state).await;
+
+        // Make the swap look malicious from Alice's side: an abnormally high
+        // TxCancel fee (half the swap). Because TxPunish spends TxCancel's output,
+        // this trips Alice's holistic loss check (lost_btc > btc / 4).
+        ctx.corrupt_alice_state(bob_swap_id, |state| {
+            let AliceState::BtcPunished { state3, .. } = state else {
+                panic!("expected Alice in BtcPunished, was {state:?}");
+            };
+            state3.tx_cancel_fee = bitcoin::Amount::from_sat(state3.btc.to_sat() / 2);
+        })
+        .await;
+
+        // Resume Bob: he detects the punishment, moves to BtcPunished, and asks
+        // Alice to cooperatively redeem the XMR.
+        let (bob_swap, _) = ctx
+            .stop_and_resume_bob_from_db(bob_join_handle, bob_swap_id)
+            .await;
+        assert!(matches!(bob_swap.state, BobState::BtcLocked { .. }));
+
+        // Alice refuses -> bob::run errors out carrying the rejection reason.
+        let error = bob::run(bob_swap)
+            .await
+            .expect_err("Bob's cooperative redeem must be refused for a malicious swap");
+
+        let reason = error
+            .downcast_ref::<CooperativeXmrRedeemRejectReason>()
+            .expect("error should carry the cooperative-redeem rejection reason");
+        assert!(
+            matches!(reason, CooperativeXmrRedeemRejectReason::MaliciousRequest),
+            "expected MaliciousRequest, got: {reason:?}"
+        );
+
+        Ok(())
+    })
+    .await;
+}

--- a/swap/tests/harness/mod.rs
+++ b/swap/tests/harness/mod.rs
@@ -26,7 +26,7 @@ use swap::network::rendezvous::XmrBtcNamespace;
 use swap::network::swarm;
 use swap::protocol::alice::{AliceState, Swap, TipConfig};
 use swap::protocol::bob::BobState;
-use swap::protocol::{Database, alice, bob};
+use swap::protocol::{Database, State, alice, bob};
 use swap::seed::Seed;
 use swap::{asb, cli, monero};
 use swap_core::bitcoin::{CancelTimelock, PunishTimelock};
@@ -861,6 +861,32 @@ impl TestContext {
         self.alice_handle = alice_handle;
         self.alice_swap_handle = alice_swap_handle;
         self.alice_rpc_server_handle = alice_rpc_server_handle;
+    }
+
+    /// Stops Alice, mutates her persisted state for `swap_id`, writes it back, and
+    /// restarts her. Used to simulate a corrupted/malicious swap from Alice's point of view.
+    pub async fn corrupt_alice_state(&mut self, swap_id: Uuid, modify: impl FnOnce(&mut AliceState)) {
+        // Stop Alice so we have exclusive access to her database.
+        self.alice_handle.abort();
+        self.alice_rpc_server_handle.abort();
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        // Load the latest state, apply the mutation, and persist it again.
+        {
+            let db = SqliteDatabase::open(self.alice_db_path.as_path(), AccessMode::ReadWrite)
+                .await
+                .unwrap();
+            let State::Alice(mut alice_state) = db.get_state(swap_id).await.unwrap() else {
+                panic!("expected an Alice state for swap {swap_id}");
+            };
+            modify(&mut alice_state);
+            db.insert_latest_state(swap_id, State::Alice(alice_state))
+                .await
+                .unwrap();
+        }
+
+        // Bring Alice back up so she can answer Bob's cooperative-redeem request.
+        self.restart_alice().await;
     }
 
     pub async fn alice_next_swap(&mut self) -> alice::Swap {


### PR DESCRIPTION
Deny cooperative XMR redeem for swaps where the taker maliciously increased the TxCancel fee to more than 1/4 of the swap amount. 