### PR TITLE
add another rendezvous for discovery and decentralization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Add another rendezvous server for discovery and decentralization.
 - ASB: The Hermes protocol is now enabled by default (`hermes_enabled` defaults to `true`), and the default `hermes_min_swap_amount` was lowered from `0.01` to `0.001` BTC (~50 USD at a reference price of 50,000 USD/BTC).
 
 ## [4.11.4] - 2026-06-30

--- a/src-gui/src/store/defaults.ts
+++ b/src-gui/src/store/defaults.ts
@@ -10,7 +10,8 @@ export const DEFAULT_RENDEZVOUS_POINTS = [
   "/dns4/discovery2.eigenwallet.org/tcp/443/wss/p2p/12D3KooWA6cnqJpVnreBVnoro8midDL9Lpzmg8oJPoAGi7YYaamE",
   "/onion3/av2jauifny7dgpvzhsnhra3cwivf6ofaefxvwhhuh5y7hsolabehhaad:8888/p2p/12D3KooWA6cnqJpVnreBVnoro8midDL9Lpzmg8oJPoAGi7YYaamE",
   "/dns4/atomic.exolix.com/tcp/443/wss/p2p/12D3KooWBk6GbgkZaeTAUByD1tJX6SdFHtzrVj3jTmurPMRvtGoY",
-  "/onion3/kjbdwt7dvtbkj2vmrxyfifjjqowp6mln4dkmpxzpftluucnfz7tlfbad:9939/p2p/12D3KooWBk6GbgkZaeTAUByD1tJX6SdFHtzrVj3jTmurPMRvtGoY"
+  "/onion3/kjbdwt7dvtbkj2vmrxyfifjjqowp6mln4dkmpxzpftluucnfz7tlfbad:9939/p2p/12D3KooWBk6GbgkZaeTAUByD1tJX6SdFHtzrVj3jTmurPMRvtGoY",
+  "/onion3/v3qmlnnutkrmc6kizg2v3q22tox3oh4lkmehcnqubk3yj4p6tunmtoqd:8888/p2p/12D3KooWDwtPvaPeiuLi7TwP7wMaZiwY3t3Sm6h7c23vxswTWAg5"
 ];
 
 // Known broken rendezvous points to remove when applying defaults

--- a/swap-env/src/defaults.rs
+++ b/swap-env/src/defaults.rs
@@ -54,6 +54,7 @@ pub fn default_rendezvous_points() -> Vec<Multiaddr> {
         "/onion3/m6rboz5lv4wxldgybgox4pr4s6xci3h2exi5nogxaox762xji2gokuad:8891/p2p/12D3KooWGjcxdpsEWspGGwkQJ9BRJQjtBQFsLk36zJxrXSBPQWov".parse().unwrap(),
         "/dns4/discovery2.eigenwallet.org/tcp/443/wss/p2p/12D3KooWA6cnqJpVnreBVnoro8midDL9Lpzmg8oJPoAGi7YYaamE".parse().unwrap(),
         "/onion3/av2jauifny7dgpvzhsnhra3cwivf6ofaefxvwhhuh5y7hsolabehhaad:8888/p2p/12D3KooWA6cnqJpVnreBVnoro8midDL9Lpzmg8oJPoAGi7YYaamE".parse().unwrap(),
+        "/onion3/v3qmlnnutkrmc6kizg2v3q22tox3oh4lkmehcnqubk3yj4p6tunmtoqd:8888/p2p/12D3KooWDwtPvaPeiuLi7TwP7wMaZiwY3t3Sm6h7c23vxswTWAg5".parse().unwrap(),
     ]
 }
 


### PR DESCRIPTION
glad to help decentralization of project. rendezvous is intended to be run long-term and maintained accordingly.

ps as nice side effect after endless tests the only thing that helped my makers getting served correctly to my test GUIs 100 out of 100 times was serving them via this new custom rendezvous. here is a video where i registered 2 makers to this new rendezvous and they instantly appear after i added the new rendezvous. of course they also register with all other default rendezvous. https://streamable.com/n7k5o8