### PR TITLE
Add monero-rpc-pool test coverage

### DIFF
--- a/monero-rpc-pool/Cargo.toml
+++ b/monero-rpc-pool/Cargo.toml
@@ -67,3 +67,7 @@ swap-serde = { path = "../swap-serde" }
 # Optional dependencies (for features)
 cuprate-epee-encoding = { git = "https://github.com/Cuprate/cuprate.git", optional = true }
 reqwest = { version = "0.11", features = ["json"], optional = true }
+
+[dev-dependencies]
+reqwest = { version = "0.11", features = ["json"] }
+tempfile = { workspace = true }

--- a/monero-rpc-pool/src/config.rs
+++ b/monero-rpc-pool/src/config.rs
@@ -63,3 +63,21 @@ impl Config {
         )
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::Config;
+    use monero_address::Network;
+    use std::path::PathBuf;
+
+    #[test]
+    fn new_random_port_uses_localhost_and_port_zero() {
+        let config = Config::new_random_port(PathBuf::from("/tmp/monero-rpc-pool"), Network::Testnet);
+
+        assert_eq!(config.host, "127.0.0.1");
+        assert_eq!(config.port, 0);
+        assert_eq!(config.data_dir, PathBuf::from("/tmp/monero-rpc-pool"));
+        assert!(config.tor_client.is_none());
+        assert_eq!(config.network, Network::Testnet);
+    }
+}

--- a/monero-rpc-pool/src/database.rs
+++ b/monero-rpc-pool/src/database.rs
@@ -28,6 +28,34 @@ pub fn network_to_string(network: &Network) -> &'static str {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::{network_to_string, parse_network};
+    use monero_address::Network;
+
+    #[test]
+    fn parse_network_accepts_expected_values_case_insensitively() {
+        assert!(matches!(parse_network("mainnet"), Ok(Network::Mainnet)));
+        assert!(matches!(parse_network("STAGENET"), Ok(Network::Stagenet)));
+        assert!(matches!(parse_network("TestNet"), Ok(Network::Testnet)));
+    }
+
+    #[test]
+    fn parse_network_rejects_unknown_values() {
+        let error = parse_network("devnet").expect_err("expected invalid network to fail");
+        assert!(error.to_string().contains("Invalid network"));
+    }
+
+    #[test]
+    fn network_to_string_round_trips_supported_networks() {
+        for network in [Network::Mainnet, Network::Stagenet, Network::Testnet] {
+            let encoded = network_to_string(&network);
+            let decoded = parse_network(encoded).expect("expected encoded network to parse");
+            assert_eq!(decoded, network);
+        }
+    }
+}
+
 #[derive(Clone)]
 pub struct Database {
     pub pool: SqlitePool,

--- a/monero-rpc-pool/src/lib.rs
+++ b/monero-rpc-pool/src/lib.rs
@@ -185,3 +185,19 @@ pub async fn start_server_with_random_port(
 
     Ok((server_info, status_receiver, pool_handle))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::ServerInfo;
+
+    #[test]
+    fn server_info_converts_to_http_url() {
+        let server_info = ServerInfo {
+            host: "127.0.0.1".to_string(),
+            port: 18081,
+        };
+
+        let url: String = server_info.into();
+        assert_eq!(url, "http://127.0.0.1:18081");
+    }
+}

--- a/monero-rpc-pool/src/types.rs
+++ b/monero-rpc-pool/src/types.rs
@@ -97,3 +97,25 @@ impl NodeRecord {
         self.health.success_rate()
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::NodeHealthStats;
+
+    #[test]
+    fn success_rate_is_zero_without_samples() {
+        let stats = NodeHealthStats::default();
+        assert_eq!(stats.success_rate(), 0.0);
+    }
+
+    #[test]
+    fn success_rate_uses_success_over_total_checks() {
+        let stats = NodeHealthStats {
+            success_count: 3,
+            failure_count: 1,
+            ..Default::default()
+        };
+
+        assert_eq!(stats.success_rate(), 0.75);
+    }
+}

--- a/monero-rpc-pool/tests/stats_endpoint.rs
+++ b/monero-rpc-pool/tests/stats_endpoint.rs
@@ -1,0 +1,43 @@
+use anyhow::Result;
+use monero_address::Network;
+use monero_rpc_pool::{config::Config, start_server_with_random_port};
+use tempfile::TempDir;
+use tokio::time::{Duration, sleep};
+
+#[tokio::test]
+async fn stats_endpoint_returns_health_payload() -> Result<()> {
+    let data_dir = TempDir::new()?;
+    let config = Config::new_random_port(data_dir.path().to_path_buf(), Network::Mainnet);
+    let (server_info, _status_receiver, _pool_handle) = start_server_with_random_port(config).await?;
+    let url = format!("http://{}:{}/stats", server_info.host, server_info.port);
+
+    let client = reqwest::Client::new();
+    let mut last_error = None;
+
+    for _ in 0..10 {
+        match client.get(&url).send().await {
+            Ok(response) => {
+                assert!(response.status().is_success());
+
+                let payload: serde_json::Value = response.json().await?;
+                assert_eq!(payload["status"], "healthy");
+                assert!(payload.get("total_node_count").is_some());
+                assert!(payload.get("healthy_node_count").is_some());
+                assert!(payload.get("successful_health_checks").is_some());
+                assert!(payload.get("unsuccessful_health_checks").is_some());
+                assert!(payload.get("top_reliable_nodes").is_some());
+                assert!(payload.get("bandwidth_kb_per_sec").is_some());
+
+                return Ok(());
+            }
+            Err(error) => {
+                last_error = Some(error);
+                sleep(Duration::from_millis(100)).await;
+            }
+        }
+    }
+
+    Err(last_error
+        .expect("expected at least one request attempt")
+        .into())
+}


### PR DESCRIPTION
## Summary
- add unit tests for monero-rpc-pool config, network parsing, server URL formatting, and node health stats helpers
- add an integration test that starts the pool on a random port and verifies the `/stats` endpoint returns the expected health payload
- add dev-dependencies needed for the new integration coverage

## Verification
- `git diff --check`
- `cargo test -p monero-rpc-pool` could not be run locally because this environment does not have `cargo`/`rustc` installed

Refs #801

Preferred payout asset if accepted: XMR.
