### PR TITLE
Only notify confirmation subscribers on status change

### DIFF
--- a/monero-wallet-ng/src/confirmations.rs
+++ b/monero-wallet-ng/src/confirmations.rs
@@ -13,7 +13,7 @@ use crate::{
     rpc::{ProvidesTransactionStatus, TransactionStatusError},
 };
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ConfirmationStatus {
     /// We haven't seen the transaction yet
     Unseen,
@@ -165,7 +165,17 @@ where
                 match get_confirmations(&provider, tx_id).await {
                     Ok(status) => {
                         backoff.reset();
-                        if sender.send(status).is_err() {
+                        // Only notify subscribers when the status actually changed, so consumers
+                        // observe an "update" per change rather than on every poll.
+                        sender.send_if_modified(|current| {
+                            if *current == status {
+                                false
+                            } else {
+                                *current = status;
+                                true
+                            }
+                        });
+                        if sender.is_closed() {
                             return;
                         }
                         tokio::time::sleep(poll_interval).await;


### PR DESCRIPTION
Previously the confirmation poll task sent the status into the watch
channel on every poll, waking all subscribers (and emitting the
"Monero transaction confirmation status update" log plus listener
callbacks) even when nothing changed. Use send_if_modified so
subscribers are only notified when the confirmation status actually
changes.