### PR TITLE
Enable Hermes by default and lower minimum Hermes swap amount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- ASB: The Hermes protocol is now enabled by default (`hermes_enabled` defaults to `true`), and the default `hermes_min_swap_amount` was lowered from `0.01` to `0.001` BTC (~50 USD at a reference price of 50,000 USD/BTC).
+
 ## [4.11.4] - 2026-06-30
 
 ## [4.11.3] - 2026-06-24

--- a/swap-env/src/config.rs
+++ b/swap-env/src/config.rs
@@ -199,7 +199,7 @@ pub struct Maker {
     #[serde(default = "default_hermes_funding_amount_piconero")]
     pub hermes_funding_amount_piconero: u64,
     /// Whether to fund the on-chain Hermes encrypted-signature channel at all.
-    /// Disabled by default.
+    /// Enabled by default.
     #[serde(default = "default_hermes_enabled")]
     pub hermes_enabled: bool,
     /// Minimum swap size (in BTC) below which the Hermes amount is not funded.
@@ -272,11 +272,12 @@ pub fn default_hermes_funding_amount_piconero() -> u64 {
 }
 
 pub fn default_hermes_enabled() -> bool {
-    false
+    true
 }
 
 pub fn default_hermes_min_swap_amount() -> bitcoin::Amount {
-    bitcoin::Amount::from_btc(0.01).expect("0.01 BTC to be a valid amount")
+    // ~50 USD worth of BTC at a reference price of 50,000 USD/BTC
+    bitcoin::Amount::from_btc(0.001).expect("0.001 BTC to be a valid amount")
 }
 
 pub fn default_btc_redeem_fee_multiplier() -> Decimal {


### PR DESCRIPTION
## Summary

Enables the Hermes protocol by default and lowers the minimum swap size below which the Hermes amount is not funded.

Changes in `swap-env/src/config.rs`:
- `default_hermes_enabled()` now returns `true` (was `false`).
- `default_hermes_min_swap_amount()` now returns `0.001` BTC (was `0.01` BTC). At a reference price of 50,000 USD/BTC this is ~50 USD.
- Updated the doc comment on `hermes_enabled` to reflect the new default.