### PR TITLE
build: bump Flatpak GNOME runtime to 50

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- GUI: Bump GNOME Flatpak runtime to 50.
+
 ## [4.13.2] - 2026-07-23
 
 - GUI + ASB: Remove nine unusable Electrum defaults and add healthy Mullvad,

--- a/flatpak/org.eigenwallet.app.json
+++ b/flatpak/org.eigenwallet.app.json
@@ -1,8 +1,8 @@
 {
   "id": "org.eigenwallet.app",
   "runtime": "org.gnome.Platform",
-  "runtime-version": "48",
-  "sdk": "org.gnome.Sdk//48",
+  "runtime-version": "50",
+  "sdk": "org.gnome.Sdk",
   "command": "unstoppableswap-gui-rs.flatpak.sh",
   "finish-args": [
     "--socket=wayland",


### PR DESCRIPTION
Fixes #840.

## Summary
- Bumps the Flatpak GNOME runtime to `50`.
- Uses the unversioned `org.gnome.Sdk` identifier to match current Flatpak SDK naming.
- Adds an Unreleased changelog entry.

## Validation
- Manifest change is limited to Flatpak runtime/SDK metadata.
- No application source changes.

Bounty payout address if accepted/merged:
`4DSQMNzzq46N1z2pZWAVdeA6JvUL9TCB2bnBiA3ZzoqEdYJnMydt5akCa3vtmapeDsbVKGPFdNkzqTcJS8M8oyK7WGjNk99k1B6CoKjvH5`
