### PR TITLE
fix(gui): refresh swap info immediately

### DIFF
--- a/src-gui/src/store/middleware/storeListener.ts
+++ b/src-gui/src/store/middleware/storeListener.ts
@@ -1,5 +1,5 @@
 import { createListenerMiddleware } from "@reduxjs/toolkit";
-import { throttle, debounce } from "lodash";
+import { throttle } from "lodash";
 import {
   getAllSwapInfos,
   getAllSwapTimelocks,
@@ -42,9 +42,9 @@ const throttledGetSwapInfoFunctions = new Map<
 // Function to get or create a throttled getSwapInfo for a specific swap_id
 const getThrottledSwapInfoUpdater = (swapId: string) => {
   if (!throttledGetSwapInfoFunctions.has(swapId)) {
-    // Create a throttled function that executes at most once every 2 seconds
-    // but will wait for 3 seconds of quiet during rapid calls (using debounce)
-    const debouncedGetSwapInfo = debounce(() => {
+    // Execute immediately on the first progress event, then coalesce rapid
+    // follow-up events so the history view is kept fresh without hammering RPC.
+    const throttledFunction = throttle(() => {
       logger.debug(`Executing getSwapInfo for swap ${swapId}`);
       getSwapInfo(swapId).catch((error) => {
         logger.debug(`Failed to fetch swap info for swap ${swapId}: ${error}`);
@@ -52,12 +52,7 @@ const getThrottledSwapInfoUpdater = (swapId: string) => {
       getSwapTimelock(swapId).catch((error) => {
         logger.debug(`Failed to fetch timelock for swap ${swapId}: ${error}`);
       });
-    }, 3000); // 3 seconds debounce for rapid calls
-
-    const throttledFunction = throttle(debouncedGetSwapInfo, 2000, {
-      leading: true, // Execute immediately on first call
-      trailing: true, // Execute on trailing edge if needed
-    });
+    }, 2000);
 
     throttledGetSwapInfoFunctions.set(swapId, throttledFunction);
   }


### PR DESCRIPTION
Fixes #822.

This removes the debounce nested inside the swap progress updater. The previous structure throttled a debounced callback, so the first progress event still waited for the debounce delay and continuous swap progress could keep pushing the history refresh later. The updater now uses a leading/trailing throttle directly, so swap info and timelock refresh immediately on the first progress event while still coalescing rapid follow-up events.

Validation:
- `npx eslint src/store/middleware/storeListener.ts`
- `git diff --check`

Note: `npm run tsc` could not complete in this checkout because the generated `src/models/tauriModel.ts` binding is gitignored and `typeshare` is not installed locally (`npm run gen-bindings` fails with `typeshare: command not found`).

Bounty payout address (XMR): `4DSQMNzzq46N1z2pZWAVdeA6JvUL9TCB2bnBiA3ZzoqEdYJnMydt5akCa3vtmapeDsbVKGPFdNkzqTcJS8M8oyK7WGjNk99k1B6CoKjvH5`
