### PR TITLE
feat: default swap offer sorting to cheapest instead of smallest

### DIFF
--- a/src-gui/src/renderer/components/pages/swap/swap/init/deposit_and_choose_offer/DepositAndChooseOfferPage.tsx
+++ b/src-gui/src/renderer/components/pages/swap/swap/init/deposit_and_choose_offer/DepositAndChooseOfferPage.tsx
@@ -33,7 +33,7 @@ export default function DepositAndChooseOfferPage({
   known_quotes,
 }: TauriSwapProgressEventContent<"WaitingForBtcDeposit">) {
   const [currentPage, setCurrentPage] = useState(1);
-  const [sortMode, setSortMode] = useState<OfferSortMode>("small");
+  const [sortMode, setSortMode] = useState<OfferSortMode>("cheapest");
   const [sortAnchorEl, setSortAnchorEl] = useState<null | HTMLElement>(null);
   const offersPerPage = 3;
 


### PR DESCRIPTION
Changes the default sort mode of the swap offer list in the GUI from
"Small swaps" to "Cheapest" (lowest price first).

Reason: as we only allow to swap maximum btc balance anyway, it does not
matter at all who offers smallest swaps. We are going to swap the whole
balance and naturally we want to see who offers this the cheapest.
Currently we see smallest swaps with makers advertising 30% fees. Makes
no sense.

- Only the initial `sortMode` state in DepositAndChooseOfferPage.tsx changed.
- The "cheapest" mode already existed (sorts ascending by quote.price);
  the sort logic and dropdown options ("Large swaps", "Small swaps",
  "Cheapest") are unchanged.
- Users can still switch sort modes via the existing dropdown.
