### PR TITLE
feat(monero-oxide): lazy RPC client

### DIFF
--- a/monero-wallet/src/wallets.rs
+++ b/monero-wallet/src/wallets.rs
@@ -33,8 +33,8 @@ pub struct Wallets {
     wallet_dir: PathBuf,
     /// The network we're on.
     network: Network,
-    /// The monero node we connect to.
-    daemon: Arc<RwLock<(Daemon, MoneroDaemon<SimpleRequestTransport>)>>,
+    /// The monero node we connect to. The RPC client is connected lazily.
+    daemon: Arc<RwLock<(Daemon, Option<MoneroDaemon<SimpleRequestTransport>>)>>,
     /// Keep the main wallet open and synced.
     main_wallet: Arc<Wallet>,
     /// Since Network::Regtest isn't a thing we have to use an extra flag.
@@ -101,10 +101,7 @@ impl Wallets {
                 .context("Failed to install tauri wallet listener")?;
         }
 
-        let rpc_client = SimpleRequestTransport::new(daemon.to_url_string())
-            .await
-            .context("Failed to initialize rpc client")?;
-        let daemon = Arc::new(RwLock::new((daemon, rpc_client)));
+        let daemon = Arc::new(RwLock::new((daemon, None)));
 
         let wallets = Self {
             wallet_dir,
@@ -163,8 +160,7 @@ impl Wallets {
                 .await?;
         }
 
-        let rpc_client = SimpleRequestTransport::new(daemon.to_url_string()).await?;
-        let daemon = Arc::new(RwLock::new((daemon, rpc_client)));
+        let daemon = Arc::new(RwLock::new((daemon, None)));
 
         let wallets = Self {
             wallet_dir,
@@ -184,11 +180,8 @@ impl Wallets {
     }
 
     pub async fn change_monero_node(&self, new_daemon: Daemon) -> Result<()> {
-        {
-            let mut daemon = self.daemon.write().await;
-            let rpc_client = SimpleRequestTransport::new(new_daemon.to_url_string()).await?;
-            *daemon = (new_daemon.clone(), rpc_client);
-        }
+        // Reconnect lazily on next use.
+        *self.daemon.write().await = (new_daemon.clone(), None);
 
         self.main_wallet
             .call(move |wallet| wallet.set_daemon(&new_daemon))
@@ -286,15 +279,38 @@ impl Wallets {
 }
 
 impl Wallets {
-    /// Get a clone of the RPC client for direct daemon communication.
-    pub async fn rpc_client(&self) -> MoneroDaemon<SimpleRequestTransport> {
-        let (_daemon, rpc_client) = self.daemon.read().await.clone();
-        rpc_client
+    /// Get the RPC client for direct daemon communication, connecting lazily on
+    /// first use (and after a node change) so an unreachable node never blocks init.
+    pub async fn rpc_client(&self) -> Result<MoneroDaemon<SimpleRequestTransport>> {
+        if let Some(rpc_client) = &self.daemon.read().await.1 {
+            return Ok(rpc_client.clone());
+        }
+
+        let mut guard = self.daemon.write().await;
+        if let Some(rpc_client) = &guard.1 {
+            return Ok(rpc_client.clone());
+        }
+
+        let rpc_client = SimpleRequestTransport::new(guard.0.to_url_string())
+            .await
+            .context("Failed to connect to Monero daemon")?;
+        guard.1 = Some(rpc_client.clone());
+
+        Ok(rpc_client)
+    }
+
+    /// Check that the daemon RPC is reachable, connecting if necessary.
+    pub async fn rpc_health_check(&self) -> Result<()> {
+        self.direct_rpc_block_height()
+            .await
+            .context("Monero daemon RPC health check failed")?;
+
+        Ok(())
     }
 
     pub async fn direct_rpc_block_height(&self) -> Result<u64> {
         use monero_daemon_rpc::prelude::ProvidesBlockchainMeta;
-        let rpc_client = self.rpc_client().await;
+        let rpc_client = self.rpc_client().await?;
 
         let height = rpc_client
             .latest_block_number()
@@ -322,7 +338,7 @@ impl Wallets {
         view_key: PrivateViewKey,
         destinations: Vec<(monero_address::MoneroAddress, f64)>,
     ) -> Result<Transaction<NotPruned>> {
-        let rpc_client = self.rpc_client().await;
+        let rpc_client = self.rpc_client().await?;
         let tx_id = tx_hash_to_bytes(lock_tx_hash)?;
 
         let spend_scalar = Zeroizing::new(spend_key.scalar);
@@ -347,7 +363,7 @@ impl Wallets {
         view_key: PrivateViewKey,
         destination: monero_address::MoneroAddress,
     ) -> Result<Transaction<NotPruned>> {
-        let rpc_client = self.rpc_client().await;
+        let rpc_client = self.rpc_client().await?;
         let tx_id = tx_hash_to_bytes(lock_tx_hash)?;
 
         let spend_scalar = Zeroizing::new(spend_key.scalar);
@@ -375,7 +391,7 @@ impl Wallets {
         private_view_key: PrivateViewKey,
         expected_amount: Amount,
     ) -> Result<bool> {
-        let rpc_client = self.rpc_client().await;
+        let rpc_client = self.rpc_client().await?;
 
         let tx_id = tx_hash_to_bytes(tx_hash)?;
         let public_spend_key = public_spend_key.decompress();
@@ -410,7 +426,7 @@ impl Wallets {
     ) -> Result<()> {
         use monero_wallet_ng::confirmations;
 
-        let rpc_client = self.rpc_client().await;
+        let rpc_client = self.rpc_client().await?;
         let tx_id = tx_hash_to_bytes(tx_hash)?;
         let subscription = confirmations::subscribe(rpc_client, tx_id, POLL_INTERVAL);
 
@@ -456,7 +472,7 @@ impl Wallets {
     ) -> Result<TxHash> {
         use monero_wallet_ng::scanner;
 
-        let rpc_client = self.rpc_client().await;
+        let rpc_client = self.rpc_client().await?;
 
         let public_spend_key = public_spend_key.decompress();
         let private_view_key = Zeroizing::new(private_view_key.0.scalar);

--- a/src-gui/src/models/tauriModelExt.ts
+++ b/src-gui/src/models/tauriModelExt.ts
@@ -427,6 +427,7 @@ export function haveFundsBeenLocked(
 
   switch (event.type) {
     case "Resuming":
+    case "CheckingMoneroNodeConnectivity":
     case "ReceivedQuote":
     case "WaitingForBtcDeposit":
     case "SwapSetupInflight":

--- a/src-gui/src/renderer/components/modal/swap/SwapStateStepper.tsx
+++ b/src-gui/src/renderer/components/modal/swap/SwapStateStepper.tsx
@@ -207,6 +207,7 @@ function getActiveStep(state: SwapState | null): PathStep | null {
       ];
 
     case "Resuming":
+    case "CheckingMoneroNodeConnectivity":
       return null;
     default:
       return fallbackStep("No step is assigned to the current state");

--- a/src-gui/src/renderer/components/pages/swap/swap/SwapStatePage.tsx
+++ b/src-gui/src/renderer/components/pages/swap/swap/SwapStatePage.tsx
@@ -48,6 +48,10 @@ export default function SwapStatePage({ state }: { state: SwapState | null }) {
   switch (type) {
     case "Resuming":
       return <CircularProgressWithSubtitle description="Resuming swap..." />;
+    case "CheckingMoneroNodeConnectivity":
+      return (
+        <CircularProgressWithSubtitle description="Checking Monero node connectivity..." />
+      );
     case "ReceivedQuote":
       return <ReceivedQuotePage />;
     case "WaitingForBtcDeposit":

--- a/swap/src/asb/event_loop.rs
+++ b/swap/src/asb/event_loop.rs
@@ -663,6 +663,7 @@ where
         let db = self.db.clone();
         let monero_wallet = self.monero_wallet.clone();
         let monero_wallet_for_proof = self.monero_wallet.clone();
+        let monero_wallet_for_health = self.monero_wallet.clone();
         let peer_id = self.peer_id();
 
         async move {
@@ -701,17 +702,23 @@ where
                     .await
             };
 
-            let result = make_quote(
-                min_buy,
-                max_buy,
-                rate,
-                get_unlocked_balance,
-                get_reserved_items,
-                get_reserve_proof,
-                developer_tip,
-                refund_policy,
-            )
-            .await;
+            // Quote zero when the daemon RPC is unreachable.
+            let result = match monero_wallet_for_health.rpc_health_check().await {
+                Ok(()) => {
+                    make_quote(
+                        min_buy,
+                        max_buy,
+                        rate,
+                        get_unlocked_balance,
+                        get_reserved_items,
+                        get_reserve_proof,
+                        developer_tip,
+                        refund_policy,
+                    )
+                    .await
+                }
+                Err(err) => Err(Arc::new(err.context("Monero daemon RPC health check failed"))),
+            };
 
             // Insert the computed quote into the cache
             // Need to clone it as insert takes ownership
@@ -1291,6 +1298,12 @@ async fn capture_wallet_snapshot(
     transfer_amount: bitcoin::Amount,
 ) -> Result<WalletSnapshot> {
     let start_time = Instant::now();
+
+    // Don't back a swap setup against an unreachable daemon.
+    monero_wallet
+        .rpc_health_check()
+        .await
+        .context("Monero daemon RPC health check failed while capturing wallet snapshot")?;
 
     let unlocked_balance = monero_wallet.main_wallet().await.unlocked_balance().await?;
     let total_balance = monero_wallet.main_wallet().await.total_balance().await?;

--- a/swap/src/asb/recovery/refund.rs
+++ b/swap/src/asb/recovery/refund.rs
@@ -101,6 +101,7 @@ pub async fn refund(
             monero_wallet
                 .rpc_client()
                 .await
+                .map_err(backoff::Error::transient)?
                 .publish_transaction(&xmr_refund_tx)
                 .await
                 .context("Failed to publish Monero refund transaction")

--- a/swap/src/cli/api/request.rs
+++ b/swap/src/cli/api/request.rs
@@ -1098,78 +1098,100 @@ pub async fn buy_xmr(
     // because we need to be able to cancel the determine_btc_to_swap(..)
     context.swap_lock.acquire_swap_lock(swap_id).await?;
 
-    let select_offer_result = tokio::select! {
-        result = determine_btc_to_swap(
-            quotes_rx,
-            bitcoin_wallet.new_address(),
-            {
-                let wallet = Arc::clone(&bitcoin_wallet_for_closures);
-                move || {
-                    let w = wallet.clone();
-                    async move { w.balance().await }
-                }
-            },
-            {
-                let wallet = Arc::clone(&bitcoin_wallet_for_closures);
-                move || {
-                    let w = wallet.clone();
-                    async move { w.max_giveable(address_len).await }
-                }
-            },
-            {
-                let wallet = Arc::clone(&bitcoin_wallet_for_closures);
-                move || {
-                    let w = wallet.clone();
-                    async move { w.sync().await }
-                }
-            },
-            tauri_handle_for_determine,
-            swap_id,
-            |quote_with_address| {
-                let tauri_handle_clone = tauri_handle_for_selection.clone();
-                Box::new(async move {
-                    let details = SelectMakerDetails {
-                        swap_id,
-                        btc_amount_to_swap: quote_with_address.quote.max_quantity,
-                        maker: quote_with_address,
-                    };
+    // Everything between acquiring the swap lock and spawning the swap task is
+    // fallible. Run it in one block and release the lock on any failure, so an
+    // error never leaves the lock held and blocking future swaps. `Ok(None)`
+    // means a force-suspension already released the lock.
+    let prepared = async {
+        let select_offer_result = tokio::select! {
+            result = determine_btc_to_swap(
+                quotes_rx,
+                bitcoin_wallet.new_address(),
+                {
+                    let wallet = Arc::clone(&bitcoin_wallet_for_closures);
+                    move || {
+                        let w = wallet.clone();
+                        async move { w.balance().await }
+                    }
+                },
+                {
+                    let wallet = Arc::clone(&bitcoin_wallet_for_closures);
+                    move || {
+                        let w = wallet.clone();
+                        async move { w.max_giveable(address_len).await }
+                    }
+                },
+                {
+                    let wallet = Arc::clone(&bitcoin_wallet_for_closures);
+                    move || {
+                        let w = wallet.clone();
+                        async move { w.sync().await }
+                    }
+                },
+                tauri_handle_for_determine,
+                swap_id,
+                |quote_with_address| {
+                    let tauri_handle_clone = tauri_handle_for_selection.clone();
+                    Box::new(async move {
+                        let details = SelectMakerDetails {
+                            swap_id,
+                            btc_amount_to_swap: quote_with_address.quote.max_quantity,
+                            maker: quote_with_address,
+                        };
 
-                    tauri_handle_clone.request_maker_selection(details, 300).await
-                }) as Box<dyn Future<Output = Result<bool>> + Send>
-            },
-        ) => {
-            Some(result?)
-        }
-        _ = context.swap_lock.listen_for_swap_force_suspension() => {
-            context.swap_lock.release_swap_lock().await.expect("Shutdown signal received but failed to release swap lock. The swap process has been terminated but the swap lock is still active.");
-
-            if let Some(handle) = tauri_handle_for_suspension {
-                handle.emit_swap_progress_event(swap_id, TauriSwapProgressEvent::Released);
+                        tauri_handle_clone.request_maker_selection(details, 300).await
+                    }) as Box<dyn Future<Output = Result<bool>> + Send>
+                },
+            ) => {
+                Some(result?)
             }
+            _ = context.swap_lock.listen_for_swap_force_suspension() => {
+                context.swap_lock.release_swap_lock().await.expect("Shutdown signal received but failed to release swap lock. The swap process has been terminated but the swap lock is still active.");
 
-            None
-        },
+                if let Some(handle) = tauri_handle_for_suspension {
+                    handle.emit_swap_progress_event(swap_id, TauriSwapProgressEvent::Released);
+                }
+
+                None
+            },
+        };
+
+        let Some((seller_multiaddr, seller_peer_id, quote, tx_lock_amount, tx_lock_fee)) =
+            select_offer_result
+        else {
+            return Ok(None);
+        };
+
+        // Insert the peer_id into the database
+        db.insert_peer_id(swap_id, seller_peer_id).await?;
+
+        db.insert_address(seller_peer_id, seller_multiaddr.clone())
+            .await?;
+
+        db.insert_monero_address_pool(swap_id, monero_receive_pool.clone())
+            .await?;
+
+        // Add the seller's address to the swarm
+        event_loop_handle
+            .queue_peer_address(seller_peer_id, seller_multiaddr.clone())
+            .await?;
+
+        Ok::<_, anyhow::Error>(Some((seller_peer_id, quote, tx_lock_amount, tx_lock_fee)))
+    }
+    .await;
+
+    let (seller_peer_id, quote, tx_lock_amount, tx_lock_fee) = match prepared {
+        Ok(Some(data)) => data,
+        Ok(None) => return Ok(()),
+        Err(err) => {
+            context
+                .swap_lock
+                .release_swap_lock()
+                .await
+                .expect("Could not release swap lock");
+            return Err(err);
+        }
     };
-
-    let Some((seller_multiaddr, seller_peer_id, quote, tx_lock_amount, tx_lock_fee)) =
-        select_offer_result
-    else {
-        return Ok(());
-    };
-
-    // Insert the peer_id into the database
-    db.insert_peer_id(swap_id, seller_peer_id).await?;
-
-    db.insert_address(seller_peer_id, seller_multiaddr.clone())
-        .await?;
-
-    db.insert_monero_address_pool(swap_id, monero_receive_pool.clone())
-        .await?;
-
-    // Add the seller's address to the swarm
-    event_loop_handle
-        .queue_peer_address(seller_peer_id, seller_multiaddr.clone())
-        .await?;
 
     tauri_handle.emit_swap_progress_event(
         swap_id,

--- a/swap/src/cli/api/request.rs
+++ b/swap/src/cli/api/request.rs
@@ -1098,100 +1098,78 @@ pub async fn buy_xmr(
     // because we need to be able to cancel the determine_btc_to_swap(..)
     context.swap_lock.acquire_swap_lock(swap_id).await?;
 
-    // Everything between acquiring the swap lock and spawning the swap task is
-    // fallible. Run it in one block and release the lock on any failure, so an
-    // error never leaves the lock held and blocking future swaps. `Ok(None)`
-    // means a force-suspension already released the lock.
-    let prepared = async {
-        let select_offer_result = tokio::select! {
-            result = determine_btc_to_swap(
-                quotes_rx,
-                bitcoin_wallet.new_address(),
-                {
-                    let wallet = Arc::clone(&bitcoin_wallet_for_closures);
-                    move || {
-                        let w = wallet.clone();
-                        async move { w.balance().await }
-                    }
-                },
-                {
-                    let wallet = Arc::clone(&bitcoin_wallet_for_closures);
-                    move || {
-                        let w = wallet.clone();
-                        async move { w.max_giveable(address_len).await }
-                    }
-                },
-                {
-                    let wallet = Arc::clone(&bitcoin_wallet_for_closures);
-                    move || {
-                        let w = wallet.clone();
-                        async move { w.sync().await }
-                    }
-                },
-                tauri_handle_for_determine,
-                swap_id,
-                |quote_with_address| {
-                    let tauri_handle_clone = tauri_handle_for_selection.clone();
-                    Box::new(async move {
-                        let details = SelectMakerDetails {
-                            swap_id,
-                            btc_amount_to_swap: quote_with_address.quote.max_quantity,
-                            maker: quote_with_address,
-                        };
-
-                        tauri_handle_clone.request_maker_selection(details, 300).await
-                    }) as Box<dyn Future<Output = Result<bool>> + Send>
-                },
-            ) => {
-                Some(result?)
-            }
-            _ = context.swap_lock.listen_for_swap_force_suspension() => {
-                context.swap_lock.release_swap_lock().await.expect("Shutdown signal received but failed to release swap lock. The swap process has been terminated but the swap lock is still active.");
-
-                if let Some(handle) = tauri_handle_for_suspension {
-                    handle.emit_swap_progress_event(swap_id, TauriSwapProgressEvent::Released);
+    let select_offer_result = tokio::select! {
+        result = determine_btc_to_swap(
+            quotes_rx,
+            bitcoin_wallet.new_address(),
+            {
+                let wallet = Arc::clone(&bitcoin_wallet_for_closures);
+                move || {
+                    let w = wallet.clone();
+                    async move { w.balance().await }
                 }
-
-                None
             },
-        };
+            {
+                let wallet = Arc::clone(&bitcoin_wallet_for_closures);
+                move || {
+                    let w = wallet.clone();
+                    async move { w.max_giveable(address_len).await }
+                }
+            },
+            {
+                let wallet = Arc::clone(&bitcoin_wallet_for_closures);
+                move || {
+                    let w = wallet.clone();
+                    async move { w.sync().await }
+                }
+            },
+            tauri_handle_for_determine,
+            swap_id,
+            |quote_with_address| {
+                let tauri_handle_clone = tauri_handle_for_selection.clone();
+                Box::new(async move {
+                    let details = SelectMakerDetails {
+                        swap_id,
+                        btc_amount_to_swap: quote_with_address.quote.max_quantity,
+                        maker: quote_with_address,
+                    };
 
-        let Some((seller_multiaddr, seller_peer_id, quote, tx_lock_amount, tx_lock_fee)) =
-            select_offer_result
-        else {
-            return Ok(None);
-        };
-
-        // Insert the peer_id into the database
-        db.insert_peer_id(swap_id, seller_peer_id).await?;
-
-        db.insert_address(seller_peer_id, seller_multiaddr.clone())
-            .await?;
-
-        db.insert_monero_address_pool(swap_id, monero_receive_pool.clone())
-            .await?;
-
-        // Add the seller's address to the swarm
-        event_loop_handle
-            .queue_peer_address(seller_peer_id, seller_multiaddr.clone())
-            .await?;
-
-        Ok::<_, anyhow::Error>(Some((seller_peer_id, quote, tx_lock_amount, tx_lock_fee)))
-    }
-    .await;
-
-    let (seller_peer_id, quote, tx_lock_amount, tx_lock_fee) = match prepared {
-        Ok(Some(data)) => data,
-        Ok(None) => return Ok(()),
-        Err(err) => {
-            context
-                .swap_lock
-                .release_swap_lock()
-                .await
-                .expect("Could not release swap lock");
-            return Err(err);
+                    tauri_handle_clone.request_maker_selection(details, 300).await
+                }) as Box<dyn Future<Output = Result<bool>> + Send>
+            },
+        ) => {
+            Some(result?)
         }
+        _ = context.swap_lock.listen_for_swap_force_suspension() => {
+            context.swap_lock.release_swap_lock().await.expect("Shutdown signal received but failed to release swap lock. The swap process has been terminated but the swap lock is still active.");
+
+            if let Some(handle) = tauri_handle_for_suspension {
+                handle.emit_swap_progress_event(swap_id, TauriSwapProgressEvent::Released);
+            }
+
+            None
+        },
     };
+
+    let Some((seller_multiaddr, seller_peer_id, quote, tx_lock_amount, tx_lock_fee)) =
+        select_offer_result
+    else {
+        return Ok(());
+    };
+
+    // Insert the peer_id into the database
+    db.insert_peer_id(swap_id, seller_peer_id).await?;
+
+    db.insert_address(seller_peer_id, seller_multiaddr.clone())
+        .await?;
+
+    db.insert_monero_address_pool(swap_id, monero_receive_pool.clone())
+        .await?;
+
+    // Add the seller's address to the swarm
+    event_loop_handle
+        .queue_peer_address(seller_peer_id, seller_multiaddr.clone())
+        .await?;
 
     tauri_handle.emit_swap_progress_event(
         swap_id,

--- a/swap/src/cli/api/tauri_bindings.rs
+++ b/swap/src/cli/api/tauri_bindings.rs
@@ -1029,6 +1029,7 @@ pub struct TauriSwapProgressEventWrapper {
 #[serde(tag = "type", content = "content")]
 pub enum TauriSwapProgressEvent {
     Resuming,
+    CheckingMoneroNodeConnectivity,
     ReceivedQuote(BidQuote),
     WaitingForBtcDeposit {
         #[typeshare(serialized_as = "string")]

--- a/swap/src/protocol/alice/swap.rs
+++ b/swap/src/protocol/alice/swap.rs
@@ -756,6 +756,7 @@ where
                     monero_wallet
                         .rpc_client()
                         .await
+                        .map_err(backoff::Error::transient)?
                         .publish_transaction(&xmr_refund_tx)
                         .await
                         .context("Failed to publish Monero refund transaction")

--- a/swap/src/protocol/bob/swap.rs
+++ b/swap/src/protocol/bob/swap.rs
@@ -123,6 +123,25 @@ async fn next_state(
             change_address,
             tx_lock_fee,
         } => {
+            // Verify the Monero daemon RPC is reachable before starting the swap.
+            event_emitter.emit_swap_progress_event(
+                swap_id,
+                TauriSwapProgressEvent::CheckingMoneroNodeConnectivity,
+            );
+            retry(
+                "Monero daemon RPC health check",
+                || async {
+                    monero_wallet
+                        .rpc_health_check()
+                        .await
+                        .map_err(backoff::Error::transient)
+                },
+                Duration::from_secs(45),
+                None,
+            )
+            .await
+            .context("Monero daemon RPC health check failed; cannot start swap")?;
+
             let tx_cancel_fee = bitcoin_wallet
                 .estimate_fee(TxCancel::weight(), Some(btc_amount))
                 .await?;
@@ -796,6 +815,7 @@ async fn next_state(
                     monero_wallet
                         .rpc_client()
                         .await
+                        .map_err(backoff::Error::transient)?
                         .publish_transaction(&xmr_redeem_tx)
                         .await
                         .context("Failed to publish Monero redeem transaction")
@@ -1321,6 +1341,7 @@ async fn next_state(
                             monero_wallet
                                 .rpc_client()
                                 .await
+                                .map_err(backoff::Error::transient)?
                                 .publish_transaction(&xmr_redeem_tx)
                                 .await
                                 .context("Failed to publish Monero redeem transaction")


### PR DESCRIPTION
Establish the RPC client lazily instead: store it as `None` at construction and connect on first use in `rpc_client()` (cached, re-established after a node change). A temporarily unreachable node no longer blocks initialization.

Add `Wallets::rpc_health_check()` and gate swaps on it:
- Bob verifies the daemon RPC is reachable in `buy_xmr` before locking Bitcoin.
- Alice responds with a zero quote when the RPC health check fails.
- Alice health-checks the RPC before handing out a swap-setup wallet snapshot.