### PR TITLE
Add wrong-XMR amount regression test

### DIFF
--- a/swap/tests/bob_refunds_when_xmr_amount_is_not_exact.rs
+++ b/swap/tests/bob_refunds_when_xmr_amount_is_not_exact.rs
@@ -71,3 +71,38 @@ async fn bob_refunds_when_xmr_amount_is_not_exact() {
     })
     .await;
 }
+
+#[tokio::test]
+async fn bob_waits_for_cancel_timelock_before_allowing_btc_redeem_when_xmr_amount_is_wrong() {
+    harness::setup_test(SlowCancelConfig, None, None, |mut ctx| async move {
+        let (bob_swap, _bob_join_handle) = ctx.bob_swap().await;
+
+        let bob_swap = tokio::spawn(bob::run_until(bob_swap, |s| {
+            matches!(s, BobState::WaitingForCancelTimelockExpiration { .. })
+        }));
+
+        let alice_swap = ctx.alice_next_swap().await;
+        let alice_state = alice::run_until(
+            alice_swap,
+            |s| matches!(s, AliceState::BtcLocked { .. }),
+            FixedRate::default(),
+        )
+        .await?;
+
+        ctx.restart_alice().await;
+        let mut alice_swap = ctx.alice_next_swap().await;
+        alice_swap.state = lower_by_one_pico(alice_state);
+        let alice_swap = tokio::spawn(alice::run(alice_swap, FixedRate::default()));
+
+        let bob_state = bob_swap.await??;
+        assert!(matches!(
+            bob_state,
+            BobState::WaitingForCancelTimelockExpiration { .. }
+        ));
+
+        ctx.assert_alice_refunded(alice_swap.await??).await;
+
+        Ok::<(), anyhow::Error>(())
+    })
+    .await;
+}


### PR DESCRIPTION
## Summary
- add a second integration test for the wrong-XMR-amount path
- verify Bob transitions into `WaitingForCancelTimelockExpiration` after Alice under-locks Monero instead of continuing toward Bitcoin redeem
- keep the existing refund/resume test intact while adding a more direct assertion for the behavior requested in #828

## Verification
- `git diff --check`
- `cargo test -p swap bob_refunds_when_xmr_amount_is_not_exact` could not be run locally because this environment does not have `cargo` or `rustc`

## Notes
- the repo already had coverage for the eventual refund path after Bob resumes from DB
- this change adds the earlier-state regression check that Bob waits for the cancel timelock once the Monero amount is wrong, before any redeem path is allowed

Fixes #828

Preferred payout asset if accepted: XMR.
