### PR TITLE
GUI: allow withdrawing Bitcoin to Taproot addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- GUI: The Bitcoin withdrawal dialog now accepts Taproot (`bc1p…`/`tb1p…`) destination addresses.
 - ASB: The Hermes protocol is now enabled by default (`hermes_enabled` defaults to `true`), and the default `hermes_min_swap_amount` was lowered from `0.01` to `0.001` BTC (~50 USD at a reference price of 50,000 USD/BTC).
 
 ## [4.11.4] - 2026-06-30

--- a/src-gui/src/renderer/components/inputs/BitcoinAddressTextField.tsx
+++ b/src-gui/src/renderer/components/inputs/BitcoinAddressTextField.tsx
@@ -9,6 +9,7 @@ type BitcoinAddressTextFieldProps = {
   helperText: string;
   onAddressValidityChange?: (valid: boolean) => void;
   allowEmpty?: boolean;
+  allowTaproot?: boolean;
 };
 
 export default function BitcoinAddressTextField({
@@ -16,6 +17,7 @@ export default function BitcoinAddressTextField({
   onAddressChange,
   helperText,
   allowEmpty = true,
+  allowTaproot = false,
   onAddressValidityChange,
   ...props
 }: BitcoinAddressTextFieldProps & TextFieldProps) {
@@ -30,12 +32,12 @@ export default function BitcoinAddressTextField({
       return "Cannot be empty";
     }
 
-    if (isBtcAddressValid(address, isTestnet())) {
+    if (isBtcAddressValid(address, isTestnet(), allowTaproot)) {
       return null;
     }
 
     return "Not a valid Bitcoin address";
-  }, [address, allowEmpty]);
+  }, [address, allowEmpty, allowTaproot]);
 
   useEffect(() => {
     if (onAddressValidityChange != null) {

--- a/src-gui/src/renderer/components/modal/wallet/pages/AddressInputPage.tsx
+++ b/src-gui/src/renderer/components/modal/wallet/pages/AddressInputPage.tsx
@@ -23,6 +23,7 @@ export default function AddressInputPage({
         onAddressValidityChange={setWithdrawAddressValid}
         helperText="All Bitcoin of the internal wallet will be transferred to this address"
         allowEmpty={false}
+        allowTaproot
         fullWidth
       />
     </>

--- a/src-gui/src/utils/conversionUtils.ts
+++ b/src-gui/src/utils/conversionUtils.ts
@@ -21,10 +21,17 @@ export function isXmrAddressValid(address: string, stagenet: boolean) {
   return new RegExp(`(?:^${re}$)`).test(address);
 }
 
-export function isBtcAddressValid(address: string, testnet: boolean) {
+export function isBtcAddressValid(
+  address: string,
+  testnet: boolean,
+  allowTaproot = false,
+) {
+  // Segwit v0 (bc1q..., ~42 chars) fits in {25,49}. Taproot v1 (bc1p...) and
+  // P2WSH are longer (up to ~90 chars total), so widen the cap when allowed.
+  const max = allowTaproot ? 87 : 49;
   const re = testnet
-    ? "(tb1)[a-zA-HJ-NP-Z0-9]{25,49}"
-    : "(bc1)[a-zA-HJ-NP-Z0-9]{25,49}";
+    ? `(tb1)[a-zA-HJ-NP-Z0-9]{25,${max}}`
+    : `(bc1)[a-zA-HJ-NP-Z0-9]{25,${max}}`;
   return new RegExp(`(?:^${re}$)`).test(address);
 }
 


### PR DESCRIPTION
## What

Allow entering Taproot (`bc1p…` / `tb1p…`) destination addresses in the GUI Bitcoin withdrawal dialog.

## Why

The withdrawal address field rejected Taproot addresses, so users couldn't sweep the internal wallet to a Taproot address. The block was purely in the frontend: `isBtcAddressValid` capped the bech32 body at 49 characters, while a Taproot address is ~59 characters after the `bc1`/`tb1` prefix, so the Withdraw button never enabled.

The backend already supports it — the withdrawal path only validates the network and builds the recipient output from `address.script_pubkey()`, which works for any address type. No Rust changes are required.

## How

- `isBtcAddressValid` gains an opt-in `allowTaproot` flag that widens the length cap (49 → 87) so Taproot/longer bech32(m) addresses pass.
- `BitcoinAddressTextField` forwards a new optional `allowTaproot` prop.
- The withdrawal `AddressInputPage` enables `allowTaproot`.

Scoped to withdrawal only: the swap **External Bitcoin refund address** field is intentionally left unchanged.

## Testing

Manually tested end-to-end on Windows: withdrawing (sweeping) the internal wallet to a mainnet Taproot (`bc1p…`) address succeeded.
