### PR TITLE
Fix: Mercy flow protocol loop termination

### DIFF
--- a/swap-machine/src/alice/mod.rs
+++ b/swap-machine/src/alice/mod.rs
@@ -170,7 +170,7 @@ pub fn is_complete(state: &AliceState) -> bool {
         | AliceState::BtcPunished { .. }
         | AliceState::SafelyAborted
         | AliceState::BtcEarlyRefunded(_)
-        | AliceState::BtcWithholdConfirmed { .. }
+        
         | AliceState::BtcMercyConfirmed { .. } => true,
         _ => false,
     }

--- a/swap/src/protocol/bob/swap.rs
+++ b/swap/src/protocol/bob/swap.rs
@@ -58,7 +58,7 @@ pub fn has_already_processed_transfer_proof(state: &BobState) -> bool {
 pub fn is_run_at_most_once(state: &BobState) -> bool {
     matches!(
         state,
-        BobState::BtcPunished { .. } | BobState::BtcWithheld(..)
+        BobState::BtcPunished { .. } 
     )
 }
 


### PR DESCRIPTION
This PR fixes issue #724 by preventing Alice and Bob from exiting the protocol loop prematurely when in the Withhold/Mercy states. 

- Removed BtcWithholdConfirmed as a terminal state for Alice, allowing her to process manual 'grant_mercy' commands.
- Removed BtcWithheld from is_run_at_most_once for Bob, ensuring he waits for Alice's TxMercy.

This should fix the broken unit tests mentioned in the issue.