### PR TITLE
fix(gui): null version

### DIFF
--- a/src-gui/src/utils/multiAddrUtils.ts
+++ b/src-gui/src/utils/multiAddrUtils.ts
@@ -17,8 +17,8 @@ export function isMakerOnCorrectNetwork(
 }
 
 /** Check whether a maker version is old and might not support newer features. */
-export function isMakerVersionOld(version: string | undefined): boolean {
-  if (version === undefined) return false;
+export function isMakerVersionOld(version: string | null | undefined): boolean {
+  if (version == null) return false;
   // This checks if the version is less than the minimum version
   // we use .compare(...) instead of .satisfies(...) because satisfies(...)
   // does not work with pre-release versions
@@ -26,16 +26,16 @@ export function isMakerVersionOld(version: string | undefined): boolean {
 }
 
 /** Check whether a maker version is too old and is known to be completely incompatile. */
-export function isMakerVersionTooOld(version: string | undefined): boolean {
-  if (version === undefined) return false;
+export function isMakerVersionTooOld(version: string | null | undefined): boolean {
+  if (version == null) return false;
   return semver.compare(version, VERSION_FLOOR_HARD) === -1;
 }
 
 /** Check whether a maker is running at or above the GUI's bundled version. */
 export function isMakerVersionLatest(
-  version: string | undefined,
-  guiVersion: string | undefined,
+  version: string | null | undefined,
+  guiVersion: string | null | undefined,
 ): boolean {
-  if (version === undefined || guiVersion === undefined) return false;
+  if (version == null || guiVersion == null) return false;
   return semver.compare(version, guiVersion) >= 0;
 }


### PR DESCRIPTION
A maker with no advertised version arrives from the backend as JSON null (Rust Option<Version> serializing None), but typeshare types the field as version?: string, hiding the null at the type level. The guard functions in multiAddrUtils.ts only bailed on undefined, so a null version slipped through to semver.compare(null, ...), which throws "Invalid version. Must be a string. Got type object" (typeof null === "object"). Because this happens during render of the offer list, the exception propagated up and crashed the entire swap page into the error boundary.

This widens the three guard signatures to accept null and switches their checks to nullish so both null and undefined are rejected before reaching semver, which is the correct answer since a maker with no version has nothing to compare against.