### PR TITLE
Update Flatpak install docs to GNOME 48 runtime

### DIFF
--- a/docs/content/getting_started/install_instructions.mdx
+++ b/docs/content/getting_started/install_instructions.mdx
@@ -81,7 +81,7 @@ Choose your platform and follow the instructions.
     # Add eigenwallet repo
     flatpak remote-add --if-not-exists eigenwallet https://eigenwallet.github.io/core/eigenwallet.flatpakrepo
     # Add dependencies
-    flatpak install flathub org.gnome.Platform//47
+    flatpak install flathub org.gnome.Platform//48
     # Install eigenwallet
     flatpak install eigenwallet org.eigenwallet.app
     ```
@@ -178,4 +178,3 @@ Each release includes `.asc` signature files alongside the binaries.
   <Cards.Card arrow title="Guide: Building from Source" href="/contributing/building_from_source">
   </Cards.Card>
 </Cards>
-


### PR DESCRIPTION
Closes #840.

The Flatpak manifest already targets `org.gnome.Platform//48` and `org.gnome.Sdk//48`, but the install instructions still told users to install the EOL GNOME 47 runtime manually. This updates the documented dependency command to `org.gnome.Platform//48` so the docs match the app manifest and avoid directing new installations to the removed/deprecated runtime.

Validation:
- `rg -n "org\.gnome\.Platform//47|runtime-version\": \"47\"|org\.gnome\.Sdk//47" docs flatpak -S` returns no matches
- `git diff --check`

XMR payout address:
`4DSQMNzzq46N1z2pZWAVdeA6JvUL9TCB2bnBiA3ZzoqEdYJnMydt5akCa3vtmapeDsbVKGPFdNkzqTcJS8M8oyK7WGjNk99k1B6CoKjvH5`