### PR TITLE
Fix deterministic swap-asb RPC bind validation

### DIFF
--- a/swap-asb/src/command.rs
+++ b/swap-asb/src/command.rs
@@ -1,9 +1,9 @@
-use anyhow::{Context, Result, bail};
+use anyhow::{Result, bail};
 use bitcoin::Address;
 use bitcoin::address::NetworkUnchecked;
 use bitcoin_wallet::{Amount, bitcoin_address};
 use std::ffi::OsString;
-use std::net::ToSocketAddrs;
+use std::net::IpAddr;
 use std::path::PathBuf;
 use structopt::StructOpt;
 use swap_env::defaults::GetDefaults;
@@ -453,10 +453,10 @@ pub struct RecoverCommandParams {
 
 fn validate_rpc_bind_args(host: &Option<String>, port: &Option<u16>) -> Result<()> {
     match (host, port) {
-        (Some(host_str), Some(port_val)) => {
-            let _ = (&host_str[..], *port_val)
-                .to_socket_addrs()
-                .context("Invalid or unknown socket address")?;
+        (Some(host_str), Some(_)) => {
+            if !is_valid_rpc_bind_host(host_str) {
+                bail!("Invalid RPC bind host `{host_str}`");
+            }
 
             Ok(())
         }
@@ -472,6 +472,26 @@ fn validate_rpc_bind_args(host: &Option<String>, port: &Option<u16>) -> Result<(
             );
         }
     }
+}
+
+fn is_valid_rpc_bind_host(host: &str) -> bool {
+    if host.is_empty() || host.trim() != host || host.len() > 253 {
+        return false;
+    }
+
+    if host.parse::<IpAddr>().is_ok() {
+        return true;
+    }
+
+    host.split('.').all(|label| {
+        !label.is_empty()
+            && label.len() <= 63
+            && !label.starts_with('-')
+            && !label.ends_with('-')
+            && label
+                .bytes()
+                .all(|byte| byte.is_ascii_alphanumeric() || byte == b'-')
+    })
 }
 
 #[cfg(test)]
@@ -1005,6 +1025,8 @@ mod tests {
         validate_rpc_bind_args(&Some("127.0.0.1".to_string()), &Some(9944)).unwrap();
         validate_rpc_bind_args(&Some("0.0.0.0".to_string()), &Some(8080)).unwrap();
         validate_rpc_bind_args(&Some("localhost".to_string()), &Some(3000)).unwrap();
+        validate_rpc_bind_args(&Some("example.invalid".to_string()), &Some(3000)).unwrap();
+        validate_rpc_bind_args(&Some("::1".to_string()), &Some(3000)).unwrap();
 
         // One Some, one None should be invalid
         assert!(validate_rpc_bind_args(&Some("127.0.0.1".to_string()), &None).is_err());
@@ -1012,6 +1034,10 @@ mod tests {
 
         // Invalid host should be invalid
         assert!(validate_rpc_bind_args(&Some("invalid@host".to_string()), &Some(9944)).is_err());
+        assert!(
+            validate_rpc_bind_args(&Some("invalid host".to_string()), &Some(9944)).is_err()
+        );
+        assert!(validate_rpc_bind_args(&Some("-invalid".to_string()), &Some(9944)).is_err());
         assert!(validate_rpc_bind_args(&Some("".to_string()), &Some(9944)).is_err());
     }
 }


### PR DESCRIPTION
Refs #724

## Summary
- make `--rpc-bind-host` validation deterministic by checking IP / hostname syntax instead of resolving DNS with `to_socket_addrs()`
- keep the paired `--rpc-bind-host` / `--rpc-bind-port` requirement unchanged
- extend the existing RPC bind validation unit test with a non-resolving reserved hostname, IPv6 localhost, and malformed hostnames

## Why
`test_rpc_bind_validation` should not depend on local DNS or `/etc/hosts` behavior. A syntactically valid bind hostname can be accepted without requiring it to resolve during argument parsing.

## Validation
- `git diff --check`

I could not run `cargo test -p swap-asb test_rpc_bind_validation` locally because this environment does not have `cargo`, `rustc`, or `rustfmt` installed.