### PR TITLE
fix(swap-orchestrator): disable cadvisor disk metrics (cadvisor#3860)

### DIFF
--- a/swap-orchestrator/src/compose.rs
+++ b/swap-orchestrator/src/compose.rs
@@ -408,6 +408,9 @@ fn build(input: OrchestratorInput) -> String {
     logging: *default-logging
     privileged: true
     cgroup: host
+    command:
+      # Workaround for cadvisor#3860
+      - '--disable_metrics=disk'
     devices:
       - /dev/kmsg:/dev/kmsg
     volumes:


### PR DESCRIPTION
Docker 29.x relocated image layer storage, which breaks cadvisor's path assumption and stalls container registration ([cadvisor#3860](https://github.com/google/cadvisor/issues/3860)). Pass `--disable_metrics=disk` to work around it; per-container CPU/memory/network metrics are unaffected and host disk usage is covered by node_exporter.